### PR TITLE
Add author identity, FAQ, and About page to docs site

### DIFF
--- a/.hugo/config.toml
+++ b/.hugo/config.toml
@@ -12,8 +12,6 @@ enableGitInfo = true
   filename = "sitemap.xml"
 
 [params]
-  author = "Chris Peoples"
-  description = "Static SAST scanner for Ansible playbooks, roles, collections, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS."
 
   themeVariant = ["relearn-dark", "relearn-light"]
   themeVariantAuto = ["relearn-dark", "relearn-light"]
@@ -41,6 +39,9 @@ enableGitInfo = true
   showVisitedLinks = false
   print = true
   printPageBreak = true
+
+  [params.author]
+    name = "Chris Peoples"
 
   [[params.boxStyle]]
     identifier = "note"

--- a/.hugo/layouts/partials/custom-header.html
+++ b/.hugo/layouts/partials/custom-header.html
@@ -2,6 +2,8 @@
 
 <link rel="canonical" href="{{ .Permalink }}" />
 
+{{- $authorId := printf "%sabout/#author" site.BaseURL }}
+
 {{- if .IsHome }}
 <script type="application/ld+json">
 {
@@ -24,11 +26,119 @@
     "priceCurrency": "USD"
   },
   "author": {
-    "@type": "Person",
-    "name": "Chris Peoples",
-    "url": "https://github.com/cpeoples"
+    "@id": "{{ $authorId }}"
   },
   "keywords": "ansible, security, sast, static analysis, playbook, role, collection, devsecops, sarif, cyclonedx, sbom, supply chain, rce, injection, secrets, owasp, cwe, nist, cis, mitre att&ck"
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "{{ $authorId }}",
+  "name": "Chris Peoples",
+  "url": "https://cpeoples.github.io",
+  "image": "https://avatars.githubusercontent.com/u/699389?v=4",
+  "jobTitle": "Software Engineer",
+  "knowsAbout": [
+    "Ansible",
+    "DevSecOps",
+    "Static Application Security Testing",
+    "Supply Chain Security",
+    "Software Composition Analysis",
+    "Mobile Forensics",
+    "Security Research",
+    "Full-Stack Development"
+  ],
+  "sameAs": [
+    "https://github.com/cpeoples",
+    "https://cpeoples.github.io",
+    "https://forum.ansible.com/u/cpeoples",
+    "https://www.linkedin.com/in/chrispeoples"
+  ]
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What does Ansible Security Scanner scan?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Ansible playbooks, roles, collections, task files, vars, and inventories. It detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is this different from ansible-lint?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "ansible-lint focuses on style and best practices. Ansible Security Scanner is a SAST tool focused on security signals: dataflow taint tracking, supply-chain risk, secrets, and known attack patterns mapped to OWASP, CWE, NIST, CIS, and MITRE ATT&CK."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does it run in CI/CD?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. It outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown. GitHub Actions, GitLab CI, and Jenkins are all supported, and PR/MR comments can be posted automatically."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it free to use?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Ansible Security Scanner is Apache-2.0 licensed and free to use commercially."
+      }
+    }
+  ]
+}
+</script>
+{{- end }}
+
+{{- if and .File (eq .File.BaseFileName "about") }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "url": "{{ .Permalink }}",
+  "name": "About",
+  "dateModified": "{{ with .Lastmod }}{{ .Format "2006-01-02T15:04:05Z07:00" }}{{ else }}{{ now.Format "2006-01-02T15:04:05Z07:00" }}{{ end }}",
+  "mainEntity": {
+    "@id": "{{ $authorId }}"
+  }
+}
+</script>
+{{- end }}
+
+{{- if not .IsHome }}
+{{- $crumbs := slice }}
+{{- $crumbs = $crumbs | append (dict "name" "Home" "url" site.BaseURL) }}
+{{- range $i, $a := .Ancestors.Reverse }}
+  {{- if not $a.IsHome }}
+    {{- $crumbs = $crumbs | append (dict "name" $a.Title "url" $a.Permalink) }}
+  {{- end }}
+{{- end }}
+{{- $crumbs = $crumbs | append (dict "name" .Title "url" .Permalink) }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {{- range $i, $c := $crumbs }}
+    {{- if $i }},{{ end }}
+    {
+      "@type": "ListItem",
+      "position": {{ add $i 1 }},
+      "name": "{{ $c.name }}",
+      "item": "{{ $c.url }}"
+    }
+    {{- end }}
+  ]
 }
 </script>
 {{- end }}

--- a/.hugo/scripts/build_docs.py
+++ b/.hugo/scripts/build_docs.py
@@ -71,6 +71,7 @@ SEVERITY_ORDER = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "INFO": 4}
 # sidebar order (lower = higher in the nav). Gaps of 10 leave room to
 # insert new pages without renumbering everything below them.
 DOC_PAGES: dict[str, dict[str, object]] = {
+    "about": {"title": "About", "weight": 10},
     "cli": {"title": "CLI Reference", "weight": 20},
     "environment": {"title": "Environment", "weight": 30},
     "api": {"title": "Python API", "weight": 40},
@@ -287,9 +288,20 @@ def build_index() -> None:
         'style="vertical-align:middle;margin-right:0.6rem;" />'
     )
 
+    description = (
+        "Static SAST scanner for Ansible playbooks, roles, collections, and "
+        "inventories. Detects malicious code, RCE, command and template "
+        "injection, hardcoded credentials, supply-chain risk, unauthorized "
+        "cloud access, lateral movement, and reverse shells. Outputs SARIF, "
+        "CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports "
+        "with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP "
+        "ASVS, MITRE ATT&CK, NIST, and CIS."
+    )
+
     frontmatter = (
         f"---\n"
         f'title: "{title}"\n'
+        f'description: "{description}"\n'
         f"weight: 1\n"
         f"alwaysopen: true\n"
         f"headingPre: '{heading_pre}'\n"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Static SAST scanner for Ansible playbooks, roles, collections, task files, vars,
 - [Project Structure](#project-structure)
 - [Documentation](#documentation)
 - [Requirements](#requirements)
+- [FAQ](#faq)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License & Attribution](#license--attribution)
@@ -263,6 +264,33 @@ For development work from source:
 pip install -e ".[dev]"
 ```
 
+## FAQ
+
+**What does Ansible Security Scanner scan?**
+
+Ansible playbooks, roles, collections, task files, vars, and inventories. It
+detects malicious code, RCE, command and template injection, hardcoded
+credentials, supply-chain risk, unauthorized cloud access, lateral movement,
+and reverse shells.
+
+**How is this different from `ansible-lint`?**
+
+`ansible-lint` focuses on style and best practices. Ansible Security Scanner
+is a SAST tool focused on security signals: dataflow taint tracking,
+supply-chain risk, secrets, and known attack patterns mapped to OWASP, CWE,
+NIST, CIS, and MITRE ATT&CK.
+
+**Does it run in CI/CD?**
+
+Yes. It outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and
+Markdown. GitHub Actions, GitLab CI, and Jenkins are all supported, and
+PR/MR comments can be posted automatically.
+
+**Is it free to use?**
+
+Yes. Ansible Security Scanner is Apache-2.0 licensed and free to use
+commercially.
+
 ## Contributing
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev-environment
@@ -363,3 +391,13 @@ In plain English:
 
 See [`NOTICE`](NOTICE) for the full attribution terms and
 [`LICENSE`](LICENSE) for the Apache-2.0 text.
+
+## AI-assistance disclosure
+
+This project follows the
+[Ansible community AI policy](https://docs.ansible.com/projects/ansible/latest/community/ai_policy.html).
+LLM tooling has helped with scaffolding, refactoring, test generation,
+and documentation. All of it is reviewed, edited, and tested by a human
+before being committed. The rules, threat models, and design decisions
+are mine, and every PR runs the full test, lint, and security gate
+before merge.

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,71 @@
+# About
+
+## The project
+
+Ansible Security Scanner is a static analysis (SAST) tool for Ansible
+playbooks, roles, collections, task files, vars, and inventories. It
+focuses on real security signals: malicious code, RCE, command and
+template injection, hardcoded credentials, supply-chain risk,
+unauthorized cloud access, lateral movement, and reverse shells. Style
+and linting concerns are intentionally left to other tools.
+
+The scanner ships [1,000+ rules](/dashboard/) organized by threat
+category, mapped to OWASP, CWE, NIST, CIS, and MITRE ATT&CK. It produces
+SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown
+output, and can post PR/MR comments directly from CI.
+
+The full source lives at
+[github.com/cpeoples/ansible-security-scanner](https://github.com/cpeoples/ansible-security-scanner)
+under the Apache-2.0 license.
+
+## The author
+
+Hi 👋, I'm [Chris Peoples](https://github.com/cpeoples). I'm a software
+engineer who has spent a lot of time around DevSecOps, static analysis,
+supply-chain security, security research, mobile forensics, and
+full-stack development. This project started because the gap between
+"lint" and "security scanner" felt much wider in the Ansible ecosystem
+than what I was used to from other languages and toolchains, and I
+wanted to help close it.
+
+The best places to reach me about the scanner:
+
+- GitHub Issues:
+  [github.com/cpeoples/ansible-security-scanner/issues](https://github.com/cpeoples/ansible-security-scanner/issues)
+- Ansible Forum:
+  [forum.ansible.com/u/cpeoples](https://forum.ansible.com/u/cpeoples)
+- LinkedIn:
+  [linkedin.com/in/chrispeoples](https://www.linkedin.com/in/chrispeoples)
+
+## Contributions are welcome
+
+Bug reports, false-positive reports, new patterns, docs improvements,
+typo fixes, ideas, opinions, all of it. There's a
+[CONTRIBUTING.md](https://github.com/cpeoples/ansible-security-scanner/blob/main/CONTRIBUTING.md)
+in the repo with the dev setup and PR checklist, but if you'd rather
+just open an issue and talk it through first, that's great too.
+
+## How rules are written
+
+Every rule in [`src/ansible_security_scanner/patterns/`](https://github.com/cpeoples/ansible-security-scanner/tree/main/src/ansible_security_scanner/patterns)
+is a YAML plugin with a curated `id`, `severity`, `description`,
+remediation guidance, and at least one mapping to an external taxonomy
+(CWE, CVE, OWASP, NIST, CIS, MITRE ATT&CK). The framework-catalog test
+fails the build on any rule that cites an unresolvable id, so every
+shipped rule has a verified link.
+
+False positives are tracked in
+[GitHub Issues](https://github.com/cpeoples/ansible-security-scanner/issues)
+and have dedicated regression tests in
+[`tests/`](https://github.com/cpeoples/ansible-security-scanner/tree/main/tests)
+to make sure they stay fixed.
+
+## AI-assistance disclosure
+
+This project follows the
+[Ansible community AI policy](https://docs.ansible.com/projects/ansible/latest/community/ai_policy.html).
+LLM tooling has helped with scaffolding, refactoring, test generation,
+and documentation. All of it is reviewed, edited, and tested by a human
+before being committed. The rules, threat models, and design decisions
+are mine, and every PR runs the full test, lint, and security gate
+before merge.


### PR DESCRIPTION
## Summary

- Top-level Person JSON-LD with stable @id, sameAs to GitHub, blog, Ansible Forum, LinkedIn
- ProfilePage JSON-LD on /about/ referencing the same Person @id
- BreadcrumbList JSON-LD on every non-home page
- FAQPage JSON-LD on the homepage with matching visible FAQ in README
- New /about/ page with project background, author bio, contact info, and AI-attribution

## Notes

- Resolves the two Hugo theme deprecation warnings (params.author and params.description)
- Homepage description moved to frontmatter so per-page descriptions work
- About page registered in DOC_PAGES with weight 10 so it leads the docs nav