### PR TITLE
Add pre-commit hook

### DIFF
--- a/.hugo/static/llms.txt
+++ b/.hugo/static/llms.txt
@@ -9,6 +9,7 @@ Ansible Security Scanner is a static analyzer purpose-built for Ansible content.
 - [Installation](https://cpeoples.github.io/ansible-security-scanner/#installation): pip install ansible-security-scanner, or brew install cpeoples/tap/ansible-security-scanner
 - [PyPI package](https://pypi.org/project/ansible-security-scanner/): pip install ansible-security-scanner
 - [Homebrew tap](https://github.com/cpeoples/homebrew-tap): brew install cpeoples/tap/ansible-security-scanner
+- [pre-commit hook](https://pre-commit.com/): add `repo: https://github.com/cpeoples/ansible-security-scanner` with hook id `ansible-security-scanner`
 - [Source code](https://github.com/cpeoples/ansible-security-scanner): GitHub repository (Apache-2.0)
 - [Documentation](https://cpeoples.github.io/ansible-security-scanner/): full docs site
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,19 @@
+- id: ansible-security-scanner
+  name: ansible-security-scanner
+  description: Static security scanner for Ansible playbooks, roles, and collections.
+  entry: ansible-security-scanner --files
+  language: python
+  types_or: [yaml]
+  files: \.(ya?ml|j2|cfg)$
+  exclude: ^(\.github/|\.hugo/themes/)
+  require_serial: true
+
+- id: ansible-security-scanner-all
+  name: ansible-security-scanner (full repository)
+  description: Scan the full repository tree (slower; useful in CI or pre-push hooks).
+  entry: ansible-security-scanner --directory .
+  language: python
+  pass_filenames: false
+  always_run: true
+  require_serial: true
+  stages: [manual, pre-push]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ brew install cpeoples/tap/ansible-security-scanner
 
 Available via the [`cpeoples/homebrew-tap`](https://github.com/cpeoples/homebrew-tap) Homebrew tap.
 
+### pre-commit
+
+Add to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/cpeoples/ansible-security-scanner
+    rev: v0.1.18
+    hooks:
+      - id: ansible-security-scanner
+```
+
+Two hook IDs are exposed:
+
+- `ansible-security-scanner` — scans only the staged YAML / `*.j2` / `*.cfg` files. Runs on every commit.
+- `ansible-security-scanner-all` — scans the full repository tree. Wired to the `pre-push` and `manual` stages so it doesn't fire on every commit; trigger it with `pre-commit run --hook-stage pre-push ansible-security-scanner-all` or in CI.
+
 ## Quick Start
 
 After installing, try one of these:


### PR DESCRIPTION
Adds `.pre-commit-hooks.yaml` so users can run the scanner from `.pre-commit-config.yaml`:

```yaml
repos:
  - repo: https://github.com/cpeoples/ansible-security-scanner
    rev: v0.1.18
    hooks:
      - id: ansible-security-scanner
```

Two hook IDs are exposed:

- `ansible-security-scanner` — scans staged YAML / `*.j2` / `*.cfg` files; runs on every commit.
- `ansible-security-scanner-all` — scans the full tree; wired to the `pre-push` and `manual` stages.

Verified locally with `pre-commit try-repo`: clean files pass (exit 0), files with findings fail (exit 1).

README and `llms.txt` updated to mention the hook alongside the existing pip / Homebrew install paths.