### PR TITLE
Sign refresh-lockfile commits so they satisfy branch protection

### DIFF
--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -48,3 +48,4 @@ jobs:
           branch: refresh-ci-lockfile
           delete-branch: true
           add-paths: .github/constraints.txt
+          sign-commits: true


### PR DESCRIPTION
## Summary

PR #22 (the first successful weekly lockfile refresh) was blocked at the merge gate by branch protection's verified-signature requirement, because `peter-evans/create-pull-request` defaults to writing the commit via local git, which produces an unsigned bot commit.

Setting `sign-commits: true` (supported on the action since v6) makes it create the commit through the GitHub REST API instead. That path produces a `github-actions[bot]` commit with a verified signature, which the branch-protection gate accepts.
