### PR TITLE
Add Homebrew install instructions

### DIFF
--- a/.hugo/static/llms.txt
+++ b/.hugo/static/llms.txt
@@ -6,7 +6,9 @@ Ansible Security Scanner is a static analyzer purpose-built for Ansible content.
 
 ## Install
 
+- [Installation](https://cpeoples.github.io/ansible-security-scanner/#installation): pip install ansible-security-scanner, or brew install cpeoples/tap/ansible-security-scanner
 - [PyPI package](https://pypi.org/project/ansible-security-scanner/): pip install ansible-security-scanner
+- [Homebrew tap](https://github.com/cpeoples/homebrew-tap): brew install cpeoples/tap/ansible-security-scanner
 - [Source code](https://github.com/cpeoples/ansible-security-scanner): GitHub repository (Apache-2.0)
 - [Documentation](https://cpeoples.github.io/ansible-security-scanner/): full docs site
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,17 @@ pip install ansible-security-scanner
 
 Requires Python 3.11+. Installs an `ansible-security-scanner` command on your PATH.
 
+### Homebrew
+
+```bash
+brew install cpeoples/tap/ansible-security-scanner
+```
+
+Available via the [`cpeoples/homebrew-tap`](https://github.com/cpeoples/homebrew-tap) Homebrew tap.
+
 ## Quick Start
 
-After `pip install ansible-security-scanner`, try one of these:
+After installing, try one of these:
 
 ```bash
 # 1. Scan the current directory, print a Markdown report to the terminal


### PR DESCRIPTION
Adds the Homebrew install snippet (brew install cpeoples/tap/ansible-security-scanner) to README.md and llms.txt now that the tap is live at github.com/cpeoples/homebrew-tap.