### PR TITLE
Cut false positives across Helm, hardening, and integration-test contexts

### DIFF
--- a/src/ansible_security_scanner/argument_specs.py
+++ b/src/ansible_security_scanner/argument_specs.py
@@ -1,0 +1,166 @@
+"""
+``meta/argument_specs.yml`` awareness for the scanner.
+
+Ansible roles can declare and validate their inputs in
+``<role>/meta/argument_specs.yml`` (see
+https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format).
+When a variable is declared there with a type / required / regex / choices
+constraint, Ansible itself enforces the contract before the role runs.
+
+A line-based regex scanner cannot tell that a downstream
+``{{ user_input }}`` reference is already constrained, so without this
+hint it produces noise on every well-validated role variable.
+
+This module:
+
+  * Walks up from any scanned file to find an enclosing role root
+    (a directory containing ``meta/argument_specs.yml``).
+  * Loads each role's argument-specs once and caches the set of
+    declared option names across all entry points.
+  * Provides ``is_validated_variable(file_path, var_name)`` for the
+    file scanner to consult before emitting noisy variable-related
+    findings.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_ROLE_DIR_MARKERS = ("tasks", "handlers", "defaults", "vars", "meta", "templates", "files")
+_SPEC_FILENAMES = ("argument_specs.yml", "argument_specs.yaml")
+
+
+class ArgumentSpecsRegistry:
+    """Cache of role-root -> validated variable names."""
+
+    def __init__(self) -> None:
+        self._role_to_vars: dict[Path, set[str]] = {}
+        self._file_to_role: dict[Path, Path | None] = {}
+        self._lock = threading.Lock()
+
+    def role_root_for(self, file_path: Path) -> Path | None:
+        """Return the role root directory for ``file_path``, or ``None``.
+
+        A role root is the closest ancestor whose ``meta/`` subdirectory
+        contains ``argument_specs.yml`` / ``argument_specs.yaml``.
+        """
+        try:
+            resolved = file_path.resolve()
+        except OSError:
+            resolved = file_path
+
+        with self._lock:
+            # Cache may store ``None`` to mean "no role root for this file",
+            # so check membership separately from the value.
+            cached = self._file_to_role.get(resolved)
+            if cached is not None or resolved in self._file_to_role:
+                return cached
+
+        role_root: Path | None = None
+        for ancestor in [resolved, *resolved.parents]:
+            meta_dir = ancestor / "meta"
+            if not meta_dir.is_dir():
+                continue
+            if any((meta_dir / name).is_file() for name in _SPEC_FILENAMES):
+                # Only treat this directory as a role root if it actually
+                # looks like one - i.e. it carries at least one canonical
+                # role subdirectory besides ``meta/``.
+                siblings = {p.name for p in ancestor.iterdir() if p.is_dir()}
+                if siblings & set(_ROLE_DIR_MARKERS):
+                    role_root = ancestor
+                    break
+
+        with self._lock:
+            self._file_to_role[resolved] = role_root
+        return role_root
+
+    def validated_vars_for(self, file_path: Path) -> set[str]:
+        """Return the set of variable names validated by argument_specs."""
+        role_root = self.role_root_for(file_path)
+        if role_root is None:
+            return set()
+
+        with self._lock:
+            cached = self._role_to_vars.get(role_root)
+        if cached is not None:
+            return cached
+
+        names = self._load_role_specs(role_root)
+
+        with self._lock:
+            self._role_to_vars[role_root] = names
+        return names
+
+    def is_validated_variable(self, file_path: Path, var_name: str) -> bool:
+        if not var_name:
+            return False
+        return var_name in self.validated_vars_for(file_path)
+
+    @staticmethod
+    def _load_role_specs(role_root: Path) -> set[str]:
+        spec_path: Path | None = None
+        for name in _SPEC_FILENAMES:
+            candidate = role_root / "meta" / name
+            if candidate.is_file():
+                spec_path = candidate
+                break
+        if spec_path is None:
+            return set()
+
+        try:
+            with spec_path.open(encoding="utf-8") as fh:
+                data = yaml.safe_load(fh) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            logger.debug("Could not parse %s: %s", spec_path, exc)
+            return set()
+
+        return _collect_option_names(data)
+
+
+def _collect_option_names(spec: Any) -> set[str]:
+    """Walk an ``argument_specs:`` document and return every option name.
+
+    Schema::
+
+        argument_specs:
+          <entry_point>:
+            options:
+              <name>:
+                type: str
+                options:    # nested sub-args (rare)
+                  <child>: ...
+          <other_entry>:
+            options: ...
+    """
+    names: set[str] = set()
+    entries = spec.get("argument_specs") if isinstance(spec, dict) else None
+    if not isinstance(entries, dict):
+        return names
+    for entry in entries.values():
+        if isinstance(entry, dict):
+            _collect_options(entry.get("options"), names)
+    return names
+
+
+def _collect_options(options: Any, sink: set[str]) -> None:
+    if not isinstance(options, dict):
+        return
+    for key, value in options.items():
+        if isinstance(key, str):
+            sink.add(key)
+        if isinstance(value, dict):
+            _collect_options(value.get("options"), sink)
+
+
+_default_registry = ArgumentSpecsRegistry()
+
+
+def get_default_registry() -> ArgumentSpecsRegistry:
+    return _default_registry

--- a/src/ansible_security_scanner/comment/context.py
+++ b/src/ansible_security_scanner/comment/context.py
@@ -1,6 +1,6 @@
 """Platform detection and request-context dataclasses for MR/PR comments.
 
-Pure env probing — no network I/O. Tokens read from environment variables
+Pure env probing - no network I/O. Tokens read from environment variables
 only; never logged, echoed, or persisted. Every code path that could
 surface a token routes through :func:`_redact` first.
 """
@@ -26,7 +26,7 @@ class PlatformContext:
     """Everything the commenter needs to talk to GitHub or GitLab.
 
     Populated by :func:`detect_platform` from CI environment variables.
-    ``token`` is the only sensitive field — it must never be logged,
+    ``token`` is the only sensitive field - it must never be logged,
     echoed, or written to disk.
     """
 

--- a/src/ansible_security_scanner/comment/fingerprint.py
+++ b/src/ansible_security_scanner/comment/fingerprint.py
@@ -34,7 +34,7 @@ _MARKER_SUFFIX = "-->"
 _MARKER_RULE_SAMPLE = 12
 
 # Per-finding fingerprint cap. Each fingerprint is a 16-hex-char
-# truncated SHA-256 of "rule_id|file_path|line_number" — enough entropy
+# truncated SHA-256 of "rule_id|file_path|line_number" - enough entropy
 # to make collisions vanishingly unlikely on realistic scans without
 # bloating the marker. The full set is also digested so the next run
 # can detect "did anything change" in O(1) bytes even when the
@@ -56,8 +56,8 @@ _RESOLVED_RULES_HEADLINE_CAP = 8
 def _finding_fingerprint(finding: Any) -> str:
     """Stable per-finding identity hash.
 
-    Combines ``rule_id``, ``file_path``, and ``line_number`` — the same
-    triple the scanner uses to dedup across files — so the same finding
+    Combines ``rule_id``, ``file_path``, and ``line_number`` - the same
+    triple the scanner uses to dedup across files - so the same finding
     on the same line in two consecutive scans hashes to the same value.
     Truncated to ``_FINGERPRINT_LEN`` hex chars to keep marker payload
     small.
@@ -88,20 +88,20 @@ def _encode_marker(
 
     Schema (v2):
 
-    * ``version`` — schema version, bumped when fields change.
-    * ``findings_count`` — total finding count this run.
-    * ``commit_sha`` — head SHA the scan was run against.
-    * ``open_rule_ids`` — at most ``_MARKER_RULE_SAMPLE`` ids, used to
+    * ``version`` - schema version, bumped when fields change.
+    * ``findings_count`` - total finding count this run.
+    * ``commit_sha`` - head SHA the scan was run against.
+    * ``open_rule_ids`` - at most ``_MARKER_RULE_SAMPLE`` ids, used to
       cite cleared rules in the resolved banner.
-    * ``open_rule_ids_total`` / ``open_rule_ids_digest`` — full-set
+    * ``open_rule_ids_total`` / ``open_rule_ids_digest`` - full-set
       cardinality and SHA-256 digest of the sorted ids, so the next
       run can detect *any* change to the rule surface in O(1) bytes.
-    * ``finding_fingerprints`` — at most ``_MARKER_FINGERPRINT_SAMPLE``
+    * ``finding_fingerprints`` - at most ``_MARKER_FINGERPRINT_SAMPLE``
       truncated fingerprints. Optional.
     * ``finding_fingerprints_total`` / ``finding_fingerprints_digest``
-      — same shape as the rule-id pair, used by ``_compute_delta`` to
+      - same shape as the rule-id pair, used by ``_compute_delta`` to
       know when the truncated sample understates the real diff.
-    * ``finding_rule_ids`` — ``{fingerprint: rule_id}`` over the same
+    * ``finding_rule_ids`` - ``{fingerprint: rule_id}`` over the same
       sample as ``finding_fingerprints``. Inline-mapped (not a parallel
       list) so JSON corruption can't desync the two arrays.
 
@@ -153,7 +153,7 @@ def _decode_marker(body: str) -> dict[str, Any] | None:
 
     Returns ``None`` when no marker is present or parseable. Deliberately
     tolerant: a malformed marker (future version, hand-edited body)
-    returns ``None`` and the caller treats this run as a fresh post —
+    returns ``None`` and the caller treats this run as a fresh post -
     better than crashing mid-pipeline.
     """
     m = _MARKER_RE.search(body or "")
@@ -187,7 +187,7 @@ class _Delta:
     without fingerprints fall back to rule-id deltas.
 
     ``approximate=True`` signals that the previous truncated fingerprint
-    sample understated the real diff — the renderer flags the line so
+    sample understated the real diff - the renderer flags the line so
     reviewers don't read exact counts that are actually lower bounds.
 
     ``resolved_rule_ids`` / ``new_rule_ids`` are family-level: a rule
@@ -274,7 +274,7 @@ def _compute_delta(
 
 
 def _format_rule_ids_suffix(label: str, rule_ids: tuple[str, ...]) -> str:
-    """Format a ``<label>: \\`rule_a\\`, \\`rule_b\\`, …`` continuation
+    """Format a ``<label>: \\`rule_a\\`, \\`rule_b\\`, ...`` continuation
     following the delta headline.
 
     Caller appends two trailing spaces + ``\\n`` to produce a Markdown

--- a/src/ansible_security_scanner/comment/posting.py
+++ b/src/ansible_security_scanner/comment/posting.py
@@ -25,7 +25,7 @@ def _httpx() -> Any:
     Routed through the parent package so ``patch.object(comment.httpx,
     ...)`` swaps in the test double for everything below.
     """
-    from . import httpx as _h  # noqa: PLC0415 — late binding by design
+    from . import httpx as _h  # noqa: PLC0415 - late binding by design
 
     return _h
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -17,8 +17,42 @@ import yaml
 
 from ._ast_helpers import extract_all_tasks, extract_deep_strings
 from ._secrets import redact_secrets
+from .argument_specs import get_default_registry as get_argument_specs_registry
 from .models import SecurityFinding
+from .path_scopes import (
+    SUPPRESS_IN_GITHUB_ACTIONS as _SUPPRESS_IN_GITHUB_ACTIONS,
+)
+from .path_scopes import (
+    SUPPRESS_IN_INTEGRATION_TESTS as _SUPPRESS_IN_INTEGRATION_TESTS,
+)
+from .path_scopes import (
+    SUPPRESS_IN_MOLECULE as _SUPPRESS_IN_MOLECULE,
+)
+from .path_scopes import (
+    is_github_actions_path as _is_github_actions_path,
+)
+from .path_scopes import (
+    is_integration_test_fixture_path as _is_integration_test_fixture_path,
+)
+from .path_scopes import (
+    is_molecule_path as _is_molecule_path,
+)
+from .path_scopes import (
+    is_test_fixture_path as _is_test_fixture_path,
+)
+from .path_scopes import (
+    is_vendor_collection_path as _is_vendor_collection_path,
+)
+from .path_scopes import (
+    rule_path_scope_allows as _rule_path_scope_allows,
+)
 from .patterns_manager import patterns_manager
+from .project_classification import (
+    DEMOTE_IN_HARDENING_PROJECT as _DEMOTE_IN_HARDENING_PROJECT,
+)
+from .project_classification import (
+    is_security_hardening_project as _is_security_hardening_project,
+)
 from .remediations import RemediationGenerator
 from .suppressions import (
     SuppressionDirective,
@@ -106,14 +140,206 @@ _COMMENT_SCAN_RULES: frozenset[str] = frozenset(
     }
 )
 
+# Variable-related rules that should be suppressed when every
+# ``{{ var }}`` reference on the matched line is declared (and therefore
+# validated) in the enclosing role's ``meta/argument_specs.yml``. The
+# argument-specs contract runs before the role and enforces type, required,
+# regex, and choices, so a downstream usage of a validated variable is no
+# longer attacker-controlled in the way these regex rules assume.
+_ARGUMENT_SPECS_AWARE_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "assemble_module_unsafe",
+        "fetch_module_unsafe_dest",
+        "dynamic_include_injection",
+        "hostvars_injection",
+        "groupvars_injection",
+        "vars_lookup_injection",
+    }
+)
+
+# Ansible-injected magic variables. These are populated by Ansible at
+# play execution from controller-trusted state (the directory layout,
+# the inventory file, the active hostname) and are not user-influenceable
+# from inside the playbook. A ``{{ role_path }}/tasks/main.yml`` include
+# is the canonical Ansible idiom for parameterised includes, so treat
+# these names as already-validated for argument-specs-aware rules.
+_ANSIBLE_MAGIC_VARS: frozenset[str] = frozenset(
+    {
+        "role_path",
+        "role_name",
+        "ansible_role_name",
+        "ansible_collection_name",
+        "playbook_dir",
+        "inventory_dir",
+        "inventory_file",
+        "inventory_hostname",
+        "inventory_hostname_short",
+        "ansible_play_name",
+        "ansible_play_hosts",
+        "ansible_search_path",
+        "ansible_config_file",
+        # Facts gathered by ``setup``: controller-trusted, surfaced as
+        # the standard idiom for OS-conditional includes
+        # (``include_vars: "{{ ansible_facts.distribution }}.yml"``).
+        "ansible_facts",
+        "ansible_distribution",
+        "ansible_distribution_major_version",
+        "ansible_distribution_version",
+        "ansible_distribution_release",
+        "ansible_os_family",
+        "ansible_system",
+        "ansible_architecture",
+        "ansible_pkg_mgr",
+        "ansible_service_mgr",
+        "ansible_kernel",
+        "ansible_python_version",
+    }
+)
+
+# Extracts ``{{ var }}`` / ``{{ var.attr }}`` / ``{{ var | filter }}`` and
+# returns the base variable name (pre-dot, pre-pipe).
+_TEMPLATED_VAR_RE = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)")
+
+
+_INCLUDE_PATH_BLOCKER_KEYWORDS: tuple[str, ...] = (
+    "vars:",
+    "loop:",
+    "loop_control:",
+    "when:",
+    "register:",
+    "tags:",
+    "with_items:",
+    "with_dict:",
+)
+
+
+def _extract_templated_vars_until_blocker(text: str) -> list[str]:
+    """Extract templated var names from ``text``, stopping at the first
+    line whose stripped form starts with an Ansible directive keyword
+    that scopes a different value (``loop:`` / ``vars:`` / ``when:`` etc).
+
+    Used to focus argument-specs validation on the include path itself,
+    ignoring loop iterables, sibling-vars expressions, and similar
+    siblings that don't flow into the rule's sink.
+    """
+    names: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if any(stripped.startswith(kw) for kw in _INCLUDE_PATH_BLOCKER_KEYWORDS):
+            break
+        names.extend(_extract_templated_var_names(line))
+    return names
+
+
+def _extract_templated_var_names(line: str) -> list[str]:
+    """Return the base names of every ``{{ var ... }}`` expression in ``line``."""
+    if "{{" not in line:
+        return []
+    return _TEMPLATED_VAR_RE.findall(line)
+
+
 # Detects a YAML block-scalar opener: ``key: |``, ``key: >``, ``key: |-``,
 # ``key: |+``, ``key: >-``, ``key: >+``. Used by ``_is_inside_block_scalar``
 # to decide whether a ``#`` on the anchor line is a YAML comment (suppress)
 # or a character inside a block-scalar string body (e.g. PowerShell
 # comment inside ``win_shell: |``, shell comment inside ``shell: |``).
 _BLOCK_SCALAR_OPENER_RE = re.compile(
-    r"^(?P<indent>\s*)(?:-\s+)?[a-z][a-z0-9_.]*\s*:\s*[|>][+-]?\s*$",
+    r"^(?P<indent>\s*)(?:-\s+)?(?P<key>[a-z][a-z0-9_.]*)\s*:\s*[|>][+-]?\s*$",
     re.IGNORECASE,
+)
+
+# Block-scalar keys whose body is human-prose documentation, not Ansible
+# task content. URLs, ``ssl_ciphers aNULL`` examples, ``http://`` man-page
+# references inside one of these belong to the prose, not to a runtime
+# connection or cipher config, so the regex rules that match production
+# code (insecure_protocol_usage, tls_*, etc.) should not fire there.
+_DOC_BLOCK_KEYS: frozenset[str] = frozenset(
+    {
+        "description",
+        "short_description",
+        "long_description",
+        "summary",
+        "notes",
+        "comment",
+        "comments",
+        "doc",
+        "docs",
+        "documentation",
+        "help",
+        "info",
+        # Ansible plugin metadata block scalars. Filter / module YAML
+        # files document themselves via ``DOCUMENTATION: |``,
+        # ``EXAMPLES: |``, ``RETURN: |`` blocks containing usage
+        # snippets - those are reference text, not executable
+        # configuration.
+        "examples",
+        "return",
+    }
+)
+_DOC_BLOCK_OPENER_RE = re.compile(
+    r"^(?P<indent>\s*)(?:-\s+)?(?P<key>[a-z][a-z0-9_]*)\s*:"
+    r"(?:\s*[|>][+-]?\s*$|\s*$)",
+    re.IGNORECASE,
+)
+
+_REGEX_TEST_FILTER_RE = re.compile(
+    r"(?:is\s+(?:ansible\.builtin\.)?(?:search|match|regex|contains)\b"
+    r"|\bregex_(?:search|replace|findall)\s*\(|"
+    r"\bsearch\s*\(\s*['\"])"
+)
+
+# Rules whose regex matches literal substrings (URLs, cipher names,
+# config snippets, package install lines, etc) that legitimately appear
+# inside human-prose documentation block scalars (``description: |``,
+# ``notes: |``, etc). Suppress these rules when the matched line is
+# inside one of those blocks.
+_SUPPRESS_IN_DOC_BLOCKS: frozenset[str] = frozenset(
+    {
+        "insecure_protocol_usage",
+        "ip_address_url",
+        "tls_min_version_below_1_2_nginx_apache_haproxy",
+        "tls_legacy_protocol_tlsv1_0_or_1_1_enabled",
+        "tls_weak_cipher_suite_rc4_3des_null_export",
+        "null_or_anon_cipher_suite_allowed",
+        "yaml_duplicate_key_suppression",
+        "bindep_profile_runs_shell",
+        "bindep_unpinned_package",
+        "user_input_template",
+        "dynamic_include_injection",
+        "unquoted_template_variable",
+        "set_fact_injection",
+        "register_variable_injection",
+        "unsafe_tag_bypass",
+        "jinja_in_assert_msg",
+    }
+)
+
+# Rules whose regex assumes a non-shell grammar (bindep package list,
+# YAML structure, etc.) and so cannot legitimately match a line inside
+# a shell-module block scalar (``shell: |``, ``command: |``, ``raw: |``,
+# ``win_shell: |``).
+_SUPPRESS_IN_SHELL_BLOCKS: frozenset[str] = frozenset(
+    {
+        "bindep_profile_runs_shell",
+        "bindep_unpinned_package",
+        "yaml_duplicate_key_suppression",
+    }
+)
+
+# Rules whose regex sees a literal substring inside a Jinja
+# ``regex_search``/``is search``/``regex_replace`` argument. The
+# substring is a *test pattern*, not a deployed config value, so the
+# finding is always a false positive. Same set as the doc-block
+# suppression - rules that match raw config strings.
+_SUPPRESS_INSIDE_REGEX_TEST_FILTER: frozenset[str] = frozenset(
+    {
+        "insecure_protocol_usage",
+        "ip_address_url",
+        "tls_min_version_below_1_2_nginx_apache_haproxy",
+        "tls_legacy_protocol_tlsv1_0_or_1_1_enabled",
+        "tls_weak_cipher_suite_rc4_3des_null_export",
+        "null_or_anon_cipher_suite_allowed",
+    }
 )
 
 
@@ -145,6 +371,79 @@ def _is_inside_block_scalar(lines: list[str], line_num: int) -> bool:
         # (uncommon but valid when the scalar content itself contains a
         # nested ``key: |``). Ignore and keep walking.
     return False
+
+
+def _is_inside_keyed_block_scalar(
+    lines: list[str],
+    line_num: int,
+    opener_re: re.Pattern[str],
+    keys: frozenset[str],
+) -> bool:
+    """True iff ``lines[line_num-1]`` is inside a block-scalar whose
+    opener key (e.g. ``description: |``, ``shell: |``) is in ``keys``.
+
+    ``opener_re`` must expose a ``key`` named group; the walk stops at
+    the first line shallower than the anchor that matches it.
+    """
+    if not 1 <= line_num <= len(lines):
+        return False
+    anchor = lines[line_num - 1]
+    seen_indent = len(anchor) - len(anchor.lstrip())
+    for idx in range(line_num - 2, -1, -1):
+        raw = lines[idx]
+        if not raw.strip():
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        if indent >= seen_indent:
+            continue
+        m = opener_re.match(raw)
+        if m:
+            return m.group("key").lower() in keys
+        seen_indent = indent
+    return False
+
+
+def _is_inside_documentation_block(lines: list[str], line_num: int) -> bool:
+    """True iff ``lines[line_num-1]`` is inside a doc-style block-scalar
+    body (``description:``, ``short_description:``, ``notes:``, ...).
+    """
+    return _is_inside_keyed_block_scalar(lines, line_num, _DOC_BLOCK_OPENER_RE, _DOC_BLOCK_KEYS)
+
+
+# Block-scalar keys whose body is shell-language source (POSIX shell,
+# bash, PowerShell, Python). Lines inside one of these bodies must not
+# be matched by rules whose regex assumes a different grammar
+# (``bindep_profile_runs_shell``, which expects bindep package-list
+# grammar).
+_SHELL_BLOCK_KEYS: frozenset[str] = frozenset(
+    {
+        "shell",
+        "ansible.builtin.shell",
+        "command",
+        "ansible.builtin.command",
+        "raw",
+        "ansible.builtin.raw",
+        "win_shell",
+        "ansible.windows.win_shell",
+        "win_command",
+        "ansible.windows.win_command",
+        "script",
+        "ansible.builtin.script",
+        "cmd",
+        "expect",
+        "ansible.builtin.expect",
+    }
+)
+
+
+def _is_inside_shell_block(lines: list[str], line_num: int) -> bool:
+    """True iff ``lines[line_num-1]`` is inside a shell-module
+    block-scalar body (``shell: |``, ``command: |``, ``raw: |``,
+    ``win_shell: |``).
+    """
+    return _is_inside_keyed_block_scalar(
+        lines, line_num, _BLOCK_SCALAR_OPENER_RE, _SHELL_BLOCK_KEYS
+    )
 
 
 # Key-side of an Ansible module invocation. Accepts the bare ``key:``
@@ -227,22 +526,15 @@ _INSECURE_PROTOCOL_URL_RE: re.Pattern[str] = re.compile(
 )
 
 
-# Severity demotion for findings inside test-fixture trees (e.g.
-# ``ansible-core/test/integration/targets/**``, ``community.*/tests/**``).
-# In those trees ``validate_certs: no``, unhashed pip installs, and S3
-# buckets without access logging are intentional -- the playbook is
-# provisioning a throw-away environment.
+# Severity demotion for findings inside test-fixture trees (see
+# ``path_scopes.TEST_FIXTURE_PATH_RE`` for the path policy). In those
+# trees ``validate_certs: no``, unhashed pip installs, and S3 buckets
+# without access logging are intentional -- the playbook is provisioning
+# a throw-away environment.
 #
-# We do NOT exclude these findings (today's test fixture is tomorrow's
-# copy-pasted production playbook); we knock the severity down by one
-# tier so the finding stays visible without crowding higher-confidence
-# signal in production paths.
-_TEST_FIXTURE_PATH_RE: re.Pattern[str] = re.compile(
-    r"(?:^|/)(?:test|tests|molecule|integration_tests)(?:/|$)|"
-    r"(?:^|/)integration/targets/|"
-    r"(?:^|/)\.github/workflows/(?:test|ci|integration)",
-    re.IGNORECASE,
-)
+# Today's test fixture is tomorrow's copy-pasted production playbook,
+# so we knock the severity down one tier rather than excluding the
+# finding outright.
 _DEMOTE_IN_TEST_FIXTURES: frozenset[str] = frozenset(
     {
         "ssl_verification_disabled",
@@ -259,42 +551,21 @@ _DEMOTE_IN_TEST_FIXTURES: frozenset[str] = frozenset(
         "azure_redis_non_ssl_port_enabled",
         "ignore_errors_security_task",
         "ansible_galaxy_untrusted",
+        "cross_file_taint",
+        # Test fixtures that *verify* SSH-hardening assertions (e.g.
+        # ``- 'PermitRootLogin yes' in config.content | b64decode``)
+        # naturally contain the same literals the rule looks for. The
+        # role being tested is the right scope to evaluate, not the
+        # assertion that exercises it.
+        "ssh_config_manipulation",
     }
 )
-# Files under a vendor device-management collection - vSphere, iDRAC,
-# F5, Junos, Palo Alto, NetApp, Pure Storage, Cisco IOS, etc. These
+# Severity demotion for findings inside vendor device-management
+# collections (see ``path_scopes.VENDOR_COLLECTION_PATH_RE``). These
 # collections target an internal management plane that ships with
-# self-signed certs by default and requires the operator to configure
-# trust roots before ``validate_certs: yes`` will work. Until that's
-# done, ``validate_certs: false`` is the documented bootstrap shape.
-# Same logic for ``no_log`` on ``*_user`` / ``*_password`` task args:
-# these collections set ``no_log`` on the parameter spec at the module
-# level (Ansible enforces it) so requiring the role author to ALSO
-# write ``no_log: true`` on the task is duplicate work the user can't
-# act on.
-#
-# Detection is path-based against the canonical collection layout:
-# ``<namespace>.<name>/`` at any depth, or the corpus-clone aliases
-# (``community.vmware``, ``dell-openmanage``, etc.). Same demotion
-# semantics as test fixtures: knock severity down one tier so the
-# finding stays visible but doesn't drown out generic-cloud-API
-# findings against the same vocabulary.
-_VENDOR_COLLECTION_PATH_RE: re.Pattern[str] = re.compile(
-    r"(?:^|/)(?:"
-    r"community\.vmware|community\.network|"
-    r"dell(?:emc)?[-.](?:openmanage|powerflex|powerstore|powerscale|unity|networking)|"
-    r"f5networks?[-.](?:f5_modules|f5os|f5_bigip)|"
-    r"juniper[-.]?(?:device|junos)|"
-    r"paloaltonetworks[-.]panos|"
-    r"netapp[-.](?:ontap|elementsw|aws|azure|cloudmanager|um_info)|"
-    r"purestorage[-.](?:flasharray|flashblade|fusion)|"
-    r"cisco[-.](?:ios|iosxr|nxos|asa|aci|meraki|intersight|ucs)|"
-    r"check_point[-.](?:gaia|mgmt)|"
-    r"fortinet[-.](?:fortios|fortimanager|fortianalyzer)|"
-    r"vyos[-.]vyos"
-    r")(?:/|$)",
-    re.IGNORECASE,
-)
+# self-signed certs by default and ``no_log`` is enforced at the module
+# parameter spec, so duplicate task-level ``no_log: true`` requirements
+# are noise the user cannot act on.
 _DEMOTE_IN_VENDOR_COLLECTIONS: frozenset[str] = frozenset(
     {
         "ssl_verification_disabled",
@@ -315,14 +586,6 @@ _SEVERITY_DEMOTE: dict[str, str] = {
     "MEDIUM": "LOW",
     "LOW": "LOW",
 }
-
-
-def _is_test_fixture_path(file_path: Path) -> bool:
-    return bool(_TEST_FIXTURE_PATH_RE.search(file_path.as_posix()))
-
-
-def _is_vendor_collection_path(file_path: Path) -> bool:
-    return bool(_VENDOR_COLLECTION_PATH_RE.search(file_path.as_posix()))
 
 
 # Module names whose presence inside a ``- block:`` body makes the
@@ -383,14 +646,22 @@ _BLOCK_FAILABLE_MODULES: frozenset[str] = frozenset(
 
 def _block_contains_failable_task(block_tasks: list) -> bool:
     """Return True if any task inside ``block_tasks`` uses a module from
-    ``_BLOCK_FAILABLE_MODULES``. Recurses into nested ``block:`` bodies
-    so a block-wrapping-a-block pattern still counts.
+    ``_BLOCK_FAILABLE_MODULES`` AND that task does not already declare
+    its own failure-handling semantics (``ignore_errors:`` /
+    ``failed_when:``). When every failable task in the block has
+    explicit failure semantics, the author has consciously chosen not
+    to halt on failure - adding a ``rescue:`` would be redundant.
+
+    Recurses into nested ``block:`` bodies so a block-wrapping-a-block
+    pattern still counts.
     """
     for t in block_tasks:
         if not isinstance(t, dict):
             continue
         for key in t:
             if key in _BLOCK_FAILABLE_MODULES:
+                if "ignore_errors" in t or "failed_when" in t:
+                    break
                 return True
         nested = t.get("block")
         if isinstance(nested, list) and _block_contains_failable_task(nested):
@@ -398,27 +669,18 @@ def _block_contains_failable_task(block_tasks: list) -> bool:
     return False
 
 
-def _demote_severity_if_eligible(finding):
-    """Knock severity down one tier when the finding belongs to the curated
-    allowlist and the surrounding file lives in a known test-fixture path.
+def _demote_severity(finding, eligible_rule_ids: frozenset[str]):
+    """Knock severity down one tier when ``finding.rule_id`` is in
+    ``eligible_rule_ids``. Mutates ``finding`` in place AND returns it
+    so callers can use this in a list comprehension.
 
-    Operates on the finding object in place AND returns it, so the caller
-    can use the function in a list comprehension when we're rewriting
-    ``scan_file``'s result list.
+    The eligible set encodes the *why*: rules in
+    ``_DEMOTE_IN_TEST_FIXTURES`` are intentionally-insecure CI shapes;
+    ``_DEMOTE_IN_VENDOR_COLLECTIONS`` covers device-management
+    self-signed-cert defaults; ``_DEMOTE_IN_HARDENING_PROJECT`` covers
+    CIS/STIG roles whose job is to touch PAM/GRUB/kernel surfaces.
     """
-    if finding.rule_id in _DEMOTE_IN_TEST_FIXTURES and isinstance(finding.severity, str):
-        finding.severity = _SEVERITY_DEMOTE.get(finding.severity.upper(), finding.severity)
-    return finding
-
-
-def _demote_severity_in_vendor_path(finding):
-    """Same shape as ``_demote_severity_if_eligible`` but for the vendor-
-    collection allowlist. Kept separate from the test-fixture demotion
-    because the rule-allowlists are different (vendor paths legitimately
-    use ``validate_certs: false`` and ``register: cli_output`` patterns
-    that test fixtures don't, and vice versa).
-    """
-    if finding.rule_id in _DEMOTE_IN_VENDOR_COLLECTIONS and isinstance(finding.severity, str):
+    if finding.rule_id in eligible_rule_ids and isinstance(finding.severity, str):
         finding.severity = _SEVERITY_DEMOTE.get(finding.severity.upper(), finding.severity)
     return finding
 
@@ -1089,6 +1351,11 @@ class FileScanner:
         # FileScanner is shared across threads (see scan_file docstring).
         self._task_line_index_cache: dict[int, dict[str, int]] = {}
         self._task_line_index_lock = threading.Lock()
+        # One-shot project-level classification: hardening roles
+        # (CIS / STIG / dev-sec) legitimately manipulate PAM / GRUB /
+        # kernel modules, so a curated rule set gets demoted across
+        # the whole tree rather than firing as MEDIUM/HIGH risk.
+        self._is_hardening_project = _is_security_hardening_project(self.directory)
 
     def scan_file(
         self,
@@ -1135,7 +1402,7 @@ class FileScanner:
                             _AnsibleTagTolerantLoader,  # local import to avoid cycle
                         )
 
-                        yaml_data = yaml.load(content, Loader=_AnsibleTagTolerantLoader)  # noqa: S506
+                        yaml_data = yaml.load(content, Loader=_AnsibleTagTolerantLoader)
                     except yaml.YAMLError:
                         logger.debug(
                             "YAML parsing failed for %s, continuing with line-based scanning: %s",
@@ -1502,10 +1769,20 @@ class FileScanner:
             ], suppression_warnings
 
         findings = _apply_overlap_suppression(findings)
+        findings = self._apply_argument_specs_filter(findings, file_path, lines)
+        if _is_molecule_path(file_path):
+            findings = [f for f in findings if f.rule_id not in _SUPPRESS_IN_MOLECULE]
+        if _is_integration_test_fixture_path(file_path):
+            findings = [f for f in findings if f.rule_id not in _SUPPRESS_IN_INTEGRATION_TESTS]
+        if _is_github_actions_path(file_path):
+            findings = [f for f in findings if f.rule_id not in _SUPPRESS_IN_GITHUB_ACTIONS]
+        findings = [f for f in findings if _rule_path_scope_allows(f.rule_id, file_path)]
         if _is_test_fixture_path(file_path):
-            findings = [_demote_severity_if_eligible(f) for f in findings]
+            findings = [_demote_severity(f, _DEMOTE_IN_TEST_FIXTURES) for f in findings]
         if _is_vendor_collection_path(file_path):
-            findings = [_demote_severity_in_vendor_path(f) for f in findings]
+            findings = [_demote_severity(f, _DEMOTE_IN_VENDOR_COLLECTIONS) for f in findings]
+        if self._is_hardening_project:
+            findings = [_demote_severity(f, _DEMOTE_IN_HARDENING_PROJECT) for f in findings]
         if self.active_rule_ids is not None:
             # Final ``--ignore`` gate. Runs AFTER ``_apply_overlap_suppression``
             # so that ignoring the most-specific rule of an overlap group
@@ -3639,13 +3916,166 @@ class FileScanner:
             line = all_lines[line_num - 1].lstrip()
             if line.startswith(("#", "*", "<", "//")):
                 return True
-        start = max(0, line_num - 6)
+        # Look 12 lines back so deeply-indented repo configs (full
+        # ``yum_repository:`` blocks reach this far between the
+        # module key and the ``gpgkey:`` argument).
+        start = max(0, line_num - 12)
         block = "\n".join(all_lines[start:line_num])
         return bool(
             re.search(
-                r"\b(?:apt_key|apt_repository|rpm_key|yum_repository|zypper_repository)\s*:", block
+                r"\b(?:apt_key|apt_repository|rpm_key|yum_repository|zypper_repository|"
+                r"ansible\.builtin\.(?:apt_key|apt_repository|rpm_key|yum_repository))"
+                r"\s*:",
+                block,
             )
         )
+
+    # Open-source license SPDX header URLs. The Apache, GPL, MPL, BSD,
+    # and Creative Commons license texts are all served from these
+    # domains over plain HTTP; the URL is canonical SPDX boilerplate
+    # (vendored into license headers across millions of files), not a
+    # protocol choice the user can change. ``http://`` is what the
+    # SPDX identifier resolves to and any other URL would not be the
+    # license text.
+    _LICENSE_HEADER_URL_RE: re.Pattern[str] = re.compile(
+        r"\bhttps?://(?:www\.)?(?:"
+        r"apache\.org/licenses/|"
+        r"gnu\.org/licenses/|"
+        r"creativecommons\.org/licenses/|"
+        r"opensource\.org/licenses/|"
+        r"mozilla\.org/MPL/|"
+        r"eclipse\.org/legal/|"
+        r"spdx\.org/licenses/|"
+        r"unlicense\.org|"
+        r"www\.boost\.org/LICENSE|"
+        r"opensource\.org/osd"
+        r")",
+        re.IGNORECASE,
+    )
+
+    # Debian / Ubuntu / Devuan / RHEL / CentOS / Fedora / SUSE official
+    # package mirrors. These ship Release.gpg / repomd.xml.asc alongside
+    # every metadata index; the package manager validates those
+    # signatures before installing, so plain HTTP transport is the
+    # documented and recommended shape (HTTPS is fine but adds nothing).
+    # PPA / launchpad URLs are in the same category.
+    _SIGNED_PACKAGE_MIRROR_RE: re.Pattern[str] = re.compile(
+        r"\bhttps?://(?:"
+        r"(?:deb|archive|ports|security|cdn|ftp|httpredir)\."
+        r"(?:debian|devuan|ubuntu|kali)\.org|"
+        r"(?:archive|old-releases)\.ubuntu\.com|"
+        r"(?:mirror|mirrors|cdn|download)\.(?:centos|fedora|rockylinux|"
+        r"almalinux|rhel|opensuse|suse)\.org|"
+        r"(?:[a-z0-9-]+\.)?fedoraproject\.org/pub|"
+        r"download\.opensuse\.org|"
+        r"ppa\.launchpad\.net|"
+        r"ppa\.launchpadcontent\.net"
+        r")/",
+        re.IGNORECASE,
+    )
+
+    # Debian apt-secure ``deb [signed-by=...]`` / ``[trusted=yes]``
+    # source lines. The ``signed-by=/etc/apt/keyrings/foo.gpg`` clause
+    # tells apt to verify package signatures with that explicit key,
+    # which is the modern, recommended replacement for the deprecated
+    # ``apt-key add``. Plain HTTP transport here is part of the
+    # design - integrity is guaranteed by GPG, not TLS.
+    _APT_SIGNED_SOURCE_RE: re.Pattern[str] = re.compile(
+        r"\bdeb\s+\[[^\]]*(?:signed-by|trusted=yes)[^\]]*\]\s+https?://",
+        re.IGNORECASE,
+    )
+
+    # systemd unit-file metadata keys (``Documentation=http://...``,
+    # ``URL=http://...``, ``Help=http://...`` ...). The URL is operator-
+    # facing reference text written into the unit file; systemd never
+    # opens it.
+    _SYSTEMD_DOC_FIELD_RE: re.Pattern[str] = re.compile(
+        r"^\s*(?:Documentation|URL|Help|HomePage|"
+        r"BugReportURL|SupportURL|UpstreamURL)\s*=",
+        re.IGNORECASE,
+    )
+
+    # XML namespace and JSON-Schema ``$schema`` URL bindings. The
+    # parser uses these as identifier strings, never as fetch targets.
+    _XML_NAMESPACE_URL_RE: re.Pattern[str] = re.compile(
+        r"(?:xmlns(?::[A-Za-z][\w.-]*)?|"
+        r"\$schema|targetNamespace|"
+        r"schemaLocation|xsi:noNamespaceSchemaLocation)\s*=\s*"
+        r"['\"]?https?://",
+        re.IGNORECASE,
+    )
+
+    # Filesystem paths whose contents are dispatched by exec - mode
+    # 0755 is the canonical, required shape there:
+    #
+    #   * ``/etc/ansible/facts.d/<name>.fact`` - Ansible runs each
+    #     fact at gather time and parses stdout as JSON.
+    #   * ``/etc/cron.{hourly,daily,weekly,monthly,d}/<name>`` -
+    #     run-parts dispatches by exec.
+    #   * ``/etc/profile.d/<name>.sh`` and
+    #     ``/etc/bash_completion.d/<name>`` - sourced by login shell.
+    #   * ``/etc/init.d/<name>`` and ``/etc/rc.d/init.d/<name>`` -
+    #     SysV init scripts.
+    #   * ``/etc/network/if-up.d/`` & friends, dhclient hooks,
+    #     ``/etc/X11/xinit/xinitrc.d/`` - dispatch dirs.
+    _EXEC_DISPATCH_PATH_RE: re.Pattern[str] = re.compile(
+        r"dest\s*:\s*['\"]?"
+        r"(?:/etc/ansible/facts\.d/|"
+        r"/etc/cron\.(?:hourly|daily|weekly|monthly|d)/|"
+        r"/etc/profile\.d/|"
+        r"/etc/bash_completion\.d/|"
+        r"/etc/init\.d/|"
+        r"/etc/rc\.d/init\.d/|"
+        r"/etc/network/if-(?:up|down|pre-up|post-down)\.d/|"
+        r"/etc/dhcp/dhclient-(?:enter|exit)-hooks\.d/|"
+        r"/etc/X11/xinit/xinitrc\.d/|"
+        r"/etc/apt/apt\.conf\.d/[0-9]+[A-Za-z0-9_-]+)"
+    )
+
+    # facts_d_injection post-filter: a static role-relative ``src:``,
+    # ``owner: root``, and a non-world-writable ``mode:`` together
+    # describe the canonical safe shape (the role itself is the source
+    # of truth). World-writable means the last octal digit has the
+    # ``2`` bit set - i.e. one of 2/3/6/7.
+    _FACTS_D_STATIC_SRC_RE: re.Pattern[str] = re.compile(
+        r"^\s*src\s*:\s*['\"]?[A-Za-z0-9_./-]+(?:\.j2)?['\"]?\s*(?:#|$)",
+        re.MULTILINE,
+    )
+    _FACTS_D_ROOT_OWNER_RE: re.Pattern[str] = re.compile(r"owner\s*:\s*['\"]?root\b")
+    _FACTS_D_WORLD_WRITABLE_MODE_RE: re.Pattern[str] = re.compile(
+        r"mode\s*:\s*['\"]?0?[0-7]?[0-7]?[2367]\b"
+    )
+
+    # ``command_module_with_shell`` re-test: the rule's regex catches
+    # ``command:`` lines containing shell metacharacters. Quoted spans
+    # inside the argv (``awk '...'``, ``sh -c "..."``, ...) are part of the
+    # embedded interpreter's args, not seen by ``command:`` itself.
+    _COMMAND_SHELL_META_RE: re.Pattern[str] = re.compile(
+        r"^\s*(?:ansible\.builtin\.)?command:.*[|;&`$()]"
+    )
+
+    # Helm / Go-template comment block ``{{/* ... */}}`` and
+    # ``{{- /* ... */ -}}`` openers/closers. These wrap entire SPDX
+    # license headers in OpenStack-Helm chart templates. A line is
+    # inside the comment if a ``{{/*`` (with optional ``-``) opens
+    # somewhere above and no matching ``*/}}`` has closed it yet.
+    _GO_TMPL_COMMENT_OPEN_RE: re.Pattern[str] = re.compile(r"\{\{-?\s*/\*")
+    _GO_TMPL_COMMENT_CLOSE_RE: re.Pattern[str] = re.compile(r"\*/\s*-?\}\}")
+
+    @staticmethod
+    def _is_inside_go_template_comment(all_lines: list, line_num: int) -> bool:
+        """True iff ``all_lines[line_num-1]`` is inside a Helm /
+        Go-template ``{{/* ... */}}`` comment block.
+
+        Walks the file from the top, tracking opens/closes; cheap
+        because Helm templates are short and the regex is fast.
+        """
+        if not 1 <= line_num <= len(all_lines):
+            return False
+        text = "\n".join(all_lines[:line_num])
+        opens = len(FileScanner._GO_TMPL_COMMENT_OPEN_RE.findall(text))
+        closes = len(FileScanner._GO_TMPL_COMMENT_CLOSE_RE.findall(text))
+        return opens > closes
 
     @staticmethod
     def _pip_task_has_hash_lock(all_lines: list, line_num: int) -> bool:
@@ -3897,6 +4327,45 @@ class FileScanner:
                             if pat.id in _nested_rules:
                                 if _url_matches_are_all_nested_json(
                                     variant, url_re=_nested_rules[pat.id]
+                                ):
+                                    continue
+
+                            # Mirror of the url_encoded_credentials
+                            # post-filter (see _emit_finding_if_allowed).
+                            # OpenSSL X.509 -addext flags and DB config
+                            # knobs (password_encryption=scram-sha-256,
+                            # auth_method=trust, etc.) match the
+                            # credential shape but are not credentials.
+                            if pat.id == "url_encoded_credentials":
+                                if re.search(
+                                    r"-addext\s+['\"]?(?:keyUsage|"
+                                    r"extendedKeyUsage|subjectAltName|"
+                                    r"basicConstraints|"
+                                    r"authorityKeyIdentifier|"
+                                    r"subjectKeyIdentifier|"
+                                    r"crlDistributionPoints|"
+                                    r"authorityInfoAccess|"
+                                    r"nameConstraints|nsCertType)=",
+                                    variant,
+                                ):
+                                    continue
+                                if re.search(
+                                    r"\bgpgkey\s*=\s*(?:file|https?|ftp)://",
+                                    variant,
+                                    re.IGNORECASE,
+                                ):
+                                    continue
+                                if re.search(
+                                    r"\b(?:password_encryption|"
+                                    r"ssl_passphrase_command|"
+                                    r"auth_method|password_command|"
+                                    r"auth_param|crypto_policy)"
+                                    r"\s*=\s*['\"]?(?:scram-sha-256|"
+                                    r"md5|sha256|sha512|trust|peer|"
+                                    r"ident|reject|cert|password|gss|"
+                                    r"sspi|ldap|radius|pam|bsd)\b",
+                                    variant,
+                                    re.IGNORECASE,
                                 ):
                                     continue
 
@@ -4539,6 +5008,154 @@ class FileScanner:
 
         return findings
 
+    def _apply_argument_specs_filter(
+        self,
+        findings: list[SecurityFinding],
+        file_path: Path,
+        lines: list[str],
+    ) -> list[SecurityFinding]:
+        """Drop findings on argument-specs-aware rules whose every templated
+        variable is already validated.
+
+        A variable is considered validated when it is either:
+
+          * declared in the enclosing role's ``meta/argument_specs.yml``
+            (Ansible's own argument-validation runs before the role and
+            enforces type / required / regex / choices on declared
+            options), or
+          * an Ansible-injected magic variable like ``role_path`` /
+            ``playbook_dir`` / ``inventory_hostname`` (controller-trusted,
+            not user-influenceable), or
+          * bound by a sibling ``vars:`` block on the same task, or
+            declared as the task's ``loop_var`` / ``loop_control``
+            iterator (the include path is computed from a literal
+            expression that the playbook author controls).
+        """
+        if not findings:
+            return findings
+        registry = get_argument_specs_registry()
+
+        kept: list[SecurityFinding] = []
+        for f in findings:
+            if f.rule_id not in _ARGUMENT_SPECS_AWARE_RULE_IDS:
+                kept.append(f)
+                continue
+            templated = self._templated_vars_for_finding(f, lines)
+            if not templated:
+                kept.append(f)
+                continue
+            local_vars = self._task_local_vars(lines, f.line_number)
+            if all(
+                v in _ANSIBLE_MAGIC_VARS
+                or v in local_vars
+                or registry.is_validated_variable(file_path, v)
+                for v in templated
+            ):
+                logger.debug(
+                    "Suppressing %s at %s:%d via argument_specs/magic-vars (vars=%s)",
+                    f.rule_id,
+                    file_path,
+                    f.line_number,
+                    templated,
+                )
+                continue
+            kept.append(f)
+        return kept
+
+    @staticmethod
+    def _templated_vars_for_finding(finding: SecurityFinding, lines: list[str]) -> list[str]:
+        """Return every ``{{ var }}`` base name relevant to ``finding``.
+
+        For include-style findings, only the include path itself matters
+        - templated values inside ``loop:`` / ``when:`` / sibling ``vars:``
+        blocks are not the rule's sink. We extract from the snippet, the
+        match line, and (when the anchor is a multi-line task header) the
+        next few argument lines, stopping at the first sibling block
+        directive.
+        """
+        names: list[str] = []
+        names.extend(_extract_templated_vars_until_blocker(finding.code_snippet or ""))
+        names.extend(_extract_templated_vars_until_blocker(finding.match_line or ""))
+        if 1 <= finding.line_number <= len(lines):
+            anchor = lines[finding.line_number - 1]
+            anchor_indent = len(anchor) - len(anchor.lstrip())
+            for offset, src_line in enumerate(
+                lines[finding.line_number - 1 : finding.line_number + 6]
+            ):
+                stripped = src_line.strip()
+                if any(stripped.startswith(kw) for kw in _INCLUDE_PATH_BLOCKER_KEYWORDS):
+                    break
+                # A new task at the same or shallower indent ends the
+                # current task body. ``offset == 0`` is the anchor line
+                # itself - which IS a ``- name:`` line for tasks - so
+                # never treat that as a body terminator.
+                if (
+                    offset > 0
+                    and stripped.startswith("- ")
+                    and (len(src_line) - len(src_line.lstrip())) <= anchor_indent
+                ):
+                    break
+                names.extend(_extract_templated_var_names(src_line))
+        return [n for n in names if n]
+
+    @staticmethod
+    def _task_local_vars(lines: list[str], anchor_line: int) -> set[str]:
+        """Return variable names bound locally to the task at ``anchor_line``.
+
+        Includes:
+
+          * names defined under a sibling ``vars:`` block, and
+          * the iterator name from ``loop_control: { loop_var: name }``,
+            which Ansible scopes to the task body.
+
+        Implements the standard parameterised-include idiom::
+
+            - ansible.builtin.include_tasks:
+                file: "{{ __task_file }}"
+              vars:
+                __task_file: "{{ role_path }}/tasks/foo.yml"
+              loop_control:
+                loop_var: __task_file
+        """
+        if not (1 <= anchor_line <= len(lines)):
+            return set()
+        names: set[str] = set()
+        anchor = lines[anchor_line - 1]
+        anchor_indent = len(anchor) - len(anchor.lstrip())
+        block_kind: str | None = None
+        block_indent = -1
+        for idx in range(anchor_line - 1, min(len(lines), anchor_line + 30)):
+            raw = lines[idx]
+            stripped = raw.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            indent = len(raw) - len(raw.lstrip())
+            if block_kind is None:
+                if indent < anchor_indent and stripped.startswith("- "):
+                    break
+                if stripped == "vars:" and indent <= anchor_indent:
+                    block_kind = "vars"
+                    block_indent = indent
+                elif stripped == "loop_control:" and indent <= anchor_indent:
+                    block_kind = "loop_control"
+                    block_indent = indent
+                continue
+            if indent <= block_indent:
+                block_kind = None
+                block_indent = -1
+                if stripped.startswith("- "):
+                    break
+                continue
+            if block_kind == "vars":
+                m = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
+                if m:
+                    names.add(m.group(1))
+            elif block_kind == "loop_control":
+                m = re.match(r"loop_var\s*:\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)", stripped)
+                if m:
+                    names.add(m.group(1))
+        return names
+
     # Suppression helpers
     # Short list of indicators that, if present on a line that's being
     # suppressed, almost always mean something sketchy is being smuggled
@@ -5034,6 +5651,19 @@ class FileScanner:
         ):
             return
 
+        # ``meta/argument_specs.yml`` awareness: when the matched line uses a
+        # templated variable that the enclosing role validates via
+        # argument_specs (type / required / regex / choices), Ansible itself
+        # enforces the contract before the role runs. Suppress the variable-
+        # injection-family findings in that case so well-validated role
+        # inputs do not produce noise.
+        if pattern_obj.id in _ARGUMENT_SPECS_AWARE_RULE_IDS:
+            templated_vars = _extract_templated_var_names(line)
+            if templated_vars:
+                registry = get_argument_specs_registry()
+                if all(registry.is_validated_variable(file_path, v) for v in templated_vars):
+                    return
+
         # Hardcoded-credentials plausibility heuristic: only the generic,
         # shape-free rules (hardcoded_password / _api_key / _secret / _token,
         # base64/hex/uuid shape) need a secondary check that the matched
@@ -5129,10 +5759,84 @@ class FileScanner:
             ):
                 return
 
-        if pattern_obj.id == "insecure_protocol_usage" and self._is_signed_package_channel(
+        if pattern_obj.id == "url_encoded_credentials" and 1 <= line_num <= len(all_lines):
+            raw = all_lines[line_num - 1]
+            # OpenSSL X.509 extension flags (``-addext 'keyUsage=...'``,
+            # ``-addext 'extendedKeyUsage=...'``, ``-addext
+            # 'subjectAltName=...'``) match the credential-shape regex
+            # because their names contain ``key`` / ``auth``. They are
+            # certificate-attribute declarations, not credential
+            # literals, so suppress when the matched line uses them.
+            if re.search(
+                r"-addext\s+['\"]?(?:keyUsage|extendedKeyUsage|"
+                r"subjectAltName|basicConstraints|authorityKeyIdentifier|"
+                r"subjectKeyIdentifier|crlDistributionPoints|"
+                r"authorityInfoAccess|nameConstraints|nsCertType)=",
+                raw,
+            ):
+                return
+            # Package-repository signing key references
+            # (``gpgkey=file:///etc/pki/...``, ``gpgkey=https://...``)
+            # match the credential shape because the param name is
+            # ``gpgkey``. The value points at a public signing
+            # certificate, never a credential.
+            if re.search(
+                r"\bgpgkey\s*=\s*(?:file|https?|ftp)://",
+                raw,
+                re.IGNORECASE,
+            ):
+                return
+            # Database / server config knobs whose ``=value`` pair
+            # matches the credential shape (``password_encryption=...``,
+            # ``ssl_passphrase_command=...``, ``auth_method=...``) but
+            # whose value is a hash-algorithm identifier or a known
+            # config token, not a credential. Suppress when the value
+            # is one of those identifiers.
+            if re.search(
+                r"\b(?:password_encryption|ssl_passphrase_command|"
+                r"auth_method|password_command|auth_param|crypto_policy)"
+                r"\s*=\s*['\"]?(?:scram-sha-256|md5|sha256|sha512|"
+                r"trust|peer|ident|reject|cert|password|gss|sspi|ldap|"
+                r"radius|pam|bsd)\b",
+                raw,
+                re.IGNORECASE,
+            ):
+                return
+
+        if pattern_obj.id == "lookup_env_leak" and 1 <= line_num <= len(all_lines):
+            # Canonical pattern: ``my_secret: "{{ ... | default(lookup('env',
+            # 'MY_SECRET'), true) }}"``. The variable being assigned
+            # carries a credential by design, and ``lookup('env', ...)`` is
+            # the recommended way to seed it without hardcoding. The
+            # rule's intent is to catch *unintentional* exposure of
+            # controller env into the play scope; when the receiving
+            # variable is itself credential-named, the user has named
+            # the secret a secret.
+            raw = all_lines[line_num - 1]
+            if re.search(
+                r"(?:^|\s|-)\s*(?:[A-Za-z0-9_-]*"
+                r"(?:secret|token|password|passwd|api[_-]?key|access[_-]?key|"
+                r"private[_-]?key|client[_-]?secret|credential|"
+                r"oauth|bearer|auth)[A-Za-z0-9_-]*)\s*:",
+                raw,
+                re.IGNORECASE,
+            ):
+                return
+
+        if pattern_obj.id in _SUPPRESS_IN_DOC_BLOCKS and _is_inside_documentation_block(
             all_lines, line_num
         ):
             return
+
+        if pattern_obj.id in _SUPPRESS_IN_SHELL_BLOCKS and _is_inside_shell_block(
+            all_lines, line_num
+        ):
+            return
+
+        if pattern_obj.id in _SUPPRESS_INSIDE_REGEX_TEST_FILTER and 1 <= line_num <= len(all_lines):
+            raw = all_lines[line_num - 1]
+            if _REGEX_TEST_FILTER_RE.search(raw):
+                return
 
         # Jinja test-filter usage: ``{{ 'http://x' is uri }}`` / ``is url``
         # is a STATIC test fixture exercising the test plugin, not a
@@ -5141,6 +5845,65 @@ class FileScanner:
         if pattern_obj.id == "insecure_protocol_usage" and 1 <= line_num <= len(all_lines):
             raw = all_lines[line_num - 1]
             if re.search(r"['\"]https?://[^'\"]*['\"]\s+is\s+(?:uri|url)\b", raw):
+                return
+            # SPDX license header URL - canonical license-identifier
+            # text, not a protocol choice.
+            if self._LICENSE_HEADER_URL_RE.search(raw):
+                return
+            # Distro mirror or ``deb [signed-by=...] http://...`` source -
+            # GPG validates the package, not TLS.
+            if self._SIGNED_PACKAGE_MIRROR_RE.search(raw) or self._APT_SIGNED_SOURCE_RE.search(raw):
+                return
+            # Helm ``{{/* ... */}}`` comment block - SPDX header in
+            # OpenStack-Helm charts lives entirely inside one.
+            if self._is_inside_go_template_comment(all_lines, line_num):
+                return
+            # Repository-management module key above the matched line
+            # (``yum_repository:`` / ``apt_key:`` / etc.) - the
+            # package manager validates the URL via GPG.
+            if self._is_signed_package_channel(all_lines, line_num):
+                return
+            # systemd unit-file metadata key, XML namespace, or JSON
+            # ``$schema`` - identifier text, never fetched.
+            if self._SYSTEMD_DOC_FIELD_RE.match(raw) or self._XML_NAMESPACE_URL_RE.search(raw):
+                return
+
+        if pattern_obj.id == "facts_d_injection" and 1 <= line_num <= len(all_lines):
+            # The rule flags *untrusted* facts.d deployments. A
+            # static role-relative ``src:`` + ``owner: root`` + a
+            # non-world-writable ``mode:`` is the canonical safe
+            # shape; templated ``src:`` or world-writable mode still
+            # fire.
+            window = "\n".join(all_lines[max(0, line_num - 12) : min(len(all_lines), line_num + 8)])
+            if (
+                self._FACTS_D_STATIC_SRC_RE.search(window)
+                and self._FACTS_D_ROOT_OWNER_RE.search(window)
+                and not self._FACTS_D_WORLD_WRITABLE_MODE_RE.search(window)
+            ):
+                return
+
+        if pattern_obj.id == "template_mode_executable_to_system_path" and 1 <= line_num <= len(
+            all_lines
+        ):
+            # Suppress when ``dest:`` points at a known exec-dispatch
+            # directory where mode 0755 is the canonical, required
+            # shape (see ``_EXEC_DISPATCH_PATH_RE`` for the list).
+            window = "\n".join(all_lines[max(0, line_num - 1) : min(len(all_lines), line_num + 18)])
+            if self._EXEC_DISPATCH_PATH_RE.search(window):
+                return
+
+        if pattern_obj.id == "command_module_with_shell" and 1 <= line_num <= len(all_lines):
+            # ``command:`` does not go through ``/bin/sh`` - quoted
+            # shell metacharacters are passed verbatim to the
+            # embedded interpreter (``awk '...&&...'``, ``sh -c '...|...'``).
+            # Strip balanced and trailing-unmatched quoted spans, then
+            # re-test for the meta-character set.
+            raw = all_lines[line_num - 1]
+            stripped = re.sub(r"'[^']*'", "''", raw)
+            stripped = re.sub(r'"[^"]*"', '""', stripped)
+            stripped = re.sub(r"'[^'\n]*$", "", stripped)
+            stripped = re.sub(r'"[^"\n]*$', "", stripped)
+            if not self._COMMAND_SHELL_META_RE.search(stripped):
                 return
 
         if (

--- a/src/ansible_security_scanner/path_scopes.py
+++ b/src/ansible_security_scanner/path_scopes.py
@@ -1,0 +1,366 @@
+"""Path-based scoping for findings.
+
+Centralises four policies that the scanner needs to apply consistently
+across both the per-file scanner and the cross-file taint tracker:
+
+* Molecule scenario trees: test orchestration where production-deploy
+  rules (mutable image tags, taint-flow from local state files, dynamic
+  set_fact keys, etc.) categorically don't apply.
+* Integration-test fixture trees (``tests/integration/targets/`` in
+  Ansible collections): scaffolding whose entire purpose is to drive
+  the module under test, so the same suppression list as Molecule
+  applies plus a few module-test-specific rules.
+* Test-fixture trees (general ``test/``, ``tests/``): rules with
+  intentional insecurity (e.g. ``validate_certs: false`` in CI
+  scaffolding) get a severity demotion rather than full suppression.
+* Vendor-collection trees: device-management collections whose modules
+  ship with self-signed certs by default.
+
+This module is the single source of truth for those path policies so
+``file_scanner`` and ``scanner`` cannot disagree on, say, what counts
+as a Molecule path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MOLECULE_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:^|/)(?:extensions/)?molecule/|(?:^|/)molecule\.ya?ml$",
+    re.IGNORECASE,
+)
+
+# Collection integration-test fixture trees. These exist solely to
+# exercise modules under test, so :latest images, dummy /usr/bin/foo
+# paths, dynamic include scaffolding, and intentional cert-validation
+# disables are all part of the test contract.
+INTEGRATION_TEST_FIXTURE_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:^|/)tests?/integration/targets/|"
+    r"(?:^|/)integration/targets/",
+    re.IGNORECASE,
+)
+
+# Today's test fixture is tomorrow's copy-pasted production playbook,
+# so we demote rather than suppress here.
+TEST_FIXTURE_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:^|/)(?:test|tests|molecule|integration_tests)(?:/|$)|"
+    r"(?:^|/)integration/targets/|"
+    r"(?:^|/)\.github/workflows/(?:test|ci|integration)",
+    re.IGNORECASE,
+)
+
+# Files under a vendor device-management collection (vSphere, iDRAC,
+# F5, Junos, Palo Alto, NetApp, Pure Storage, Cisco IOS, etc). These
+# target an internal management plane that ships with self-signed certs
+# by default, so ``validate_certs: false`` is the documented bootstrap
+# shape until the operator configures trust roots.
+VENDOR_COLLECTION_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:^|/)(?:"
+    r"community\.vmware|community\.network|"
+    r"dell(?:emc)?[-./](?:openmanage|powerflex|powerstore|powerscale|unity|networking)|"
+    r"f5networks?[-./](?:f5_modules|f5os|f5_bigip)|"
+    r"juniper[-./]?(?:device|junos)|"
+    r"paloaltonetworks[-./]panos|"
+    r"netapp[-./](?:ontap|elementsw|aws|azure|cloudmanager|um_info)|"
+    r"purestorage[-./](?:flasharray|flashblade|fusion)|"
+    r"cisco[-./](?:ios|iosxr|nxos|asa|aci|meraki|intersight|ucs)|"
+    r"check_point[-./](?:gaia|mgmt)|"
+    r"fortinet[-./](?:fortios|fortimanager|fortianalyzer)|"
+    r"vyos[-./]vyos"
+    r")(?:/|$)",
+    re.IGNORECASE,
+)
+
+# Rules that describe production-deploy risk and never make sense
+# inside a Molecule scenario. Suppressed outright there rather than
+# demoted - Molecule fixtures pin ``:latest`` tags on purpose, register
+# fact state from developer-controlled JSON, and use dynamic-key
+# ``set_fact`` to fan a single fixture out across many parameter sets.
+SUPPRESS_IN_MOLECULE: frozenset[str] = frozenset(
+    {
+        "k8s_image_latest_or_untagged",
+        "cross_file_taint",
+        "set_fact_injection",
+        "dynamic_include_injection",
+        "jinja_in_assert_msg",
+        "ee_untrusted_base_image",
+        "ansible_python_interpreter_override",
+        "lookup_env_leak",
+        "recursive_delete_critical",
+        "raw_module_usage",
+        "kubernetes_privileged_pod",
+        "kubernetes_sa_token_automount_not_disabled",
+        "inventory_host_pattern_all_hosts",
+    }
+)
+
+# Rules suppressed inside ``tests/integration/targets/``. Same baseline
+# as Molecule (test orchestration, not production deploy) plus a handful
+# of module-test-specific rules: collection authors test their own
+# modules by writing ``- alternatives: path: /usr/bin/dummy1`` and
+# ``- pip: name: foo`` (no hash) and ``- npm: name: bar`` (no
+# integrity check) - those are the *correct* shape to validate the
+# module's behavior, not a deploy risk.
+SUPPRESS_IN_INTEGRATION_TESTS: frozenset[str] = SUPPRESS_IN_MOLECULE | frozenset(
+    {
+        "binary_replace_system_path",
+        "container_image_unpinned_tag",
+        "k8s_no_resource_limits",
+        "pip_install_without_hash_check_from_public_index",
+        "npm_install_runs_postinstall_scripts_from_untrusted_registry",
+        "user_input_template",
+        "lookup_file_traversal",
+        "script_module_unsafe",
+        "plaintext_password_should_be_vaulted",
+        "ip_address_url",
+        "container_image_over_http_registry",
+        "ansible_galaxy_untrusted",
+        # Module-under-test rules: collection integration tests exist
+        # to drive the module they ship, so flagging that drive as a
+        # "module misuse" is just flagging the test for testing.
+        "ssh_authorized_keys_write",
+        "firewalld_flush_or_disable",
+        "command_module_with_shell",
+        "ansible_block_without_rescue_or_always",
+        "ignore_errors_security_task",
+        "ignore_errors_security",
+        # Network-device collection ACL fixtures contain ``eq telnet``
+        # tokens describing a port match, not actual telnet usage.
+        "telnet_usage",
+        # Module-test fixtures inevitably string-concatenate
+        # ``client_id=...&secret=...`` style URL params to verify the
+        # module's wire format. The module is what we actually want
+        # to flag, not its test scaffold.
+        "url_encoded_credentials",
+        # Module-test fixtures verify failure modes by intentionally
+        # using insecure shapes (``http://`` URLs to test HTTP handling,
+        # ``disable_gpg_check: true`` to test --nogpgcheck, ``fetch:``
+        # to /tmp paths, ``no_log`` defaults to test logging). The
+        # rule's signal is the production playbook, not the unit test.
+        "unquoted_template_variable",
+        "missing_no_log",
+        "fetch_module_unsafe_dest",
+        "get_url_no_checksum",
+        "insecure_protocol_usage",
+        "unsafe_tag_bypass",
+        "dnf_disable_gpg_check_true",
+        "yum_disable_gpg_check_true",
+        "apt_disable_gpg_check_true",
+        "uri_module_url_plaintext_http",
+        # SSL/TLS verification toggles in module-test fixtures: tests
+        # exercise both ``validate_certs: true`` and
+        # ``validate_certs: false`` paths to verify the module honors
+        # the param. Same for ``verify_ssl: false`` on AWX/Tower
+        # collection tests, and ``ssl_verification_disabled`` on
+        # vCenter/vSphere fixtures (vCenter ships with self-signed
+        # certs; collection tests can't bring an enterprise CA).
+        "ssl_verification_disabled",
+        "uri_module_validate_certs_false",
+        "get_url_validate_certs_false",
+        # Test scaffolds that exercise ``ANSIBLE_CONFIG`` overrides,
+        # ``shell: cd ... && ...`` chaining for setup/teardown, ``assemble:``
+        # behavior, and ``lookup('pipe', ...)`` semantics. The signal is
+        # the production playbook, not the assertion harness.
+        "ansible_config_override",
+        "command_chaining",
+        "assemble_module_unsafe",
+        "lookup_pipe_rce",
+        "lookup_url_rce",
+        "jinja2_lookup_pipe_in_template",
+        "untrusted_apt_repo",
+        "untrusted_yum_repo",
+        "ansible_galaxy_install_force_latest",
+        "role_meta_dependency_without_version",
+        "template_in_file_path",
+        "hardcoded_password",
+        "hardcoded_api_key",
+        "elastic_apm_secret_token_or_api_key_literal",
+        "become_method_unsafe",
+        "ssl_cert_generation",
+        # Cloud-IaC rules in module test fixtures: collection
+        # integration tests exercise their own modules by creating
+        # the resource under test (Azure subnets, GCP buckets,
+        # disks, DNS zones, etc.). Those resources are torn down at
+        # end-of-test, so missing NSGs / CMEK / access logging
+        # there is part of the test contract, not a deployment risk.
+        # The same rules continue to fire on production playbooks.
+        "azure_subnet_without_network_security_group",
+        "azure_vm_disk_encryption_not_enabled",
+        "azure_ml_access",
+        "gcp_storage_bucket_without_access_logging",
+        "gcp_compute_disk_without_cmek",
+        "gcp_dns_managed_zone_dnssec_rsasha1_or_disabled",
+        "gcp_service_account_key",
+        "ansible_k8s_module",
+        # Other rules whose signal is dominated by collection test
+        # scaffolding: throwaway hardcoded creds in module-auth
+        # smoke tests, ``add_host`` / ``delegate_to`` rig wiring
+        # for multi-host fixtures, ``crontab`` / ``world_writable``
+        # / ``raw_github_content`` / ``http_basic_auth`` /
+        # ``ssh_userknownhosts_devnull`` used to drive the module
+        # under test, ``apt_force_flag_true`` exercising the
+        # module's force path, and ``facts_d_injection`` /
+        # ``ansible_become_pass`` / ``jinja_in_when_clause``
+        # patterns vendored as fixture inputs.
+        "hardcoded_credentials",
+        "crontab_modification",
+        "user_input_execution",
+        "world_writable_files",
+        "add_host_dynamic",
+        "delegate_to_external_host",
+        "raw_github_content",
+        "backup_deletion",
+        "package_gpg_check_disabled",
+        "jinja2_render_sensitive_var",
+        "subshell_execution",
+        "dangerous_world_writable",
+        "ssh_userknownhosts_devnull",
+        "ssh_stricthostkey_disabled",
+        "slsa_provenance_verification_missing",
+        "git_hook_or_config_write",
+        "http_basic_auth",
+        "apt_force_flag_true",
+        "jinja_in_when_clause",
+        "ansible_become_pass",
+        "facts_d_injection",
+        "nohup_background_persistence",
+    }
+)
+
+# GitHub Actions workflow trees. ``.github/workflows/`` files use
+# GitHub's own ``${{ ... }}`` expression syntax which collides with
+# our Jinja2-injection regexes (the inner ``{{ inputs.foo }}``
+# substring matches), so a focused suppression list keeps Ansible
+# Jinja rules from firing on GHA contexts. The dedicated
+# ``github_actions_*`` rules still apply.
+GITHUB_ACTIONS_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:^|/)\.github/workflows/",
+    re.IGNORECASE,
+)
+
+SUPPRESS_IN_GITHUB_ACTIONS: frozenset[str] = frozenset(
+    {
+        "user_input_template",
+        "unquoted_template_variable",
+        "jinja_in_assert_msg",
+        "set_fact_injection",
+        "register_variable_injection",
+        "dynamic_include_injection",
+        "ansible_python_interpreter_override",
+        "lookup_env_leak",
+        "ip_address_url",
+        "missing_no_log",
+        "ignore_errors_security",
+        "ignore_errors_security_task",
+        # GHA jobs install test dependencies straight from PyPI; the
+        # rule's "pin to a hash" advice belongs in production
+        # ``requirements.txt`` files, not throwaway CI matrices.
+        "pip_install_without_hash_check_from_public_index",
+        "pip_install_no_version",
+        "npm_install_runs_postinstall_scripts_from_untrusted_registry",
+    }
+)
+
+
+# Per-rule filename scope. A rule listed here only fires when the
+# scanned file's path matches its regex. Rules without an entry fire
+# everywhere.
+RULE_PATH_SCOPES: dict[str, re.Pattern[str]] = {
+    "galaxy_requirements_git_branch_ref": re.compile(
+        r"(?:^|/)(?:requirements|collections|roles)\.ya?ml$|"
+        r"(?:^|/)galaxy[^/]*\.ya?ml$",
+        re.IGNORECASE,
+    ),
+    "galaxy_requirements_http_source": re.compile(
+        r"(?:^|/)(?:requirements|collections|roles)\.ya?ml$|"
+        r"(?:^|/)galaxy[^/]*\.ya?ml$",
+        re.IGNORECASE,
+    ),
+    # YAML-specific rules cannot fire on Jinja templates - .j2 files
+    # render to non-YAML target formats (apt.conf, nginx.conf, etc.)
+    # so duplicate-key semantics don't apply.
+    "yaml_duplicate_key_suppression": re.compile(
+        r"\.ya?ml(?:\.j2)?$|\.json$",
+        re.IGNORECASE,
+    ),
+    # bindep profiles live in ``bindep.txt`` or ``bindep.yml`` (next to
+    # ``execution-environment.yml``), or are embedded into a playbook
+    # via ``copy.content: |``. The rule is meaningless on plain prose
+    # files like ``changelogs/changelog.yaml`` where backticks denote
+    # markdown code spans, not bindep shell-execs - constrain to those
+    # three shapes.
+    "bindep_profile_runs_shell": re.compile(
+        r"(?:^|/)bindep[^/]*\.(?:txt|ya?ml)$|"
+        r"(?:^|/)execution[_-]environment\.ya?ml$|"
+        r"(?:^|/)(?:tasks|playbooks?|roles)/",
+        re.IGNORECASE,
+    ),
+    # The Ansible ``raw:`` MODULE only ever appears in task files
+    # (``tasks/*.yml``, ``handlers/*.yml``) or top-level playbooks.
+    # In ``defaults/``, ``vars/``, ``meta/``, ``host_vars/``, and
+    # ``group_vars/`` a ``raw:`` line is just a YAML dict key in
+    # role-author-defined data (e.g. debops's ``divert``/``raw:`` config
+    # blocks); it is never a module invocation. Constraining the rule
+    # to task-bearing locations eliminates ~200 FPs in role libraries
+    # that use ``raw`` as a domain term in their config schema.
+    "raw_module_usage": re.compile(
+        r"(?:^|/)(?:tasks|handlers|playbooks?)/[^/]+\.ya?ml$|"
+        r"(?:^|/)site\.ya?ml$|"
+        r"^[^/]+\.ya?ml$",
+        re.IGNORECASE,
+    ),
+}
+
+
+def is_molecule_path(file_path: Path) -> bool:
+    return bool(MOLECULE_PATH_RE.search(file_path.as_posix()))
+
+
+def is_integration_test_fixture_path(file_path: Path) -> bool:
+    return bool(INTEGRATION_TEST_FIXTURE_PATH_RE.search(file_path.as_posix()))
+
+
+def is_test_fixture_path(file_path: Path) -> bool:
+    return bool(TEST_FIXTURE_PATH_RE.search(file_path.as_posix()))
+
+
+def is_vendor_collection_path(file_path: Path) -> bool:
+    return bool(VENDOR_COLLECTION_PATH_RE.search(file_path.as_posix()))
+
+
+def is_github_actions_path(file_path: Path) -> bool:
+    return bool(GITHUB_ACTIONS_PATH_RE.search(file_path.as_posix()))
+
+
+def is_helm_template_file(file_path: Path) -> bool:
+    """Return ``True`` when ``file_path`` is a Helm chart template.
+
+    Helm templates are Go-templates that render to Kubernetes manifests at
+    ``helm install`` time, so the Ansible / K8s rules don't apply - the
+    shapes inside are template *source*, not deployed manifests.
+
+    Detection: ``.yaml`` / ``.yml`` / ``.tpl`` file inside a ``templates/``
+    directory whose chart root (within four levels) holds ``Chart.yaml``.
+    """
+    posix = file_path.as_posix()
+    if file_path.suffix == ".tpl":
+        return True
+    if file_path.suffix not in (".yaml", ".yml"):
+        return False
+    if "/templates/" not in posix and not posix.startswith("templates/"):
+        return False
+    # Four-level cap accommodates ``<umbrella>/charts/<sub>/templates/<file>.yaml``.
+    cursor = file_path.parent
+    for _ in range(4):
+        if cursor == cursor.parent:
+            break
+        if (cursor / "Chart.yaml").is_file():
+            return True
+        cursor = cursor.parent
+    return False
+
+
+def rule_path_scope_allows(rule_id: str, file_path: Path) -> bool:
+    scope = RULE_PATH_SCOPES.get(rule_id)
+    return scope is None or bool(scope.search(file_path.as_posix()))

--- a/src/ansible_security_scanner/patterns/ansible_hygiene.yml
+++ b/src/ansible_security_scanner/patterns/ansible_hygiene.yml
@@ -13,9 +13,13 @@ patterns:
     severity: "MEDIUM"
     title: "Credential Visible in Comment"
     description: "A commented-out line contains what appears to be a hardcoded credential. Even in comments, credentials are visible in version control history."
-    regex: "^\\s*#.*(?:password|passwd|pwd|secret|token|api_key|apikey)\\s*[:=]\\s*[\"']?(?!\\{\\{)[A-Za-z0-9!@#$%^&*()_+=./-]{6,}[\"']?"
+    # Match when the value either (a) is quoted, or (b) contains a digit
+    # or symbol that lifts it above plain prose. Reject Ansible state
+    # keywords (``always|never|on_create|...``) and bare identifiers that
+    # are obviously variable refs (``token=consul_management_token``).
+    regex: "^\\s*#.*(?:password|passwd|pwd|secret|token|api_key|apikey)\\s*[:=]\\s*(?:[\"'](?!\\{\\{)[A-Za-z0-9!@#$%^&*()_+=./-]{6,}[\"']|(?!\\{\\{)(?!(?:always|never|on_create|present|absent|latest|default|yes|no|true|false|none)\\b)[A-Za-z0-9._-]*[0-9!@#$%^&*()+=/-][A-Za-z0-9!@#$%^&*()_+=./-]{4,})"
     positive_examples:
-      - "# truststore_password: cassandra"
+      - "# truststore_password: \"cassandra\""
     recommendation: "Remove hardcoded credentials from comments; use placeholders like <REDACTED> or {{ vault_variable }}"
     cwe: ['CWE-540', 'CWE-798']
     owasp_appsec: ["A01:2021", "A07:2021"]

--- a/src/ansible_security_scanner/patterns/binary_planting.yml
+++ b/src/ansible_security_scanner/patterns/binary_planting.yml
@@ -8,9 +8,12 @@ patterns:
     severity: "CRITICAL"
     title: "System Binary Replacement"
     description: "Copies or writes a file to system binary directories, potentially replacing a legitimate binary"
-    regex: "(?:dest|path):\\s*['\"]?/(?:usr/)?(?:s?bin|local/s?bin)/(?!README|LICENSE)\\w+['\"]?\\s*$"
+    # Anchor the YAML key so variable assignments whose names happen to end in
+    # ``_path`` / ``_dest`` (e.g. ``__some_internal_path: /usr/bin/foo``) do
+    # not get mistaken for a ``path:`` / ``dest:`` module argument.
+    regex: "(?:^|\\s)(?:dest|path):\\s*['\"]?/(?:usr/)?(?:s?bin|local/s?bin)/(?!README|LICENSE)\\w+['\"]?\\s*$"
     positive_examples:
-      - "path: '/usr/bin/dummy1'"
+      - "  path: '/usr/bin/dummy1'"
     recommendation: "System binaries should only be installed via package managers; audit this write carefully"
     cwe: ['CWE-506', 'CWE-732']
     owasp_asvs: [V5.3.1]

--- a/src/ansible_security_scanner/patterns/k8s_insecure_spec.yml
+++ b/src/ansible_security_scanner/patterns/k8s_insecure_spec.yml
@@ -413,7 +413,11 @@ patterns:
     severity: "LOW"
     title: "Kubernetes Container Missing Resource Limits"
     description: "Container spec omits `resources.limits` (and often `resources.requests`). Without limits, a single compromised or buggy pod can consume all CPU/memory on its node, triggering OOM-kills of co-tenants (noisy-neighbor DoS) and driving the node into NotReady. For memory specifically, missing limits means the container can never be OOM-killed early by cgroup - it keeps growing until it evicts legitimate workloads."
-    regex: "resources:\\s*\\{\\s*\\}"
+    # Require the key to be ``resources:`` exactly (with optional
+    # ``computeResources`` alias and optional list-item dash), not the
+    # tail of a longer Ansible variable name like
+    # ``__nginx_modules_map_resources``.
+    regex: "(?:^|\\s)(?:-\\s+)?(?:resources|computeResources):\\s*\\{\\s*\\}"
     positive_examples:
       - "- computeResources: {}"
     multiline: true

--- a/src/ansible_security_scanner/patterns/offensive_tools.yml
+++ b/src/ansible_security_scanner/patterns/offensive_tools.yml
@@ -88,7 +88,13 @@ patterns:
     severity: "CRITICAL"
     title: "Password Cracking Tool"
     description: "Installs or runs password cracking tools like hashcat or John the Ripper"
-    regex: "\\b(?:hashcat|john(?:theripper)?|hydra|medusa|ncrack|ophcrack|cewl|crunch)\\b(?!.*(?:doe|smith|user))"
+    # Anchor the tool name to a package-install / command-execution
+    # shape so plain prose ("John Smith", "john-westcott-iv",
+    # ``value: John``) cannot match. Accepts:
+    #   * package-install module args (``name: john``, ``- john``)
+    #   * command/shell/script lines invoking the binary
+    #   * apt/yum/dnf/pacman/brew CLI install lines
+    regex: "(?:^|\\s)(?:-\\s+|name:\\s+|cmd:\\s+|command:\\s+|shell:\\s+|script:\\s+|/(?:usr/)?(?:s?bin|local/(?:s?bin|opt))/|(?:apt(?:-get)?|yum|dnf|zypper|pacman|brew|apk|emerge)\\s+(?:-\\S+\\s+)*install\\s+(?:[\\w.-]+\\s+)*)['\"]?(?:hashcat|john(?:theripper|-the-ripper)?|hydra|medusa|ncrack|ophcrack|cewl|crunch)['\"]?\\b"
     positive_examples:
       - "- john-the-ripper"
     recommendation: "Password cracking tools should never appear in production playbooks"

--- a/src/ansible_security_scanner/patterns/privilege_escalation.yml
+++ b/src/ansible_security_scanner/patterns/privilege_escalation.yml
@@ -28,9 +28,12 @@ patterns:
     severity: "CRITICAL"
     title: "SetUID Binary Creation"
     description: "Creating or modifying setuid binaries for privilege escalation"
-    regex: "chmod.*[0-7]*4[0-7]*|chmod.*u\\+s"
+    # Require an actual setuid mode (leading 4/5/6/7 in a 4-digit octal) or
+    # the symbolic ``u+s``. The previous regex matched any chmod containing
+    # a ``4`` digit, so benign ``chmod 0640`` triggered it.
+    regex: "chmod\\s+(?:0?[4567][0-7]{3}|u\\+s)\\b"
     positive_examples:
-      - "chmod 0640 /etc/ldap/localhost.key"
+      - "chmod 4755 /usr/local/bin/foo"
     recommendation: "Setuid binaries are an enduring privilege-escalation surface; prefer filesystem capabilities (setcap cap_net_bind_service+ep) or a systemd unit with the appropriate User= / AmbientCapabilities= directives instead of setting the suid bit."
     cwe: ['CWE-250', 'CWE-732']
     owasp_asvs: [V5.3.1, V13.4.5, V15.2.3]

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -472,7 +472,7 @@ patterns:
           author: example
           description: example
     multiline: true
-    window: 15
+    window: 30
     recommendation: "Add `license: MIT` (or an SPDX identifier matching your repo's LICENSE file) to galaxy_info."
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ['CM-11', 'SA-10', 'SI-7']
@@ -1005,9 +1005,9 @@ patterns:
     severity: "HIGH"
     title: "ansible-navigator Pulls Execution Environment From Public Registry"
     description: "An `ansible-navigator.yml` / `ansible-navigator.yaml` config (or `--execution-environment-image` CLI flag) references an EE image from `quay.io/`, `docker.io/`, `ghcr.io/`, or `registry.hub.docker.com/` without a SHA pin, and `pull.policy` is `always` or unset. Every `ansible-navigator run` then pulls whatever the public tag currently points at - a single registry-side retag (accidental or malicious) silently changes the Ansible runtime, collections, and Python dependencies for every operator."
-    regex: "(?:execution-environment-image|ee-image|execution_environment_image|image)\\s*:\\s*[\"']?(?:quay\\.io|docker\\.io|ghcr\\.io|registry\\.hub\\.docker\\.com)/[A-Za-z0-9][A-Za-z0-9._/-]*(?::[A-Za-z0-9._-]+)?[\"']?(?!\\s*@sha256:)"
+    regex: "(?:execution-environment-image|ee-image|execution_environment_image)\\s*:\\s*[\"']?(?:quay\\.io|docker\\.io|ghcr\\.io|registry\\.hub\\.docker\\.com)/[A-Za-z0-9][A-Za-z0-9._/-]*(?::[A-Za-z0-9._-]+)?[\"']?(?!\\s*@sha256:)"
     positive_examples:
-      - "image: quay.io/coreos/etcd:v3.1.10"
+      - "execution-environment-image: quay.io/coreos/etcd:v3.1.10"
     multiline: false
     recommendation: "Mirror the EE image into your organisation's registry (Quay on-prem, Harbor, GitLab Container Registry) and pin by digest: `image: registry.example.com/ee/aap:2.14@sha256:abc...`. Set `pull.policy: missing` (pull only when absent) rather than `always`. Automate digest updates via Renovate so a human reviews every EE rotation in PR form."
     cis_controls: ["CIS-Supply-Chain"]

--- a/src/ansible_security_scanner/patterns/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/system_compromise.yml
@@ -52,9 +52,9 @@ patterns:
         textbook persistence/privesc primitive on Linux.
     recommendation: |
       Avoid creating new setuid/setgid binaries. Most legitimate privilege escalation needs are met by `sudo` rules, capabilities (`setcap cap_net_bind_service+ep`), systemd `User=`/`Group=` units, or polkit. If a setuid binary is genuinely required, ship it from a trusted package (rpm/deb) so the file is owned by `root:root`, mode `4755`, and tracked by the package manager - never `chmod u+s` an arbitrary script or copy from a playbook. Audit existing setuid binaries on every host with `find / -perm -4000 -type f -xdev -ls` and remove anything not in your distro's setuid baseline.
-    regex: "chmod\\s+[0-7]*[4][0-7]*\\s+|chmod\\s+u\\+s"
+    regex: "chmod\\s+(?:0?[4567][0-7]{3}|u\\+s|g\\+s)\\b"
     positive_examples:
-      - "chmod 0640 /etc/ldap/localhost.key"
+      - "chmod 4755 /usr/local/bin/foo"
     cwe: ['CWE-250', 'CWE-732']
     owasp_asvs: [V5.3.1, V13.4.5, V15.2.3]
     mitre_attack: ['T1548.001']

--- a/src/ansible_security_scanner/patterns/unsafe_permissions.yml
+++ b/src/ansible_security_scanner/patterns/unsafe_permissions.yml
@@ -958,7 +958,7 @@ patterns:
     severity: "HIGH"
     title: "template Rendering Executable File to System Path"
     description: "A `template:` task renders content to /etc/, /usr/bin/, /usr/local/bin/, /usr/sbin/, /opt/, or /root/ AND sets an executable mode (0755, 0775, 0777, 4xxx, or anything with the x-bit). That combination is the classic webshell / persistence-hook pattern: a templated script that runs during cron/systemd/PATH lookup, easy to forget in audits because it looks like 'just a config file'."
-    regex: "(?:ansible\\.builtin\\.)?template\\s*:[\\s\\S]{0,300}?dest\\s*:\\s*['\"]?(?:/etc/|/usr/(?:local/)?(?:bin|sbin)/|/opt/|/root/)[^\\n]*[\\s\\S]{0,300}?mode\\s*:\\s*['\"]?0?[4-7]?[0-7]?[1357]\\b|(?:ansible\\.builtin\\.)?template\\s*:[\\s\\S]{0,300}?mode\\s*:\\s*['\"]?0?[4-7]?[0-7]?[1357]\\b[\\s\\S]{0,300}?dest\\s*:\\s*['\"]?(?:/etc/|/usr/(?:local/)?(?:bin|sbin)/|/opt/|/root/)"
+    regex: "(?:ansible\\.builtin\\.)?template\\s*:[^\\n]*\\n(?:(?![ \\t]*-\\s)[ \\t]+[^\\n]*\\n){0,10}?[ \\t]+dest\\s*:\\s*['\"]?(?:/etc/|/usr/(?:local/)?(?:bin|sbin)/|/opt/|/root/)[^\\n]*\\n(?:(?![ \\t]*-\\s)[ \\t]+[^\\n]*\\n){0,10}?[ \\t]+mode\\s*:\\s*['\"]?0?[4-7]?[0-7]?[1357]\\b|(?:ansible\\.builtin\\.)?template\\s*:[^\\n]*\\n(?:(?![ \\t]*-\\s)[ \\t]+[^\\n]*\\n){0,10}?[ \\t]+mode\\s*:\\s*['\"]?0?[4-7]?[0-7]?[1357]\\b[^\\n]*\\n(?:(?![ \\t]*-\\s)[ \\t]+[^\\n]*\\n){0,10}?[ \\t]+dest\\s*:\\s*['\"]?(?:/etc/|/usr/(?:local/)?(?:bin|sbin)/|/opt/|/root/)"
     positive_examples:
       - |2-
         template:

--- a/src/ansible_security_scanner/patterns/variable_injection.yml
+++ b/src/ansible_security_scanner/patterns/variable_injection.yml
@@ -71,12 +71,13 @@ patterns:
     # Matches both inline form (`include_vars: "{{ x }}"`) and block form
     # (`include_vars:` followed by `file: "{{ x }}"` on the next line) so
     # authors can't evade the rule by splitting the key/value.
-    regex: "include(?:_vars|_tasks)?:(?:\\s*\\{\\{[^}]+\\}\\}|[\\s\\S]{0,100}?(?:file|name):\\s*['\"]?\\{\\{[^}]+\\}\\})"
+    regex: "include(?:_vars|_tasks)?:(?:\\s*['\"]?\\{\\{[^}]+\\}\\}|(?:[ \\t]*\\n[ \\t]+){1,3}(?:file|name):\\s*['\"]?\\{\\{[^}]+\\}\\})"
     positive_examples:
       - |2-
-        include_tasks: create_device.yml
-          vars:
-            image_file: '{{ remote_tmp_dir }}
+        include_tasks: "{{ user_supplied_path }}"
+      - |2-
+        include_tasks:
+          file: "{{ user_supplied_path }}"
     multiline: true
     window: 6
     recommendation: "Drive ansible.builtin.include_tasks / include_vars from a controller-defined variable resolved against an allow-list (loop with when: var in known_set), and place the included files in a controller-owned directory to prevent path traversal."

--- a/src/ansible_security_scanner/project_classification.py
+++ b/src/ansible_security_scanner/project_classification.py
@@ -1,0 +1,115 @@
+"""Project-level classification for findings.
+
+Some Ansible projects are *security-hardening* roles whose purpose is
+to manipulate exactly the surfaces our scanner flags as risky:
+``/etc/pam.d/`` files, GRUB config, kernel module loading, sudoers
+files, login banners, and so on. The CIS / STIG / dev-sec hardening
+roles are the canonical examples - their entire job is to tighten
+those surfaces, so the surface-touching rules are working-as-designed
+rather than findings to act on.
+
+This module classifies a scanned directory once at scan-start and
+exposes a single boolean: ``is_security_hardening_project``. The
+file scanner uses that to demote a curated list of system-modification
+rules from MEDIUM/HIGH down a step, reducing noise without erasing
+the audit trail.
+
+Detection signal: any of ``meta/main.yml``, ``galaxy.yml``, or
+``collection.yml`` at the project root listing ``cis``, ``stig``,
+``hardening``, ``benchmark``, ``lockdown``, or ``compliance`` in its
+galaxy tags / collection tags. Exactly the marker every published
+hardening role uses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+
+import yaml
+
+_HARDENING_TAGS: frozenset[str] = frozenset(
+    {
+        "cis",
+        "stig",
+        "hardening",
+        "benchmark",
+        "lockdown",
+        "compliance",
+        "complianceascode",
+        "ansible-lockdown",
+    }
+)
+
+# Rules that hardening roles legitimately trigger by design. Demoted
+# (not suppressed) inside a hardening project so an auditor still sees
+# the touch-points but the security score doesn't double-count them
+# as risk.
+DEMOTE_IN_HARDENING_PROJECT: frozenset[str] = frozenset(
+    {
+        "pam_module_manipulation",
+        "grub_bootloader_modification",
+        "shadow_file_access",
+        "kernel_module_load",
+        "kernel_module_loading",
+        "crontab_modification",
+        "selinux_disable",
+        "apparmor_disable",
+        "firewall_disable",
+        "firewalld_flush_or_disable",
+        "iptables_nat_redirect",
+        "ssh_config_manipulation",
+        "ssh_authorized_keys_write",
+        "sudo_nopasswd",
+        "init_script_creation",
+        "motd_banner_injection",
+        "dpkg_apt_hooks_persistence",
+        "ansible_block_without_rescue_or_always",
+        "shadow_copy_or_passwd_export",
+        "world_writable_files",
+    }
+)
+
+
+def _read_yaml(path: Path) -> dict | None:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError):
+        return None
+
+
+def _tags_from(data: dict | None, *paths: tuple[str, ...]) -> Iterable[str]:
+    if not isinstance(data, dict):
+        return ()
+    for path in paths:
+        cursor: object = data
+        for key in path:
+            if not isinstance(cursor, dict):
+                cursor = None
+                break
+            cursor = cursor.get(key)
+        if isinstance(cursor, list):
+            yield from (str(t).lower() for t in cursor if isinstance(t, (str, bytes)))
+
+
+def is_security_hardening_project(directory: Path) -> bool:
+    """Return ``True`` when ``directory`` is a CIS / STIG / hardening role.
+
+    Reads only the top-level metadata files (``meta/main.yml``,
+    ``galaxy.yml``, ``collection.yml``); cheap one-shot check at
+    scan-start.
+    """
+    candidates = (
+        (directory / "meta" / "main.yml", (("galaxy_info", "galaxy_tags"),)),
+        (directory / "galaxy.yml", (("tags",),)),
+        (directory / "collection.yml", (("tags",),)),
+    )
+    for path, key_paths in candidates:
+        if not path.is_file():
+            continue
+        data = _read_yaml(path)
+        for tag in _tags_from(data, *key_paths):
+            if tag in _HARDENING_TAGS:
+                return True
+    return False

--- a/src/ansible_security_scanner/remediations/variables.py
+++ b/src/ansible_security_scanner/remediations/variables.py
@@ -30,12 +30,13 @@ class VariableInjectionRemediationGenerator(BaseRemediationGenerator):
 {code_snippet}
 ```
 
-**✅ Minimal Fix (Validate input):**
+**✅ Validate and reject (preferred):**
 ```yaml
 - name: Validate {var_match}
-  assert:
+  ansible.builtin.assert:
     that:
       - {var_match} is defined
+      - {var_match} is string
       - {var_match} is match("^[a-zA-Z0-9._-]+$")
     fail_msg: "Invalid or undefined {var_match}"
 
@@ -43,26 +44,29 @@ class VariableInjectionRemediationGenerator(BaseRemediationGenerator):
   # Your original task here with the validated variable
 ```
 
-**✅ Best Practice Fix (Sanitize and validate):**
-```yaml
-- name: Sanitize {var_match}
-  set_fact:
-    validated_{var_match}: "{{{{ {var_match} | regex_replace('[^a-zA-Z0-9._-]', '') }}}}"
-  when:
-    - {var_match} is defined
-    - {var_match} | length > 0
+**✅ Constrain at the role boundary (recommended for roles):**
+Define the variable in `meta/argument_specs.yml` so Ansible enforces the
+type and pattern before the role runs:
 
-- name: Use sanitized variable
-  # Your original task here with validated_{var_match}
-  when: validated_{var_match} is defined
+```yaml
+# meta/argument_specs.yml
+argument_specs:
+  main:
+    options:
+      {var_match}:
+        type: str
+        required: true
+        # restrict to the exact shape you accept
+        # (see: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format)
 ```
 
-**🔐 Variable Security Best Practices:**
-- Always validate input variables
-- Use the `quote` filter for shell variables
-- Sanitize variables before use
-- Use `assert` tasks to validate assumptions
-- Implement proper error handling
+**🔐 Notes:**
+- Reject invalid input with `assert`. Do not silently strip characters with
+  `regex_replace` - silent rewriting can mask attempted injection and turn
+  a clear failure into a hard-to-debug success.
+- Use the `quote` filter when interpolating any variable into shell/command.
+- Prefer `meta/argument_specs.yml` for role inputs; it runs before the role
+  and gives a single, declarative validation point.
 """
 
         return template

--- a/src/ansible_security_scanner/scanner.py
+++ b/src/ansible_security_scanner/scanner.py
@@ -16,12 +16,32 @@ from typing import Any
 
 import yaml
 
-from .file_scanner import DependencyCollector, FileScanner, FixProposer, ParsedFile, TaintTracker
+from .file_scanner import (
+    DependencyCollector,
+    FileScanner,
+    FixProposer,
+    ParsedFile,
+    TaintTracker,
+)
 from .models import ScanReport, SecurityScore
+from .path_scopes import (
+    SUPPRESS_IN_INTEGRATION_TESTS,
+    SUPPRESS_IN_MOLECULE,
+    is_helm_template_file,
+    is_integration_test_fixture_path,
+    is_molecule_path,
+    is_test_fixture_path,
+)
 from .patterns_manager import known_rule_ids, resolve_rule_specs
 from .score_calculator import ScoreCalculator
 
 logger = logging.getLogger(__name__)
+
+
+# ``cross_file_taint`` findings are emitted by ``TaintTracker`` after
+# ``FileScanner`` returns and bypass the per-file demotion pipeline,
+# so apply test-fixture demotion here for parity.
+_DEMOTE_IN_TEST_FIXTURES_TAINT: frozenset[str] = frozenset({"cross_file_taint"})
 
 
 # Ansible playbooks frequently use ``!vault`` and ``!unsafe`` tags that
@@ -37,7 +57,7 @@ class _AnsibleTagTolerantLoader(yaml.SafeLoader):
     """
 
 
-def _construct_untagged(loader, tag_suffix, node):  # noqa: D401 - yaml API shape
+def _construct_untagged(loader, tag_suffix, node):
     if isinstance(node, yaml.ScalarNode):
         return loader.construct_scalar(node)
     if isinstance(node, yaml.SequenceNode):
@@ -201,6 +221,18 @@ class AnsibleSecurityScanner:
             yml_files = [
                 f for f in all_candidate_files if not f.name.startswith(".") and f.is_file()
             ]
+            # Helm chart templates are Go-templates rendered by
+            # ``helm install`` / ``helm template``; they don't parse as
+            # Ansible YAML and are reviewed by ``kubeconform`` /
+            # ``kube-linter`` instead. Filter them out before scanning.
+            helm_files = {f for f in yml_files if is_helm_template_file(f)}
+            if helm_files:
+                logger.info(
+                    "Excluded %d Helm chart template file(s) from scan "
+                    "(rendered by ``helm template``, not Ansible)",
+                    len(helm_files),
+                )
+                yml_files = [f for f in yml_files if f not in helm_files]
             # Stable order for deterministic reporting.
             yml_files.sort()
 
@@ -255,7 +287,7 @@ class AnsibleSecurityScanner:
                 # the existing "data=None" degraded path so line-based
                 # scans still run.
                 try:
-                    data = yaml.load(raw, Loader=_AnsibleTagTolerantLoader)  # noqa: S506  (tolerant loader is SafeLoader + unknown-tag passthrough)
+                    data = yaml.load(raw, Loader=_AnsibleTagTolerantLoader)
                 except yaml.YAMLError:
                     logger.debug("YAML parse failed for %s: %s", yml_file, e)
                     data = None
@@ -345,7 +377,20 @@ class AnsibleSecurityScanner:
             for yml_file, pf in parsed_files.items():
                 if pf.data is None:
                     continue
-                findings.extend(tracker.scan_sinks(yml_file, pf.data, pf.lines))
+                taint_findings = tracker.scan_sinks(yml_file, pf.data, pf.lines)
+                if is_molecule_path(yml_file):
+                    taint_findings = [
+                        f for f in taint_findings if f.rule_id not in SUPPRESS_IN_MOLECULE
+                    ]
+                if is_integration_test_fixture_path(yml_file):
+                    taint_findings = [
+                        f for f in taint_findings if f.rule_id not in SUPPRESS_IN_INTEGRATION_TESTS
+                    ]
+                if is_test_fixture_path(yml_file):
+                    for tf in taint_findings:
+                        if tf.rule_id in _DEMOTE_IN_TEST_FIXTURES_TAINT:
+                            tf.severity = "LOW"
+                findings.extend(taint_findings)
 
         # Opt-in git-history sweep: rescan every tracked file at each of
         # the last N commits that touched it, looking for secrets that

--- a/src/ansible_security_scanner/taint_tracker.py
+++ b/src/ansible_security_scanner/taint_tracker.py
@@ -624,6 +624,7 @@ class TaintTracker:
                 if f"name: {task_name}" in line or f'name: "{task_name}"' in line:
                     line_num = i
                     break
+        match_line = lines[line_num - 1].rstrip() if 0 < line_num <= len(lines) else ""
         return SecurityFinding(
             file_path=rel,
             line_number=line_num,
@@ -646,6 +647,7 @@ class TaintTracker:
                 "Jinja-templated string."
             ),
             code_snippet=snippet.strip(),
+            match_line=match_line,
             remediation_example=self._remediator.generate_taint_flow_fix(
                 rule_id="cross_file_taint",
                 code_snippet=snippet.strip(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,23 @@ def _scan_directory_in_process(directory: Path):
 
 
 @pytest.fixture(scope="session")
+def path_scoped_findings_json() -> dict:
+    """Findings from the per-rule fixture directory.
+
+    A handful of rules (``bindep_profile_runs_shell``,
+    ``galaxy_requirements_*``, ``secret_in_comment``) only fire on
+    specific filenames. Their evidence lives in
+    ``tests/playbooks/path_scoped/`` under the canonical filename so
+    the rule's path scope passes; the bad-example coverage test
+    unions these findings with the main bad-example findings.
+    """
+    target_dir = TESTS_DIR / "path_scoped"
+    if not target_dir.exists():
+        return {"findings": []}
+    return _report_to_json_dict(_scan_directory_in_process(target_dir))
+
+
+@pytest.fixture(scope="session")
 def multi_example_clean_report():
     """Scan of ``tests/playbooks/multi_example_clean/`` - a 6-file
     hardened role fixture. Expected to produce zero findings; guards

--- a/tests/playbooks/path_scoped/requirements.yml
+++ b/tests/playbooks/path_scoped/requirements.yml
@@ -1,0 +1,13 @@
+---
+collections:
+  - name: community.general
+    version: latest
+  - name: community.general
+    src: http://galaxy.example.com/path/to/community-general.tar.gz
+
+roles:
+  - name: example.role
+    src: http://galaxy.example.com/path/to/example-role.tar.gz
+    version: main
+
+# Comment with sensitive value: api_key="abc123XYZ_secret"

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -701,7 +701,7 @@ class TestFingerprintsAndDelta:
         assert "Progress" not in body
         assert "since last scan" not in body
 
-    # ---- Receipts continuation: "Resolved rules: …" ----
+    # ---- Receipts continuation: "Resolved rules: ..." ----
     # Marker carries a {fingerprint: rule_id} mapping so the next scan
     # can name which rule families disappeared. Tests pin: round-trip,
     # _compute_delta surfaces the ids, _render_delta_line prints them,
@@ -2200,7 +2200,7 @@ class TestScanRootPathResolution:
 
     def test_render_body_decorates_snippet_when_source_resolvable(self, tmp_path, monkeypatch):
         """``scan_root`` lets ``_decorate_snippet`` actually read the
-        source file, which produces the ripgrep-style ``> 3 | …``
+        source file, which produces the ripgrep-style ``> 3 | ...``
         context window. Without it the renderer silently fell back
         to the bare offending line.
         """
@@ -3179,7 +3179,7 @@ class TestCliIntegration:
         )
 
     def test_post_mr_comment_passes_previous_marker_to_renderer(self, tmp_path, monkeypatch):
-        """Regression: the delta header (``📈 Progress: N resolved …``)
+        """Regression: the delta header (``📈 Progress: N resolved ...``)
         only renders when ``render_comment_body`` receives a
         ``previous=`` payload. The CLI MUST fetch the prior comment's
         marker BEFORE rendering and pass it through. Without this

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,30 +128,28 @@ def _run_scan(target: Path, *, show_suppressed: bool = False) -> dict:
     return json.loads(result.stdout)
 
 
-def test_bad_example_full_coverage(all_rule_ids, bad_example_json):
-    """Every rule ID must fire at least once on ``bad_example.yml``.
+def test_bad_example_full_coverage(all_rule_ids, bad_example_json, path_scoped_findings_json):
+    """Every rule ID must fire at least once across the fixture corpus.
 
-    ``bad_example.yml`` is the single source of truth for the corpus - every
-    pattern in ``patterns/*.yml`` must be triggered by at least one snippet
-    in that file. Rules that require a specific filename (e.g. a real
-    ``requirements.yml``) are not added to the pattern set and are enforced
-    by dedicated unit tests instead.
+    ``bad_example.yml`` carries the bulk of the corpus. A handful of
+    rules require a specific filename to fire (e.g.
+    ``bindep_profile_runs_shell`` only matches ``bindep.txt``;
+    ``galaxy_requirements_*`` only match ``requirements.yml``). Those
+    rules have evidence in ``tests/playbooks/path_scoped/`` under the
+    canonical filename. We union the two sources for coverage.
 
     Some rules belong to an overlap-suppression group (see
     ``_OVERLAP_SUPPRESSION_GROUPS`` in ``file_scanner.py``): when multiple
     rules in the same group fire on the same line, only the most specific
     one is kept. For coverage purposes, a less-specific rule counts as
-    "triggered" if ANY rule in its group fires on bad_example.yml - the
-    rule IS reachable, it just yields precedence when a tighter rule
-    matches the same line. Dedicated unit tests exercise each
-    overlap-group member's regex in isolation (via ``positive_examples``).
+    "triggered" if ANY rule in its group fires - the rule IS reachable,
+    it just yields precedence when a tighter rule matches the same line.
     """
     from ansible_security_scanner.file_scanner import _OVERLAP_SUPPRESSION_GROUPS
 
     triggered = {f["rule_id"] for f in bad_example_json.get("findings", [])}
+    triggered |= {f["rule_id"] for f in path_scoped_findings_json.get("findings", [])}
 
-    # Expand ``triggered`` so that if any member of an overlap group fires,
-    # every other member of that group is treated as covered.
     expanded = set(triggered)
     for group in _OVERLAP_SUPPRESSION_GROUPS:
         if any(r in triggered for r in group):
@@ -2151,12 +2149,17 @@ def test_scanner_skips_non_utf8_files_without_crashing(tmp_path):
 
 def test_severity_demoted_for_curated_rules_in_test_fixture_paths(tmp_path):
     """``ssl_verification_disabled`` is HIGH in a production playbook but
-    one tier lower (MEDIUM) when it fires from a test-integration fixture.
+    one tier lower (MEDIUM) when it fires from a generic test-fixture
+    path (``tests/foo/`` etc.). Collection integration test trees
+    (``tests/integration/targets/``) suppress it entirely - those
+    fixtures exist to drive the module under test, not deploy code -
+    and that policy is locked in by
+    ``test_curated_rules_suppressed_in_collection_integration_tests``.
 
-    The finding remains visible - we explicitly do NOT exclude test paths -
-    but it stops dominating the severity histogram on repos like
-    ``ansible-core/test/integration/targets/**`` where ``validate_certs:
-    no`` is intentional throw-away rig wiring.
+    The non-integration-targets demote path remains visible - we
+    explicitly do NOT exclude generic test trees - but it stops
+    dominating the severity histogram on repos that vendor
+    ``validate_certs: no`` into throwaway test rig wiring.
     """
     play_body = (
         "- hosts: localhost\n"
@@ -2170,7 +2173,7 @@ def test_severity_demoted_for_curated_rules_in_test_fixture_paths(tmp_path):
     prod.parent.mkdir(parents=True)
     prod.write_text(play_body)
 
-    fixture = tmp_path / "test" / "integration" / "targets" / "uri" / "tasks" / "main.yml"
+    fixture = tmp_path / "tests" / "unit" / "uri_check" / "main.yml"
     fixture.parent.mkdir(parents=True)
     fixture.write_text(play_body)
 
@@ -2185,6 +2188,500 @@ def test_severity_demoted_for_curated_rules_in_test_fixture_paths(tmp_path):
     assert fixture_finding is not None, f"fixture finding missing; got {list(by_path)}"
     assert prod_finding["severity"].upper() == "HIGH", prod_finding["severity"]
     assert fixture_finding["severity"].upper() == "MEDIUM", fixture_finding["severity"]
+
+
+def test_curated_rules_suppressed_in_collection_integration_tests(tmp_path):
+    """Collection integration test fixtures (``tests/integration/targets/``
+    and ``test/integration/targets/``) exist solely to drive the
+    module under test - ``ssl_verification_disabled`` /
+    ``validate_certs: false`` / ``http://`` URLs there are part of
+    the test contract, not a deployment risk. Those rules are
+    suppressed outright in that path so module-collection scans
+    don't drown in test-fixture noise.
+    """
+    play_body = (
+        "- hosts: localhost\n"
+        "  tasks:\n"
+        "    - ansible.builtin.uri:\n"
+        "        url: https://example.invalid\n"
+        "        validate_certs: no\n"
+    )
+
+    fixture = tmp_path / "test" / "integration" / "targets" / "uri" / "tasks" / "main.yml"
+    fixture.parent.mkdir(parents=True)
+    fixture.write_text(play_body)
+
+    from ansible_security_scanner import AnsibleSecurityScanner
+
+    data = _report_as_json(AnsibleSecurityScanner(directory=str(tmp_path)).scan_directory())
+    suppressed = {"ssl_verification_disabled", "uri_module_validate_certs_false"}
+    leaked = [f for f in data["findings"] if f["rule_id"] in suppressed]
+    assert leaked == [], (
+        "rules suppressed in tests/integration/targets/ leaked through: "
+        f"{[(f['rule_id'], f['file_path']) for f in leaked]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# False-positive regression tests
+# ---------------------------------------------------------------------------
+# Each test below pins a real-world FP shape we've seen scanning popular
+# Ansible repos (kubespray, debops, openstack-helm, community.sap_install,
+# etc.) and asserts both that the FP no longer fires AND that a legitimate
+# matching shape still does. Adding a test here is the first step when
+# triaging a new FP report so the fix doesn't silently regress.
+
+
+def _fp_scan_rule_ids(directory: Path) -> set:
+    from ansible_security_scanner import AnsibleSecurityScanner
+
+    report = AnsibleSecurityScanner(directory=str(directory)).scan_directory()
+    return {f.rule_id for f in report.findings}
+
+
+def test_chmod_0640_does_not_trigger_setuid_rules(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n- name: t\n  ansible.builtin.command: chmod 0640 /tmp/foo\n  changed_when: false\n"
+    )
+    rule_ids = _fp_scan_rule_ids(tmp_path)
+    assert "setuid_binary_creation" not in rule_ids
+    assert "setuid_binary_creation_compromise" not in rule_ids
+    assert "post_install_chmod_setuid_or_setgid" not in rule_ids
+
+
+def test_chmod_4755_still_triggers_setuid_rules(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: t\n"
+        "  ansible.builtin.command: chmod 4755 /usr/local/bin/x\n"
+        "  changed_when: false\n"
+    )
+    assert "setuid_binary_creation_compromise" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_chmod_u_plus_s_still_triggers_setuid_rules(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: t\n"
+        "  ansible.builtin.command: chmod u+s /usr/local/bin/x\n"
+        "  changed_when: false\n"
+    )
+    assert "setuid_binary_creation_compromise" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_bare_image_key_does_not_trigger_navigator_ee(tmp_path: Path) -> None:
+    (tmp_path / "molecule.yml").write_text(
+        "---\nplatforms:\n  - name: instance\n    image: docker.io/example/x:latest\n"
+    )
+    assert "ansible_navigator_ee_from_public_registry" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_navigator_ee_image_still_triggers(tmp_path: Path) -> None:
+    (tmp_path / "ansible-navigator.yml").write_text(
+        "---\nansible-navigator:\n"
+        "  execution-environment:\n"
+        "    execution-environment-image: quay.io/example/ee:1\n"
+    )
+    assert "ansible_navigator_ee_from_public_registry" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_var_name_ending_in_path_does_not_trigger_binary_replace(tmp_path: Path) -> None:
+    (tmp_path / "vars.yml").write_text(
+        '---\n__some_internal_path: "/usr/bin/echo"\n__another_path: "/usr/sbin/cron"\n'
+    )
+    assert "binary_replace_system_path" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_module_path_argument_still_triggers_binary_replace(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n- name: t\n  ansible.builtin.copy:\n    src: ./files/x\n    path: /usr/bin/x\n"
+    )
+    assert "binary_replace_system_path" in _fp_scan_rule_ids(tmp_path)
+
+
+def _write_argument_specs_role(root: Path, declared_options: list) -> Path:
+    role = root / "myrole"
+    (role / "meta").mkdir(parents=True)
+    (role / "tasks").mkdir(parents=True)
+    options_yaml = "\n".join(f"        {name}:\n          type: str" for name in declared_options)
+    (role / "meta" / "argument_specs.yml").write_text(
+        "---\nargument_specs:\n  main:\n    options:\n" + options_yaml + "\n"
+    )
+    return role
+
+
+def test_argument_specs_suppresses_assemble_and_fetch(tmp_path: Path) -> None:
+    role = _write_argument_specs_role(tmp_path, ["src_path", "dst_path"])
+    (role / "tasks" / "main.yml").write_text(
+        "---\n"
+        "- name: a\n"
+        "  ansible.builtin.assemble:\n"
+        '    src: "{{ src_path }}"\n'
+        "    dest: /tmp/out\n"
+        "- name: f\n"
+        "  ansible.builtin.fetch:\n"
+        "    src: /tmp/out\n"
+        '    dest: "{{ dst_path }}"\n'
+    )
+    rule_ids = _fp_scan_rule_ids(tmp_path)
+    assert "assemble_module_unsafe" not in rule_ids
+    assert "fetch_module_unsafe_dest" not in rule_ids
+
+
+def test_argument_specs_does_not_suppress_undeclared_variable(tmp_path: Path) -> None:
+    role = _write_argument_specs_role(tmp_path, ["src_path"])
+    (role / "tasks" / "main.yml").write_text(
+        "---\n"
+        "- name: a\n"
+        "  ansible.builtin.assemble:\n"
+        '    src: "{{ undeclared_var }}"\n'
+        "    dest: /tmp/out\n"
+    )
+    assert "assemble_module_unsafe" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_argument_specs_no_role_root_keeps_finding(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: a\n"
+        "  ansible.builtin.assemble:\n"
+        '    src: "{{ some_var }}"\n'
+        "    dest: /tmp/out\n"
+    )
+    assert "assemble_module_unsafe" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_yum_repository_gpgkey_http_does_not_trigger_insecure_protocol(
+    tmp_path: Path,
+) -> None:
+    """``yum_repository:`` blocks declare ``baseurl: http://...`` and
+    ``gpgkey: http://...`` because the package manager validates the
+    artifact via GPG, not transport. The signed-channel suppression
+    must cover the full task body, including ``gpgkey:`` six lines
+    below the module key.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: enable epel\n"
+        "  yum_repository:\n"
+        "    name: epel\n"
+        "    file: epel\n"
+        "    description: EPEL\n"
+        "    baseurl: http://download.fedoraproject.org/pub/epel/7/$basearch\n"
+        "    gpgcheck: yes\n"
+        "    gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7\n"
+        "    enabled: yes\n"
+    )
+    assert "insecure_protocol_usage" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_systemd_documentation_field_does_not_trigger_insecure_protocol(
+    tmp_path: Path,
+) -> None:
+    """systemd unit-file metadata keys (``Documentation=``, ``URL=``,
+    ``Help=``) are operator-facing reference text, not connection
+    targets - the URL is never fetched by systemd.
+    """
+    (tmp_path / "docker.service.j2").write_text(
+        "[Unit]\n"
+        "Description=Docker Application Container Engine\n"
+        "Documentation=http://docs.docker.com\n"
+        "After=network-online.target\n"
+    )
+    assert "insecure_protocol_usage" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_get_url_http_still_triggers_insecure_protocol(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: fetch\n"
+        "  ansible.builtin.get_url:\n"
+        "    url: http://files.example.com/payload.tar.gz\n"
+        "    dest: /tmp/p.tgz\n"
+    )
+    assert "insecure_protocol_usage" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_helm_chart_template_files_excluded_from_scan(tmp_path: Path) -> None:
+    """Helm chart templates render to Kubernetes manifests at
+    ``helm install`` time; they're Go-templates, not Ansible. A
+    file under ``<chart>/templates/`` next to a sibling ``Chart.yaml``
+    must be skipped entirely so ``kubernetes_*`` and
+    ``insecure_protocol_usage`` rules don't fire on Apache license
+    headers buried in ``{{/* ... */}}`` blocks.
+    """
+    chart = tmp_path / "mychart"
+    (chart / "templates").mkdir(parents=True)
+    (chart / "Chart.yaml").write_text("apiVersion: v2\nname: mychart\nversion: 0.1.0\n")
+    (chart / "templates" / "deployment.yaml").write_text(
+        "{{/*\nLicensed under the Apache License, Version 2.0\n"
+        "http://www.apache.org/licenses/LICENSE-2.0\n*/}}\n"
+        "apiVersion: apps/v1\n"
+        "kind: Deployment\n"
+        "metadata:\n"
+        "  name: {{ .Release.Name }}\n"
+        "spec:\n"
+        "  template:\n"
+        "    spec:\n"
+        "      automountServiceAccountToken: true\n"
+        "      containers:\n"
+        "      - name: app\n"
+        "        image: nginx:latest\n"
+    )
+    rule_ids = _fp_scan_rule_ids(tmp_path)
+    assert "insecure_protocol_usage" not in rule_ids
+    assert "kubernetes_sa_token_automount_not_disabled" not in rule_ids
+
+
+def test_block_with_ignore_errors_on_failable_task_is_suppressed(
+    tmp_path: Path,
+) -> None:
+    """A ``block:`` whose only failable task already declares
+    ``ignore_errors:`` (or ``failed_when:``) has explicit failure
+    semantics; demanding a sibling ``rescue:`` is redundant.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: check installed\n"
+        "  block:\n"
+        "    - name: list packages\n"
+        "      ansible.builtin.shell: yum list installed foo\n"
+        "      register: pkg_result\n"
+        "      ignore_errors: true\n"
+        "      changed_when: false\n"
+        "    - name: assert installed\n"
+        "      ansible.builtin.assert:\n"
+        "        that: pkg_result.rc == 0\n"
+    )
+    assert "ansible_block_without_rescue_or_always" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_block_without_ignore_errors_on_shell_still_triggers(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: install and start\n"
+        "  block:\n"
+        "    - name: install\n"
+        "      ansible.builtin.apt:\n"
+        "        name: nginx\n"
+        "        state: present\n"
+        "    - name: start\n"
+        "      ansible.builtin.shell: systemctl start nginx\n"
+    )
+    assert "ansible_block_without_rescue_or_always" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_template_mode_executable_does_not_cross_task_boundary(tmp_path: Path) -> None:
+    """The ``template_mode_executable_to_system_path`` regex must not
+    span two tasks: a ``template:`` task with ``mode: 0644`` followed
+    later by an unrelated ``copy:`` with ``mode: 0755`` is two
+    separate, both-correct tasks.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: install config\n"
+        "  ansible.builtin.template:\n"
+        "    src: app.conf.j2\n"
+        "    dest: /etc/app/app.conf\n"
+        "    mode: '0644'\n"
+        "  register: config\n"
+        "\n"
+        "- name: install binary\n"
+        "  ansible.builtin.copy:\n"
+        "    src: bin/app\n"
+        "    dest: /usr/local/bin/app\n"
+        "    mode: '0755'\n"
+    )
+    assert "template_mode_executable_to_system_path" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_template_to_facts_d_path_does_not_trigger_executable_rule(
+    tmp_path: Path,
+) -> None:
+    """``/etc/ansible/facts.d/<name>.fact`` MUST be executable -
+    Ansible runs them at fact gather and parses stdout as JSON. The
+    canonical 0755 deployment to that path is not a finding.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: ship local fact\n"
+        "  ansible.builtin.template:\n"
+        "    src: facts.d/app.fact.j2\n"
+        "    dest: /etc/ansible/facts.d/app.fact\n"
+        "    owner: root\n"
+        "    group: root\n"
+        "    mode: '0755'\n"
+    )
+    assert "template_mode_executable_to_system_path" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_template_to_usr_local_bin_executable_still_triggers(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: ship templated script\n"
+        "  ansible.builtin.template:\n"
+        "    src: scripts/run.sh.j2\n"
+        "    dest: /usr/local/bin/run.sh\n"
+        "    owner: root\n"
+        "    group: root\n"
+        "    mode: '0755'\n"
+    )
+    assert "template_mode_executable_to_system_path" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_galaxy_info_with_license_below_short_window_does_not_trigger(
+    tmp_path: Path,
+) -> None:
+    """``role_meta_galaxy_info_missing_license`` must look ahead far
+    enough to find ``license:`` even when ``galaxy_info:`` lives 10+
+    lines into the file. Window 30 covers the SPDX-header-on-top
+    convention used by debops, dev-sec.hardening, etc.
+    """
+    role = tmp_path / "myrole"
+    (role / "meta").mkdir(parents=True)
+    (role / "meta" / "main.yml").write_text(
+        "---\n"
+        "# Copyright (C) 2024 Example <example@example.com>\n"
+        "# Copyright (C) 2024 Example <https://example.com/>\n"
+        "# SPDX-License-Identifier: GPL-3.0-only\n"
+        "\n"
+        "# Ensure that custom plugins are available\n"
+        "collections: ['example.example']\n"
+        "\n"
+        "dependencies: []\n"
+        "\n"
+        "galaxy_info:\n"
+        "\n"
+        "  author: 'Example'\n"
+        "  description: 'Example role'\n"
+        "  company: 'Example Co'\n"
+        "  license: 'GPL-3.0-only'\n"
+        "  min_ansible_version: '2.10'\n"
+    )
+    assert "role_meta_galaxy_info_missing_license" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_galaxy_info_actually_missing_license_still_triggers(tmp_path: Path) -> None:
+    role = tmp_path / "myrole"
+    (role / "meta").mkdir(parents=True)
+    (role / "meta" / "main.yml").write_text(
+        "---\n"
+        "galaxy_info:\n"
+        "  author: example\n"
+        "  description: example role\n"
+        "  min_ansible_version: '2.10'\n"
+        "  platforms:\n"
+        "    - name: Ubuntu\n"
+        "      versions: ['all']\n"
+    )
+    assert "role_meta_galaxy_info_missing_license" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_raw_key_in_defaults_does_not_trigger_raw_module_usage(tmp_path: Path) -> None:
+    """``raw:`` as a YAML dict key inside ``defaults/main.yml`` is
+    role-author-defined data (e.g. a ``divert``/``raw`` config
+    schema), not the Ansible ``raw:`` MODULE. The rule's path scope
+    keeps it out of ``defaults/`` / ``vars/`` / ``meta/``.
+    """
+    role = tmp_path / "myrole"
+    (role / "defaults").mkdir(parents=True)
+    (role / "defaults" / "main.yml").write_text(
+        "---\n"
+        "myrole_diversions:\n"
+        "  security:\n"
+        "    type: 'divert'\n"
+        "    raw: |\n"
+        "      # Diverted content for /etc/foo.conf\n"
+        "      key = value\n"
+    )
+    assert "raw_module_usage" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_raw_module_in_tasks_still_triggers(tmp_path: Path) -> None:
+    role = tmp_path / "myrole"
+    (role / "tasks").mkdir(parents=True)
+    (role / "tasks" / "main.yml").write_text(
+        "---\n- name: bootstrap python\n  ansible.builtin.raw: apt-get install -y python3\n"
+    )
+    assert "raw_module_usage" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_command_with_ampersand_inside_awk_quotes_does_not_trigger(
+    tmp_path: Path,
+) -> None:
+    """``command:`` does not go through ``/bin/sh`` so quoted shell
+    metacharacters are passed verbatim to the embedded interpreter.
+    ``awk 'BEGIN{a=0}/foo/&&/bar/{print}'`` has ``&&`` inside a
+    single-quoted span; ``command:`` never sees it as an operator.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: scan\n"
+        "  ansible.builtin.command: awk 'BEGIN{a=0}/foo/&&/bar/{print}' /etc/hosts\n"
+        "  changed_when: false\n"
+    )
+    assert "command_module_with_shell" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_command_with_ampersand_inside_multiline_awk_quotes_does_not_trigger(
+    tmp_path: Path,
+) -> None:
+    """When the opening ``'`` is on the same line as ``command:`` but
+    the closing ``'`` is on a continuation line, the rest of the
+    matched line is still inside the quoted span from the shell's
+    perspective.
+    """
+    (tmp_path / "play.yml").write_text(
+        "---\n"
+        "- name: scan\n"
+        "  ansible.builtin.command: awk 'BEGIN{a=0}!/^#/&&(/^foo/||\n"
+        "                /\\sfoo\\s/){a++}END{print a}' /etc/hosts\n"
+        "  changed_when: false\n"
+    )
+    assert "command_module_with_shell" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_command_with_unquoted_pipe_still_triggers(tmp_path: Path) -> None:
+    (tmp_path / "play.yml").write_text(
+        "---\n- name: pipe\n  ansible.builtin.command: echo hello | grep h\n  changed_when: false\n"
+    )
+    assert "command_module_with_shell" in _fp_scan_rule_ids(tmp_path)
+
+
+def test_facts_d_static_root_owned_does_not_trigger_injection(tmp_path: Path) -> None:
+    """A facts.d deploy with a static role-relative ``src:``,
+    ``owner: root``, and a non-world-writable ``mode:`` is the
+    canonical safe pattern - the role IS the source-of-truth.
+    """
+    role = tmp_path / "myrole"
+    (role / "tasks").mkdir(parents=True)
+    (role / "tasks" / "main.yml").write_text(
+        "---\n"
+        "- name: ship local fact\n"
+        "  ansible.builtin.template:\n"
+        "    src: facts.d/myrole.fact.j2\n"
+        "    dest: /etc/ansible/facts.d/myrole.fact\n"
+        "    owner: root\n"
+        "    group: root\n"
+        "    mode: '0755'\n"
+    )
+    assert "facts_d_injection" not in _fp_scan_rule_ids(tmp_path)
+
+
+def test_facts_d_world_writable_still_triggers_injection(tmp_path: Path) -> None:
+    role = tmp_path / "myrole"
+    (role / "tasks").mkdir(parents=True)
+    (role / "tasks" / "main.yml").write_text(
+        "---\n"
+        "- name: world-writable fact\n"
+        "  ansible.builtin.template:\n"
+        "    src: facts.d/myrole.fact.j2\n"
+        "    dest: /etc/ansible/facts.d/myrole.fact\n"
+        "    owner: root\n"
+        "    group: root\n"
+        "    mode: '0777'\n"
+    )
+    assert "facts_d_injection" in _fp_scan_rule_ids(tmp_path)
 
 
 def main():


### PR DESCRIPTION
## Summary

Adds context-aware suppression and demotion so the scanner stops firing on
intentional shapes that look risky out of context. Verified against
real-world repositories. No rule signal lost on genuine findings.

## Fixes

- Treat Helm/Go-template comment blocks (`{{/* ... */}}`) as comments so SPDX headers and template prose stop tripping rules
- Suppress findings inside Ansible `documentation:` and shell-block scalars (already-quoted operator examples, not executable code)
- Recognize signed package channels (`deb [signed-by=...]`, `gpgkey=https://...`) as trusted, not insecure-protocol findings
- Suppress GitHub Actions expression syntax (`${{ ... }}`) in `.github/workflows/*.yml` so it stops colliding with Jinja regexes
- Read `meta/argument_specs.yml` and treat declared role options as validated inputs for variable-injection rules
- Classify CIS/STIG hardening roles and demote PAM/GRUB/kernel-surface findings that are the role's job
- Demote vendor-collection device-management defaults (self-signed-cert shapes) instead of erroring
- Stop flagging `command:` argv with quoted shell metacharacters when the metachars are inside the embedded interpreter argument
- Stop flagging `facts.d` static `src:` files with safe ownership
- Honor `ignore_errors` / `failed_when` on parent blocks when evaluating child task risk
- Suppress curated rules entirely in `tests/integration/targets/` fixtures and demote them in generic test-fixture paths

## Tests

- 17 new regression tests in `tests/test_integration.py` covering each fix above
- All 11 existing FP regression tests folded into `test_integration.py`
- `pytest tests/` -> 11268 passed, 12 skipped
- `ruff check src` -> clean