### PR TITLE
Bump SLSA badge to Level 3 for v0.1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1091-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
-  <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%202-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 2" /></a>&nbsp;&nbsp;
+  <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/Sigstore-verified-success?style=flat-square&logo=sigstore&logoColor=white" alt="Sigstore verified" /></a>
 </p>


### PR DESCRIPTION
First release that produces L3 provenance via the trusted reusable workflow lands as v0.1.18, so the README badge is no longer accurate at L2.