### PR TITLE
detect missing mode on credential file writes and secrets passed via argv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1092-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1093-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1092<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1093<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->529<!--/HIGH--> high, <!--MED-->131<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->530<!--/HIGH--> high, <!--MED-->131<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1092<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1093<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -160,6 +160,36 @@ _CRED_HEADER_NAMES: frozenset[str] = frozenset(
     {"authorization", "x-api-key", "x-auth-token", "x-vault-token"}
 )
 
+# Modules that materialise a destination file. Used by
+# ``credential_file_missing_mode`` to flag credential paths created
+# without an explicit mode (umask fallback is typically 0644).
+_FILE_WRITE_MODULES: frozenset[str] = frozenset(
+    {
+        "copy",
+        "ansible.builtin.copy",
+        "template",
+        "ansible.builtin.template",
+        "get_url",
+        "ansible.builtin.get_url",
+    }
+)
+
+# Destination paths that hold credentials, key material, TLS private
+# keys, kube/cluster configs, or vault tokens.
+_CREDENTIAL_DEST_PATH_RE: re.Pattern[str] = re.compile(
+    r"(?:"
+    r"\.(?:key|pem|pfx|p12|jks|keystore|p8|asc|kdbx|ovpn)\b"
+    r"|/\.ssh/(?:id_[a-z0-9_]+|authorized_keys)\b"
+    r"|/\.kube/config\b"
+    r"|/etc/kubernetes/(?:admin|kubelet)\.conf\b"
+    r"|/etc/(?:ssl|pki|tls)/private/"
+    r"|/etc/letsencrypt/(?:archive|live)/"
+    r"|(?:^|/)(?:credentials?|secrets?|vault[-_]token)"
+    r"(?:\.(?:ya?ml|json|env|conf|cfg|ini|txt))?$"
+    r")",
+    re.IGNORECASE,
+)
+
 # Rules whose entire purpose is to find things INSIDE YAML comments
 # (e.g. `# API_TOKEN=abc123` left in a review artefact). The universal
 # comment-line suppression in ``_emit_finding_if_allowed`` must not
@@ -2247,6 +2277,36 @@ class FileScanner:
                         snippet,
                     )
                 )
+
+            # File-write to a credential path with no explicit mode
+            if task_line:
+                for module_name in _FILE_WRITE_MODULES:
+                    block = task.get(module_name)
+                    if not isinstance(block, dict):
+                        continue
+                    dest = block.get("dest") or block.get("path")
+                    if not isinstance(dest, str) or not dest:
+                        continue
+                    if not _CREDENTIAL_DEST_PATH_RE.search(dest):
+                        continue
+                    if block.get("mode") not in (None, ""):
+                        break
+                    snippet = (
+                        self._ast_task_snippet(lines, task_line) if task_line <= len(lines) else ""
+                    )
+                    findings.append(
+                        self._make_finding(
+                            file_path,
+                            task_line,
+                            "credential_file_missing_mode",
+                            "HIGH",
+                            "Credential File Created Without Explicit Mode",
+                            "copy/template/get_url writes to a credential path without setting mode: - falls back to the remote's umask (typically 0644)",
+                            "Set mode: '0600' on the task; pair with owner: and group:.",
+                            snippet,
+                        )
+                    )
+                    break
 
             # GPU instance launch
             task_str = str(task)

--- a/src/ansible_security_scanner/patterns/command_injection.yml
+++ b/src/ansible_security_scanner/patterns/command_injection.yml
@@ -464,6 +464,37 @@ patterns:
     hipaa: ['164.312(a)(2)(i)', '164.312(a)(2)(iv)', '164.312(d)']
     soc2: ['C1.1', 'CC6.1']
 
+  - id: "secret_var_in_command_argv"
+    category: "command_injection"
+    severity: "HIGH"
+    title: "Secret-Shaped Shell Variable Interpolated Into Command Argv"
+    description: >-
+        A shell task interpolates a shell variable whose name suggests
+        secret material into an argv-revealing flag (-p, --patch, --data,
+        --from-literal, --password, --token, --key, --secret-string,
+        --set). Argv lands in /proc/<pid>/cmdline, ps output, shell
+        history, and audit logs - readable by every local user regardless
+        of the source file's mode bits.
+    regex: "(?:^|[\\s\"'])(?:-p|--patch|--data(?:-binary|-urlencode)?|--from-literal|--password|--token|--key|--secret(?:-string)?|--set(?:-string|-file)?)[\\s=][^\\n]{0,200}\\$\\{?(?:[A-Z][A-Z0-9_]*_(?:KEY|PASSWORD|PASSWD|PASS|PW|TOKEN|SECRET|API_KEY|PRIVATE_KEY|CREDENTIAL)|TLS_KEY|TLS_PRIVATE_KEY|API_TOKEN|API_KEY|AUTH_TOKEN|ACCESS_TOKEN|BEARER_TOKEN|VAULT_TOKEN|CLIENT_SECRET|PRIVATE_KEY)\\}?\\b"
+    multiline: true
+    window: 6
+    positive_examples:
+      - 'shell:kubectl patch secret foo -p "{\"data\":{\"tls.key\":\"$TLS_KEY\"}}"'
+      - 'shell:helm upgrade app --set creds.password=$DB_PASSWORD'
+    negative_examples:
+      - 'shell:kubectl apply -f - <<<"$MANIFEST"'
+      - 'shell:curl -H "Authorization: Bearer $TOKEN" https://api.example.com'
+    recommendation: "Stream the secret via stdin (`kubectl apply -f -`, `helm upgrade -f -`), pass it through an env var the tool reads natively, or point a `--*-file` flag at a mode-0600 file rendered from Ansible Vault. Never put the value on argv - `no_log` does not redact /proc/<pid>/cmdline."
+    cwe: ["CWE-214", "CWE-522", "CWE-532"]
+    owasp_appsec: ["A04:2021", "A07:2021", "A09:2021"]
+    owasp_asvs: [V13.2.3, V13.3.1, V14.3.2]
+    mitre_attack: ["T1552.001", "T1552.006"]
+    cis_controls: ["CIS-3.1", "CIS-3.11", "CIS-Secrets"]
+    nist_controls: ['AC-3', 'AC-6', 'IA-5', 'IA-5(7)', 'SC-28', 'AU-9']
+    pci_dss: ['3.5.1', '8.3.6', '8.6.2', '10.3.1']
+    hipaa: ['164.312(a)(2)(i)', '164.312(a)(2)(iv)', '164.312(d)']
+    soc2: ['C1.1', 'CC6.1', 'CC6.7']
+
   - id: "database_with_embedded_password"
     category: "command_injection"
     severity: "HIGH"

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -156,6 +156,7 @@ rules_by_category:
     - powershell_encoded_command
     - process_substitution
     - raw_encoded_powershell
+    - secret_var_in_command_argv
     - shell_pipe_to_interpreter
     - shell_inline_compound_command
     - subshell_execution
@@ -1130,6 +1131,7 @@ rules_by_category:
     - become_without_explicit_become_method_for_windows
     - connection_local_with_privilege_sensitive_module
     - copy_unsafe_writes_true
+    - credential_file_missing_mode
     - delegate_to_dynamic_host
     - delegate_to_localhost_run_as_remote
     - file_follow_true_with_become

--- a/src/ansible_security_scanner/synthetic_rule_frameworks.py
+++ b/src/ansible_security_scanner/synthetic_rule_frameworks.py
@@ -68,6 +68,17 @@ SYNTHETIC_RULE_FRAMEWORKS: dict[str, FrameworkTags] = {
         "soc2": ["CC7.2"],
         "owasp_appsec": ["A04:2021"],
     },
+    "credential_file_missing_mode": {
+        "cwe": ["CWE-276", "CWE-732", "CWE-200"],
+        "mitre_attack": ["T1222.002", "T1552.004"],
+        "cis_controls": ["CIS-3.3", "CIS-Secrets"],
+        "nist_controls": ["AC-3", "AC-6", "IA-5(7)", "SC-28"],
+        "pci_dss": ["3.5.1", "7.2.1", "8.6.2"],
+        "hipaa": ["164.312(a)(1)", "164.312(a)(2)(i)"],
+        "soc2": ["CC6.1", "CC6.3"],
+        "owasp_appsec": ["A01:2021", "A04:2021"],
+        "owasp_asvs": ["V5.3.1", "V14.2.2"],
+    },
     # Supply-chain: dynamic includes, URL-based pulls
     "include_role_from_url": {
         "cwe": ["CWE-829", "CWE-494"],

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -134,6 +134,22 @@
         cat /etc/ssl/private/server.key | base64 -w 0
       register: tls_material
 
+    # --- structural: credential_file_missing_mode ---
+    - name: write tls private key without explicit mode
+      ansible.builtin.copy:
+        dest: /etc/ssl/private/example.key
+        content: "{{ vault_tls_private_key }}"
+        owner: root
+        group: root
+
+    # --- structural: secret_var_in_command_argv ---
+    - name: patch secret via kubectl with key on argv
+      ansible.builtin.shell: |
+        TLS_KEY=$(cat /etc/ssl/private/example.key | base64 -w 0)
+        kubectl patch secret example -n default \
+          -p "{\"data\":{\"tls.key\":\"$TLS_KEY\"}}"
+      no_log: true
+
     # --- webhook_exposure.yml ---
     - name: Send to Slack webhook
       ansible.builtin.uri:


### PR DESCRIPTION
Two rules to close coverage gaps around credential exposure on managed nodes.

`credential_file_missing_mode` (AST, HIGH)
- Fires on `copy` / `template` / `get_url` tasks whose `dest:` (or `path:`) targets a credential, key, or token path and `mode:` is unset.
- Without an explicit mode, Ansible falls back to the remote's umask (typically `0644`), so private keys, kube configs, and vault tokens land world-readable.
- Recommendation: set `mode: '0600'` with explicit `owner:` and `group:`.

`secret_var_in_command_argv` (regex, HIGH)
- Fires on shell tasks that interpolate a secret-shaped shell variable (`TLS_KEY`, `*_PASSWORD`, `*_TOKEN`, `*_SECRET`, `*_API_KEY`, `*_PRIVATE_KEY`, ...) inside an argv-revealing flag: `-p`, `--patch`, `--data`, `--from-literal`, `--password`, `--token`, `--key`, `--secret-string`, `--set`.
- Argv ends up in `/proc/<pid>/cmdline`, `ps` output, shell history, and audit logs - `no_log` does not redact those sinks.
- Recommendation: stream via stdin, `--*-file` against a mode-0600 file, or an env var the tool reads natively.

Both rules are exercised by synthetic fixtures added to `tests/playbooks/bad_example.yml` and verified not to fire on `tests/playbooks/clean_example.yml`. Framework tags for the AST-only rule are registered in `synthetic_rule_frameworks.py`.