### PR TITLE
suppress insecure_protocol on cloud metadata urls and add *_key credential rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1091-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1092-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1091<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1092<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->528<!--/HIGH--> high, <!--MED-->131<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->529<!--/HIGH--> high, <!--MED-->131<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1091<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1092<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -127,6 +127,39 @@ _DISK_SINK_MODULES: frozenset[str] = frozenset(
     }
 )
 
+# HTTP-fetch modules whose body carries credential fields. Used by
+# ``_is_security_task`` to flag ``ignore_errors`` on tasks whose name
+# isn't security-keyword-bearing but whose body shape is.
+_HTTP_FETCH_MODULES: frozenset[str] = frozenset(
+    {
+        "uri",
+        "ansible.builtin.uri",
+        "get_url",
+        "ansible.builtin.get_url",
+        "win_uri",
+        "ansible.windows.win_uri",
+    }
+)
+_CRED_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "password",
+        "passwd",
+        "url_password",
+        "token",
+        "auth_token",
+        "api_key",
+        "apikey",
+        "secret",
+        "client_secret",
+        "private_key",
+        "force_basic_auth",
+    }
+)
+_CRED_FIELD_SUFFIXES: tuple[str, ...] = ("_password", "_token", "_secret", "_key")
+_CRED_HEADER_NAMES: frozenset[str] = frozenset(
+    {"authorization", "x-api-key", "x-auth-token", "x-vault-token"}
+)
+
 # Rules whose entire purpose is to find things INSIDE YAML comments
 # (e.g. `# API_TOKEN=abc123` left in a review artefact). The universal
 # comment-line suppression in ``_emit_finding_if_allowed`` must not
@@ -964,6 +997,50 @@ _OVERLAP_SUPPRESSION_GROUPS: tuple[tuple[str, ...], ...] = (
         "google_api_key",
         "youtube_api_key",
     ),
+    # SSH host-key bypass family. A single inventory line of
+    # ``ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o
+    # UserKnownHostsFile=/dev/null"`` matches all three. Keep the
+    # inventory-scoped framing; the bare-flag rules are strict
+    # subsets of the same evidence.
+    (
+        "ssh_args_disable_host_key",
+        "ssh_stricthostkey_disabled",
+        "ssh_userknownhosts_devnull",
+    ),
+    # Root authorized_keys writes. ``root_ssh_key_modification``
+    # is the CRITICAL root-specific framing with persistence-
+    # primitive remediation; ``ssh_authorized_keys_write`` fires
+    # on ANY authorized_keys write.
+    (
+        "root_ssh_key_modification",
+        "ssh_authorized_keys_write",
+    ),
+    # ``plaintext_credential_key_var`` is the generic ``*_key:
+    # "<literal>"`` rule meant to plug the long-tail gap. When any
+    # narrower rule co-fires (vendor-specific token rules, the
+    # ``api_key:`` / ``private_key:`` regexes, or the broader
+    # plaintext-password rule), keep the targeted framing - it
+    # carries provider-tailored rotation guidance.
+    (
+        "stripe_api_key",
+        "anthropic_api_key_credential",
+        "openai_api_key_credential",
+        "twitter_api_key",
+        "google_api_key",
+        "youtube_api_key",
+        "github_token",
+        "github_personal_access_token_literal",
+        "slack_bot_or_app_token_literal",
+        "heroku_api_key",
+        "mailchimp_api_key",
+        "mailgun_api_key",
+        "sendgrid_api_key",
+        "aws_access_key",
+        "aws_secret_key",
+        "hardcoded_api_key",
+        "plaintext_password_should_be_vaulted",
+        "plaintext_credential_key_var",
+    ),
 )
 
 
@@ -1644,6 +1721,11 @@ class FileScanner:
                 # Same relationship for yum/dnf's validate_certs.
                 "yum_validate_certs_false": {"ssl_verification_disabled"},
                 "dnf_validate_certs_false": {"ssl_verification_disabled"},
+                # `ssrf_to_cloud_metadata_service` anchors on the
+                # module/curl/wget token and carries IMDSv2 context;
+                # `cloud_instance_metadata` is the bare-IP regex that
+                # also fires on the same task.
+                "ssrf_to_cloud_metadata_service": {"cloud_instance_metadata"},
             }
             # Maximum line gap between the module-header anchor and the
             # offending argument line that still counts as "the same task".
@@ -3895,12 +3977,18 @@ class FileScanner:
             "ansible.builtin.raw",
         ):
             cmd = task.get(mod)
-            if isinstance(cmd, str) and cred_pattern.search(cmd):
-                return True
-            if isinstance(cmd, dict):
+            if isinstance(cmd, str):
+                cmd_str = cmd
+            elif isinstance(cmd, dict):
                 cmd_str = str(cmd.get("cmd", "")) + " " + str(cmd.get("argv", ""))
-                if cred_pattern.search(cmd_str):
-                    return True
+            else:
+                continue
+            if cred_pattern.search(cmd_str):
+                return True
+            # Reading key material into a register without `no_log`
+            # leaks the bytes via stdout / callback plugins.
+            if self._CRED_FILE_READ_RE.search(cmd_str):
+                return True
 
         vars_block = task.get("vars", {})
         if isinstance(vars_block, dict):
@@ -4002,6 +4090,42 @@ class FileScanner:
         r"\$schema|targetNamespace|"
         r"schemaLocation|xsi:noNamespaceSchemaLocation)\s*=\s*"
         r"['\"]?https?://",
+        re.IGNORECASE,
+    )
+
+    # Cloud instance-metadata-service endpoints. Plaintext is
+    # mandated by spec - the hypervisor terminates the request
+    # so no TLS handshake is possible. The actionable risk is
+    # caught by ``ssrf_to_cloud_metadata_service``; suppress
+    # ``insecure_protocol_usage`` on these URLs.
+    _CLOUD_METADATA_URL_RE: re.Pattern[str] = re.compile(
+        r"\b(?:http|ftp)://(?:"
+        r"169\.254\.169\.254|"
+        r"\[?fd00:ec2::254\]?|"
+        r"100\.100\.100\.200|"
+        r"metadata\.google\.internal|"
+        r"metadata\.goog|"
+        r"metadata\.azure\.com|"
+        r"169\.254\.170\.2"
+        r")(?::|/|$)",
+        re.IGNORECASE,
+    )
+
+    # Shell commands reading credential material into a register.
+    # Used by ``_task_handles_credentials`` so ``register:`` of a
+    # private-key / TLS / kube / SSH file fires ``missing_no_log``
+    # even when the command line carries no ``password=`` token.
+    _CRED_FILE_READ_RE: re.Pattern[str] = re.compile(
+        r"(?:cat|openssl|base64|gpg|head|tail|less|more|pbcopy|xclip)\s+"
+        r"(?:[^|;&\n]*?\s)?(?:"
+        r"[\w./~-]*?\.(?:key|pem|pfx|p12|jks|keystore|truststore|ovpn|kdbx|asc)\b|"
+        r"/etc/(?:ssl|pki|tls|kubernetes|docker)/[^\s|;&]*|"
+        r"/etc/letsencrypt/[^\s|;&]*|"
+        r"~?/?\.ssh/(?:id_[a-z0-9_]+|authorized_keys|known_hosts|config)\b|"
+        r"/var/lib/(?:rancher|kubelet)/[^\s|;&]*\.(?:key|pem|crt)|"
+        r"/root/\.kube/config|"
+        r"/etc/kubernetes/admin\.conf"
+        r")",
         re.IGNORECASE,
     )
 
@@ -4112,7 +4236,26 @@ class FileScanner:
             "secret",
         ]
         task_name = str(task.get("name", "")).lower()
-        return any(kw in task_name for kw in security_keywords)
+        if any(kw in task_name for kw in security_keywords):
+            return True
+
+        # Body-shape fallback: a uri/get_url task carrying credential
+        # fields or auth headers is security-critical even when the
+        # task name is generic.
+        for module_name in _HTTP_FETCH_MODULES:
+            block = task.get(module_name)
+            if not isinstance(block, dict):
+                continue
+            for k in block:
+                lk = str(k).lower()
+                if lk in _CRED_FIELD_NAMES or lk.endswith(_CRED_FIELD_SUFFIXES):
+                    return True
+            headers = block.get("headers")
+            if isinstance(headers, dict) and any(
+                str(hk).lower() in _CRED_HEADER_NAMES for hk in headers
+            ):
+                return True
+        return False
 
     def _task_has_hardcoded_credential(self, task: dict) -> bool:
         """Check if a credential-handling task has hardcoded (non-variable) credential values"""
@@ -4329,6 +4472,14 @@ class FileScanner:
                                     variant, url_re=_nested_rules[pat.id]
                                 ):
                                     continue
+
+                            # Mirror of the cloud-metadata-URL post-filter
+                            # (see ``_emit_finding_if_allowed``).
+                            if (
+                                pat.id == "insecure_protocol_usage"
+                                and self._CLOUD_METADATA_URL_RE.search(variant)
+                            ):
+                                continue
 
                             # Mirror of the url_encoded_credentials
                             # post-filter (see _emit_finding_if_allowed).
@@ -5845,6 +5996,11 @@ class FileScanner:
         if pattern_obj.id == "insecure_protocol_usage" and 1 <= line_num <= len(all_lines):
             raw = all_lines[line_num - 1]
             if re.search(r"['\"]https?://[^'\"]*['\"]\s+is\s+(?:uri|url)\b", raw):
+                return
+            # Cloud instance-metadata-service endpoint - plaintext-
+            # only by spec; ``ssrf_to_cloud_metadata_service`` is the
+            # actionable finding, this regex would just be noise.
+            if self._CLOUD_METADATA_URL_RE.search(raw):
                 return
             # SPDX license header URL - canonical license-identifier
             # text, not a protocol choice.

--- a/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
+++ b/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
@@ -1034,6 +1034,42 @@ patterns:
     owasp_appsec: ["A04:2021", "A07:2021"]
     owasp_asvs: [V13.3.1, V14.1.1, V14.2.1]
 
+  - id: "plaintext_credential_key_var"
+    category: "hardcoded_credentials"
+    severity: "HIGH"
+    title: "Variable Named *_key Has Plaintext Credential-Shaped Value"
+    description: >-
+        A var whose name ends in ``_key`` is assigned a credential-shaped
+        string literal: 16+ chars of base64 / hex / UUID / token charset, no
+        path separators, no whitespace, not Jinja, not vault-encrypted. The
+        narrow ``api_key`` / ``private_key`` rules above miss the long tail
+        of vendor-specific ``*_key`` fields. Public-material keys
+        (``ssh_public_key``, ``gpg_key``, ``host_key``, ``public_key``,
+        ``verify_key``, ``verifying_key``) and keys whose value is a
+        filesystem path or URL are excluded.
+    regex: "^(?!\\s*#)\\s*(?!ssh_public_key|gpg_key|host_key|public_key|verify_key|verifying_key)[a-zA-Z_][a-zA-Z0-9_]*_key\\s*:\\s*[\"'](?!\\{\\{)(?!\\$ANSIBLE_VAULT)(?![~/.][/.])[A-Za-z0-9+/=_-]{16,}[\"']\\s*$"
+    positive_examples:
+      - "license_key: \"AAAAAAAAAAAAAAAAAAAA1234567890\""
+      - "encryption_key: \"YWJjZGVmZ2hpamtsbW5vcA==\""
+      - "hmac_key: \"0123456789abcdef0123456789abcdef\""
+    negative_examples:
+      - "license_key: \"{{ vault_license_key }}\""
+      - "encryption_key: \"{{ lookup('community.hashi_vault.hashi_vault', 'secret=app/key') }}\""
+      - "ssh_public_key: \"ssh-ed25519 AAAA...\""
+      - "gpg_key: \"https://example.com/RPM-GPG-KEY-vendor\""
+      - "host_key: \"/etc/ssh/ssh_host_ed25519_key.pub\""
+      - "license_key_file: \"/etc/licenses/app.lic\""
+    recommendation: "Treat the literal as a leaked secret: rotate the key at the issuing service, replace the value with a Vault-encrypted variable ({{ vault_<name> }}) or a secrets-manager lookup, and audit the service's access log for unauthorised use of the leaked key."
+    cwe: ["CWE-798", "CWE-259", "CWE-312"]
+    owasp_appsec: ["A07:2021", "A04:2021"]
+    owasp_asvs: [V13.2.3, V13.3.1, V14.1.1, V14.2.1]
+    mitre_attack: ["T1552.001"]
+    cis_controls: ["CIS-3.1", "CIS-Secrets"]
+    nist_controls: ['AC-3', 'IA-5', 'IA-5(7)', 'SC-28']
+    pci_dss: ['3.5.1', '8.3.6', '8.6.2']
+    hipaa: ['164.312(a)(2)(i)', '164.312(a)(2)(iv)', '164.312(d)']
+    soc2: ['C1.1', 'CC6.1']
+
   - id: "vault_id_hardcoded_in_plaintext"
     category: "hardcoded_credentials"
     severity: "MEDIUM"

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -285,6 +285,7 @@ rules_by_category:
     - okta_api_token_literal
     - openai_api_key_credential
     - paypal_braintree_token
+    - plaintext_credential_key_var
     - plaintext_password_should_be_vaulted
     - portainer_admin_password_hash_default_or_inline
     - postgresql_password_command

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -113,6 +113,27 @@
       ansible.builtin.shell: iptables -A INPUT -s 10.0.0.0/8 -j ACCEPT
       ignore_errors: true
 
+    # --- structural: ignore_errors_security_task (body-shape) ---
+    - name: configure remote service via api
+      ansible.builtin.uri:
+        url: "https://service.example.invalid/api/users/admin"
+        method: PUT
+        user: "admin"
+        password: "{{ admin_pw }}"
+        force_basic_auth: true
+        body_format: json
+        body:
+          username: admin
+          password: "{{ new_pw }}"
+        status_code: [200, 201]
+      ignore_errors: true
+
+    # --- structural: missing_no_log (key-path) ---
+    - name: read tls material into a fact
+      ansible.builtin.shell: |
+        cat /etc/ssl/private/server.key | base64 -w 0
+      register: tls_material
+
     # --- webhook_exposure.yml ---
     - name: Send to Slack webhook
       ansible.builtin.uri:


### PR DESCRIPTION
## Summary

- exclude cloud metadata service endpoints from `insecure_protocol_usage`; the actionable SSRF finding still fires on the same line
- new `plaintext_credential_key_var` rule for generic `*_key:` vars assigned a credential-shaped literal, with overlap groups deferring to existing vendor-specific rules
- shell tasks reading key material into a `register:` without `no_log: true` now trigger `missing_no_log`
- HTTP-fetch tasks carrying credential fields or auth headers in the body are classified as security-critical even when the task name is generic
- new overlap groups for SSH host-key bypass and root `authorized_keys` writes so the most actionable framing wins
- synthetic fixtures in `bad_example.yml` exercise the new detectors
