### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.hugo/static/llms.txt
+++ b/.hugo/static/llms.txt
@@ -22,7 +22,7 @@ Ansible Security Scanner is a static analyzer purpose-built for Ansible content.
 ## Distribution and supply-chain
 
 - License: Apache-2.0
-- Python: 3.11, 3.12, 3.13
+- Python: 3.11, 3.12, 3.13, 3.14
 - Provenance: [SLSA Build Level 3](https://slsa.dev/spec/v1.0/levels#build-l3)
 - SBOM: CycloneDX, attached to every GitHub release
 - Signing: Sigstore-verified release artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Security",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Software Development :: Testing",


### PR DESCRIPTION
Adds Python 3.14 to the supported versions matrix.

- Adds the `Programming Language :: Python :: 3.14` classifier so PyPI shows the badge and resolvers see it as supported.
- Adds 3.14 to the test matrix in `scanner-ci.yml`.
- Updates `llms.txt` to mention 3.14.

Verified locally on Python 3.14.2: `pip install -e ".[dev]"` succeeds and the full suite passes (11,288 passed, 12 skipped, 0 failures).