### PR TITLE
Pin CI tooling versions via PIP_CONSTRAINT

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,19 @@ updates:
       prefix: deps
       include: scope
 
+  - package-ecosystem: pip
+    directory: "/.github/workflows"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels: [dependencies, python, ci]
+    commit-message:
+      prefix: ci(deps)
+      include: scope
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,0 +1,6 @@
+# Pinned CI tools. Dependabot updates this weekly via .github/dependabot.yml.
+pip==26.1.1
+pre-commit==4.6.0
+build==1.5.0
+twine==6.2.0
+pyyaml==6.0.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
+
 jobs:
   pre-commit:
     name: pre-commit (ruff + yamllint)

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -13,6 +13,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
+
 jobs:
   test:
     name: Tests (${{ matrix.python-version }})

--- a/.github/workflows/scanner-docs.yml
+++ b/.github/workflows/scanner-docs.yml
@@ -22,6 +22,9 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+env:
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/scanner-release.yml
+++ b/.github/workflows/scanner-release.yml
@@ -39,6 +39,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/workflows/constraints.txt
+
 jobs:
   build:
     name: Build distribution


### PR DESCRIPTION
Adds `.github/workflows/constraints.txt` with pinned versions of `pip`, `pre-commit`, `build`, `twine`, and `pyyaml`, wired into every workflow via `PIP_CONSTRAINT`. Dependabot now watches the file weekly. Satisfies the OpenSSF Scorecard Pinned-Dependencies check.