### PR TITLE
close regex bypasses and add ast rule for private key writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1093-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1100-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1093<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1100<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->530<!--/HIGH--> high, <!--MED-->131<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->536<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1093<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1100<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -190,6 +190,36 @@ _CREDENTIAL_DEST_PATH_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# Destination paths that resemble private-key / TLS-secret material
+# (filename-shape only - dest *prefix* is checked separately by
+# ``_INSECURE_KEY_DEST_PREFIX_RE``).
+_PRIVATE_KEY_DEST_RE: re.Pattern[str] = re.compile(
+    r"(?:"
+    r"id_(?:rsa|ed25519|ecdsa|dsa)\b"
+    r"|\.(?:key|pem|pfx|p12|jks|p8|ovpn)\b"
+    r"|(?:^|/)private[-_]?key"
+    r")",
+    re.IGNORECASE,
+)
+
+# Destination prefixes that are world-readable, world-writable, or
+# otherwise unsuitable as at-rest homes for private-key material.
+# Acceptable canonical homes are matched separately by
+# ``_CANONICAL_KEY_DEST_PREFIX_RE`` and short-circuit before this
+# check runs.
+_INSECURE_KEY_DEST_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"^(?:/tmp/|/var/tmp/|/dev/shm/|/home/root/|/srv/|/opt/|/mnt/|/media/|/data/|/var/log/|/var/cache/|/var/spool/)",
+    re.IGNORECASE,
+)
+
+# Destination prefixes that are acceptable canonical homes for
+# private-key material; a dest matching one of these short-circuits
+# the rule regardless of the filename shape.
+_CANONICAL_KEY_DEST_PREFIX_RE: re.Pattern[str] = re.compile(
+    r"(?:/\.ssh/|/etc/ssh/|/etc/ssl/private/|/etc/pki/tls/private/|/etc/pki/ca-trust/|/etc/letsencrypt/|/run/|/var/lib/)",
+    re.IGNORECASE,
+)
+
 # Rules whose entire purpose is to find things INSIDE YAML comments
 # (e.g. `# API_TOKEN=abc123` left in a review artefact). The universal
 # comment-line suppression in ``_emit_finding_if_allowed`` must not
@@ -584,7 +614,7 @@ _IP_URL_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 _INSECURE_PROTOCOL_URL_RE: re.Pattern[str] = re.compile(
-    r"(?:http|ftp|telnet)://(?!(?:localhost|127\.0\.0\.1|\[::1\])(?::|/))[^\s'\"]+",
+    r"(?:http|ftp|telnet|tftp|rsync)://(?!(?:localhost|127\.0\.0\.1|\[::1\])(?::|/))[^\s'\"]+",
     re.IGNORECASE,
 )
 
@@ -2303,6 +2333,47 @@ class FileScanner:
                             "Credential File Created Without Explicit Mode",
                             "copy/template/get_url writes to a credential path without setting mode: - falls back to the remote's umask (typically 0644)",
                             "Set mode: '0600' on the task; pair with owner: and group:.",
+                            snippet,
+                        )
+                    )
+                    break
+
+            # File-write of private-key / TLS-secret material to a non-canonical
+            # dest via copy/template/get_url (the native-module path that
+            # ``private_key_copied_outside_dot_ssh`` and
+            # ``tls_secret_downloaded_to_world_dir`` cannot reach because they
+            # only scan ``shell:`` / ``command:`` strings).
+            if task_line:
+                for module_name in _FILE_WRITE_MODULES:
+                    block = task.get(module_name)
+                    if not isinstance(block, dict):
+                        continue
+                    dest = block.get("dest") or block.get("path")
+                    if not isinstance(dest, str) or not dest:
+                        continue
+                    src = block.get("src") or block.get("url") or ""
+                    looks_like_key = bool(
+                        _PRIVATE_KEY_DEST_RE.search(dest)
+                        or (isinstance(src, str) and _PRIVATE_KEY_DEST_RE.search(src))
+                    )
+                    if not looks_like_key:
+                        continue
+                    if _CANONICAL_KEY_DEST_PREFIX_RE.search(dest):
+                        break
+                    if not _INSECURE_KEY_DEST_PREFIX_RE.search(dest):
+                        break
+                    snippet = (
+                        self._ast_task_snippet(lines, task_line) if task_line <= len(lines) else ""
+                    )
+                    findings.append(
+                        self._make_finding(
+                            file_path,
+                            task_line,
+                            "private_key_written_outside_canonical_dir_ast",
+                            "HIGH",
+                            "Private Key Or TLS Secret Written To A Non-Canonical Path",
+                            "copy/template/get_url writes private-key-shaped material (id_rsa, *.key, *.pem, privatekey) to a world-readable or non-canonical path (/tmp, /var/tmp, /dev/shm, /home/root, /srv, /opt, /mnt, /data, /var/log, /var/cache).",
+                            "Move the dest under the canonical home for the key type (`~/.ssh/` for SSH keys, `/etc/ssl/private/`, `/etc/pki/tls/private/`, or `/etc/letsencrypt/live/` for TLS), set `mode: '0600'`, `owner:`, and `group:` to the consuming service account.",
                             snippet,
                         )
                     )

--- a/src/ansible_security_scanner/patterns/command_injection.yml
+++ b/src/ansible_security_scanner/patterns/command_injection.yml
@@ -371,12 +371,29 @@ patterns:
     severity: "HIGH"
     title: "Curl with Hardcoded Credentials"
     description: >-
-        Task invokes curl -u 'user:password' with the credentials baked into the
-        playbook. The pair is visible in process listings and Ansible's verbose
-        output, defeating any vault elsewhere.
-    regex: "^(?!\\s*#)\\s*(?:ansible\\.builtin\\.)?(?:shell|command|raw):\\s*.*curl.*-u\\s+[\"'][^\"']*:[^\"']*[\"']"
+        Task invokes curl/wget/HTTPie with hardcoded basic-auth credentials, a
+        netrc file, or a -K config file containing user:password. The pair is
+        visible in process listings and Ansible's verbose output, defeating any
+        vault elsewhere.
+    regex: "^(?!\\s*#)\\s*(?:-\\s+)?(?:name\\s*:[^\\n]*\\n\\s*(?:-\\s+)?)?(?:ansible\\.builtin\\.)?(?:shell|command|raw|win_shell|win_command):[\\s\\S]{0,200}?(?:curl|wget|http(?:ie)?)\\s+[^\\n]*?(?:-u|--user|-a|--auth)(?:\\s+|=)['\"]?[A-Za-z0-9._@%+-]+:[^\\s'\"\\n{=][^\\s'\"\\n{]*['\"]?|^(?!\\s*#)\\s*(?:-\\s+)?(?:name\\s*:[^\\n]*\\n\\s*(?:-\\s+)?)?(?:ansible\\.builtin\\.)?(?:shell|command|raw|win_shell|win_command):[\\s\\S]{0,300}?wget\\s+[^\\n]*?--user(?:\\s+|=)['\"]?[A-Za-z0-9._@%+-]+['\"]?[^\\n]*?--password(?:\\s+|=)['\"]?[^\\s'\"\\n{=][^\\s'\"\\n{]*['\"]?|^(?!\\s*#)\\s*(?:-\\s+)?(?:name\\s*:[^\\n]*\\n\\s*(?:-\\s+)?)?(?:ansible\\.builtin\\.)?(?:shell|command|raw):[\\s\\S]{0,200}?curl\\s+[^\\n]*?(?:-K\\s+[^\\s'\"\\n{=]\\S*|--netrc(?:-file)?\\b)"
     positive_examples:
-      - 'shell:curl-u ":"'
+      - "shell: curl -u \"admin:secret\" https://example.com/"
+      - "shell: curl -u admin:secret https://example.com/"
+      - "shell: curl --user admin:secret https://example.com/"
+      - "shell: curl --user=admin:secret https://example.com/"
+      - "shell: curl -K /etc/curl-creds.cfg https://example.com/"
+      - "shell: curl --netrc https://example.com/"
+      - "shell: curl --netrc-file /tmp/netrc https://example.com/"
+      - "shell: http -a admin:secret https://example.com/"
+      - "shell: wget --user=admin --password=secret https://example.com/"
+      - "shell: wget --user admin --password secret https://example.com/"
+      - "command: curl --user=admin:secret https://example.com/"
+    negative_examples:
+      - "shell: curl -u \"{{ user }}:{{ pw }}\" https://example.com/"
+      - "shell: curl -u \"admin:{{ vault_pw }}\" https://example.com/"
+      - "shell: curl https://example.com/"
+      - "shell: wget --user=admin --password={{ vault_pw }} https://example.com/"
+      - "shell: curl -K {{ creds_file }} https://example.com/"
     recommendation: "Move the username:password out of curl -u into the calling module: ansible.builtin.uri url_username: / url_password: (or community.general.curl with separate secret args), and source the credential from Ansible Vault."
     cwe: ["CWE-312", "CWE-798"]
     owasp_appsec: ["A04:2021", "A07:2021"]
@@ -494,6 +511,41 @@ patterns:
     pci_dss: ['3.5.1', '8.3.6', '8.6.2', '10.3.1']
     hipaa: ['164.312(a)(2)(i)', '164.312(a)(2)(iv)', '164.312(d)']
     soc2: ['C1.1', 'CC6.1', 'CC6.7']
+
+  - id: "secret_piped_to_text_processor"
+    category: "command_injection"
+    severity: "MEDIUM"
+    title: "Secret Manager Output Piped Through External Text Processor"
+    description: >-
+        A shell task fetches material from a secret store
+        (`aws secretsmanager get-secret-value`, `gcloud secrets versions
+        access`, `az keyvault secret show`, `vault kv get`, `op read`,
+        `bw get password`) and pipes the result through `jq`, `awk`,
+        `sed`, `grep`, `cut`, or `tr`. Even with `no_log: true`, the
+        secret crosses argv and process memory of every command in the
+        pipe; auditd `execve` records, `bash -x`, `set -x`, and
+        `strace -f` all capture the value. Use the corresponding lookup
+        plugin or query syntax built into the CLI so the value never
+        leaves the privileged process.
+    regex: "(?:(?:aws\\s+secretsmanager\\s+get-secret-value|gcloud\\s+secrets\\s+versions\\s+access|az\\s+keyvault\\s+secret\\s+show|vault\\s+kv\\s+get|vault\\s+read|op\\s+read|bw\\s+get\\s+password|kubectl\\s+get\\s+secret\\s+[^\\n]*?-o\\s*(?:json|yaml|jsonpath))[\\s\\S]{0,400}\\|\\s*(?:jq|awk|sed|grep|cut|tr|head|tail|tee|xargs|xxd|base32|base64|od|python3?\\s+-c)\\b|(?:aws\\s+secretsmanager\\s+get-secret-value|gcloud\\s+secrets\\s+versions\\s+access|az\\s+keyvault\\s+secret\\s+show|vault\\s+kv\\s+get|vault\\s+read|op\\s+read|bw\\s+get\\s+password|kubectl\\s+get\\s+secret\\s+[^\\n]*?-o\\s*(?:json|yaml|jsonpath))[\\s\\S]{0,400}>\\s*(?:/tmp/|/var/tmp/|/dev/shm/)[\\s\\S]{0,200}?(?:jq|awk|sed|grep|cut|python3?\\s+-c)\\b)"
+    multiline: true
+    window: 6
+    positive_examples:
+      - "shell: aws secretsmanager get-secret-value --secret-id app | jq -r '.SecretString'"
+      - "shell: vault kv get -format=json secret/app | jq -r .data.data.password"
+      - "shell: kubectl get secret app -o jsonpath='{.data.password}' | base64 -d"
+    negative_examples:
+      - "shell: aws secretsmanager get-secret-value --secret-id app --query SecretString --output text"
+    recommendation: "Use the native query/format option of the secret-store CLI (`--query`, `--format=value(...)`, `-field=`, `-o jsonpath`) and route the value into stdin / an env var of the consuming process. For Ansible, prefer the matching lookup plugin (`community.aws.aws_secret`, `community.hashi_vault.vault_kv2_get`, `community.general.onepassword`) so the secret never crosses a shell pipeline."
+    cwe: ["CWE-214", "CWE-532"]
+    owasp_appsec: ["A09:2021"]
+    owasp_asvs: [V13.2.3, V14.3.2]
+    mitre_attack: ["T1552.001"]
+    cis_controls: ["CIS-3.11", "CIS-Secrets"]
+    nist_controls: ['AU-9', 'IA-5', 'SC-28']
+    pci_dss: ['8.6.2', '10.3.1']
+    hipaa: ['164.312(a)(2)(i)']
+    soc2: ['CC6.1', 'CC7.2']
 
   - id: "database_with_embedded_password"
     category: "command_injection"

--- a/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
+++ b/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
@@ -93,18 +93,27 @@ patterns:
     severity: "CRITICAL"
     title: "AWS Access Key"
     description: >-
-        Matches the AWS Access Key ID format (AKIA + 16 base32 chars). An exposed
-        AKIA key is the public half of a credential pair and is routinely paired
-        with a leaked secret in the same file.
-    regex: "\\bAKIA[0-9A-Z]{16}\\b"
+        Matches an AWS Access Key ID: long-term IAM user keys (AKIA + 16 base32)
+        or temporary STS session credentials (ASIA + 16 base32). Both are the
+        public half of a credential pair and routinely co-located with a leaked
+        secret access key in the same file. Resource IDs (AROA / AIDA / ANPA /
+        AGPA) are intentionally excluded - they are not secrets, only ARN
+        components, and including them produces false positives on legitimate
+        IAM role/user/policy references.
+    regex: "\\b(?:AKIA|ASIA)[0-9A-Z]{16}\\b"
     positive_examples:
       - "aws_access_key_id: AKIAIOSFODNN7EXAMPLE"
       - "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
       - "key: 'AKIA1234567890ABCDEF'"
+      - "aws_session_token_id: ASIAIOSFODNN7EXAMPLE"
+      - "key: 'ASIA1234567890ABCDEF'"
     negative_examples:
       - "key: AKIASHORT"
       - "variable: AKIAIOSFODNN7EXAMPLETOOLONG"
       - "aws_access_key_id: \"{{ vault_aws_access_key }}\""
+      - "iam_role_id: AROA1234567890ABCDEF"
+      - "iam_user_id: AIDA1234567890ABCDEF"
+      - "managed_policy_id: ANPA1234567890ABCDEF"
     recommendation: "Treat the AKIA... key as compromised: deactivate it in IAM, create a replacement (or migrate the workload to an IAM Role / instance profile), and audit CloudTrail for unauthorised API calls bearing this access key id."
     cwe: ["CWE-798"]
     owasp_appsec: ["A07:2021"]
@@ -1019,10 +1028,31 @@ patterns:
     category: "hardcoded_credentials"
     severity: "HIGH"
     title: "Variable Named *password/*secret/*token Has Plaintext Value"
-    description: "A var with a name that screams 'secret' (db_password, api_token, jwt_secret, private_key) is assigned a literal non-Jinja, non-vault value in a playbook or vars file - the secret sits in plaintext in version control."
-    regex: "^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:password|passwd|_pw|_pass|secret|token|api_key|apikey|private_key)\\s*:\\s*['\"](?!{{)(?!\\$ANSIBLE_VAULT)[^'\"\\n]{4,}['\"]"
+    description: "A var with a name that screams 'secret' (db_password, api_token, jwt_secret, private_key, aws_secret_access_key, rootpw, svc_creds) is assigned a literal non-Jinja, non-vault, non-`!vault`-tagged value - the secret sits in plaintext in version control. Both quoted and unquoted YAML scalars are flagged. Path/file aliases (`*_file`, `*_url`) are intentionally excluded - they reference where a credential lives, not the credential itself."
+    regex: "^\\s*(?:[A-Za-z][A-Za-z0-9_]*?)?(?:password|passwd|secret|token|apikey|credentials?|api[-_]key|private[-_]?key|secret[-_]?key|access[-_]?key|secret[-_]?token|root_?pw|db_?pw|svc_?pw|admin_?pw|user_?pw|sa_?pw|sys_?pw|_pw|_pass|_key|_creds?)(?=\\s*:)\\s*:\\s*(?:['\"](?!{{)(?!\\$ANSIBLE_VAULT)(?!!vault\\b)[^'\"\\n]{4,}['\"]|(?!['\"\\[\\{\\|>!])(?!\\{\\{)(?!\\$ANSIBLE_VAULT)(?!(?:true|false|yes|no|on|off|null|none|~|\\d+(?:\\.\\d+)?)\\b\\s*(?:#|$))[^\\s'\"\\n#]{4,}[^\\s\\n#]*)"
     positive_examples:
       - "clientSecret: \"**********\""
+      - "db_password: 'hunter2'"
+      - "api_token: \"abc1234xyz\""
+      - "private_key: 'ssh-rsa-content'"
+      - "aws_secret_access_key: 'foobarbaz'"
+      - "rootpw: changeme123"
+      - "svc_creds: hardcoded123"
+      - "admin_credentials: x123456"
+      - "registry_apikey: rEALsEcret123"
+    negative_examples:
+      - "db_password: '{{ vault_db_password }}'"
+      - "db_password: \"{{ vault_db_password }}\""
+      - "db_password: !vault |"
+      - "name: password"
+      - "description: password retrieval"
+      - "password_file: /etc/.creds"
+      - "vault_password_file: /etc/vault.pw"
+      - "token_url: https://example.com"
+      - "automountServiceAccountToken: false"
+      - "auth_token: yes"
+      - "expires_token: 3600"
+      - "api_key: null"
     recommendation: "Move the value to a vault-encrypted file (ansible-vault encrypt_string) and reference it via {{ vault_varname }}. Never commit literal secrets."
     cis_controls: ["CIS-Secrets"]
     nist_controls: ['IA-5', 'IA-5(1)', 'IA-5(7)', 'SC-28']
@@ -1919,3 +1949,28 @@ patterns:
     nist_controls: ['AU-9', 'IA-5', 'SC-28']
     pci_dss: ['8.6.2', '10.3.1']
     soc2: ['CC6.1', 'CC7.2']
+
+  - id: "factory_default_credential_in_basic_auth"
+    category: "hardcoded_credentials"
+    severity: "HIGH"
+    title: "Factory-Default Credential Passed to curl/wget Basic Auth"
+    description: "A `curl -u`, `curl --user`, `wget --user`/`--password`, or `http --auth` invocation passes a known vendor factory-default credential as the password component. Vendor first-boot credentials are public knowledge (CIRT.net default-password database, NIST 800-53 baseline checks); reusing them in automation against a deployed appliance leaves the appliance authenticatable with a credential listed in every default-password database. Tokens covered include enterprise-appliance defaults (`welcome`, `changeit`, `tigertiger`, `procurve`, `calvin`, `PASSW0RD`, `ADMIN`, `cisco`, `c1sco12345`, `tomcat`, `ubnt`, `mikrotik`, `pfsense`, `vagrant`, `raspberry`, `changeme`) and the generic top-of-list passwords (`password`, `123456`, `12345678`, `qwerty`, `letmein`, `toor`, `admin123`, `Admin@123`, `Passw0rd`, `P@ssw0rd`, `monitor`, `support`, `service`)."
+    regex: "(?:curl|wget|http(?:ie)?)\\s+[^\\n]*?(?:-u|--user|-a|--auth)[\\s=]['\"]?[^\\s:'\"]*?:(?:welcome|changeme|changeit|tigertiger|procurve|cisco|c1sco12345|calvin|PASSW0RD|ADMIN|ipmi|tomcat|ubnt|mikrotik|pfsense|vagrant|raspberry|password|password1|password123|123456|12345678|qwerty|letmein|default|secret|toor|admin123|Admin@123|Passw0rd|P@ssw0rd|monitor|support|service|public|private)['\"]?(?=\\s|['\"]|$)|(?:curl|wget|http(?:ie)?)\\s+[^\\n]*?--password[\\s=]['\"]?(?:welcome|changeme|changeit|tigertiger|procurve|cisco|c1sco12345|calvin|PASSW0RD|ADMIN|ipmi|tomcat|ubnt|mikrotik|pfsense|vagrant|raspberry|password|password1|password123|123456|12345678|qwerty|letmein|default|secret|toor|admin123|Admin@123|Passw0rd|P@ssw0rd|monitor|support|service|public|private)['\"]?(?=\\s|['\"]|$)"
+    positive_examples:
+      - "curl -u admin:welcome https://controller.example/api"
+      - "wget --user=admin --password=changeme https://device.example/"
+    negative_examples:
+      - "curl -u admin:{{ vault_admin_password }} https://controller.example/api"
+      - "curl -u admin:$ADMIN_PASSWORD https://controller.example/api"
+    multiline: true
+    window: 4
+    recommendation: "Replace the factory default with a freshly-rotated credential sourced from a secret manager and pass it via stdin / a netrc file rather than the command line so it does not appear in `ps`, audit logs, or shell history. The factory password should be rotated as part of first-boot and never reused for subsequent automation."
+    cwe: ['CWE-521', 'CWE-798']
+    owasp_appsec: ["A07:2021"]
+    owasp_asvs: [V2.1.1, V2.1.2]
+    mitre_attack: ['T1078.001', 'T1110.001']
+    cis_controls: ['CIS-4.7', 'CIS-5.2']
+    nist_controls: ['IA-5', 'IA-5(1)']
+    pci_dss: ['2.2.2', '8.3.5']
+    hipaa: ['164.308(a)(5)(ii)(D)']
+    soc2: ['CC6.1']

--- a/src/ansible_security_scanner/patterns/insecure_communication.yml
+++ b/src/ansible_security_scanner/patterns/insecure_communication.yml
@@ -53,8 +53,8 @@ patterns:
     category: "insecure_communication"
     severity: "MEDIUM"
     title: "Insecure Protocol Usage"
-    description: "An Ansible task value (url, dest, repo, src) references http://, ftp://, or telnet:// for content that is not signature-validated. URLs inside comments, license headers, doc text, and apt_key:/apt_repository: invocations (which are GPG-validated by the package manager) are filtered out post-match."
-    regex: "\\b(?:http|ftp|telnet)://(?!(?:localhost|127\\.0\\.0\\.1|\\[::1\\])(?::|/))"
+    description: "An Ansible task value (url, dest, repo, src) references http://, ftp://, telnet://, tftp://, or rsync:// for content that is not signature-validated. None of these schemes encrypt traffic; tftp and rsync (the rsync:// daemon protocol, not rsync-over-ssh) additionally have no built-in authentication. URLs inside comments, license headers, doc text, and apt_key:/apt_repository: invocations (which are GPG-validated by the package manager) are filtered out post-match."
+    regex: "\\b(?:http|ftp|telnet|tftp|rsync)://(?!(?:localhost|127\\.0\\.0\\.1|\\[::1\\])(?::|/))"
     positive_examples:
       - |2-
             - name: fetch config
@@ -65,6 +65,14 @@ patterns:
               ansible.builtin.get_url:
                 url: http://files.example.com/payload.tar.gz
                 dest: /tmp/p.tgz
+      - |2-
+            - name: tftp boot image (no auth, no encryption)
+              ansible.builtin.get_url:
+                url: tftp://boot.example.com/img.bin
+                dest: /var/lib/img.bin
+      - |2-
+            - name: rsync daemon (no encryption)
+              ansible.builtin.shell: rsync -av rsync://mirror.example.com/repo /srv/repo
     negative_examples:
       - |2-
             - name: fetch via https
@@ -93,9 +101,19 @@ patterns:
         verify_ssl / ssl_verify / check_ssl / validate_certs is set to false/no/0.
         Disabling cert validation defeats TLS's identity guarantee and reduces
         transport security to encryption alone.
-    regex: "(?:verify_ssl|ssl_verify|check_ssl|validate_certs):\\s*(?:false|no|0)"
+    regex: "(?:verify_ssl|ssl_verify|check_ssl|validate_certs)\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#)"
     positive_examples:
       - "validate_certs: false"
+      - "validate_certs: 'no'"
+      - "validate_certs: \"false\""
+      - "validate_certs: 0"
+      - "validate_certs: off"
+      - "verify_ssl: No"
+      - "ssl_verify: false  # legacy"
+    negative_examples:
+      - "validate_certs: true"
+      - "validate_certs: 'true'"
+      - "validate_certs: yes"
     recommendation: "Remove validate_certs: false / verify_ssl: false; if the endpoint uses an internal CA, distribute that CA bundle to the controller and pass it via ca_path: rather than disabling verification."
     cwe: ["CWE-295", "CWE-297"]
     owasp_appsec: ["A07:2021"]
@@ -344,7 +362,7 @@ patterns:
     # and also hit a local admin endpoint later. Anchor on ``helm repo
     # add`` / ``helm_repository`` and allow only a short
     # same-line / args-block window to the insecure token.
-    regex: "helm\\s+repo\\s+add\\s+[^\\n]*?(?:\\s+http://|--insecure-skip-tls-verify)|kubernetes\\.core\\.helm_repository:[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n){0,8}?[ \\t]+(?:url\\s*:\\s*['\"]?http://|validate_certs\\s*:\\s*(?:false|no))"
+    regex: "helm\\s+repo\\s+add\\s+[^\\n]*?(?:\\s+http://|--insecure-skip-tls-verify)|kubernetes\\.core\\.helm_repository:[^\\n]*\\n(?:[ \\t]+[^\\n]*\\n){0,8}?[ \\t]+(?:url\\s*:\\s*['\"]?http://|validate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#))"
     multiline: true
     window: 10
     positive_examples:
@@ -692,6 +710,30 @@ patterns:
     mitre_attack: ['T1557', 'T1557.002']
     cis_controls: ['CIS-3.10', 'CIS-12.6']
     nist_controls: ['SC-8', 'SC-8(1)']
+    pci_dss: ['4.2.1']
+    hipaa: ['164.312(e)(1)']
+    soc2: ['CC6.7']
+
+  - id: "shell_ssh_scp_strict_host_key_disabled"
+    category: "insecure_communication"
+    severity: "HIGH"
+    title: "shell ssh / scp / sftp Invoked With StrictHostKeyChecking=no"
+    description: "An `ansible.builtin.shell` or `ansible.builtin.command` task runs `ssh`, `scp`, `sftp`, or `rsync -e ssh` with `-o StrictHostKeyChecking=no` (or `=accept-new`/`=off`), or sets `UserKnownHostsFile=/dev/null`. This bypasses SSH host-identity verification and accepts whatever key the remote sends - any on-path attacker can sit between the controller and the target and read or modify every byte of the session, including private-key transfers. The existing `ssh_args_disable_host_key` rule only catches the Ansible `ansible_ssh_common_args` variable; this catches the shell-level invocation that Ansible's SSH layer never sees."
+    regex: "(?m)^\\s*(?:-\\s+)?(?:ansible\\.builtin\\.)?(?:shell|command):\\s*(?=[|>]|\\S)[\\s\\S]{0,600}?(?:ssh|scp|sftp|rsync\\s+[^\\n]*?-e\\s+['\"]?ssh)\\s+[^\\n]*?(?:-o\\s*StrictHostKeyChecking\\s*=\\s*(?:no|off|accept-new|0|false)|-o\\s*UserKnownHostsFile\\s*=\\s*/dev/null|-F\\s+(?:/tmp/|/var/tmp/|/dev/shm/))\\b"
+    multiline: true
+    window: 10
+    positive_examples:
+      - "shell: scp -o StrictHostKeyChecking=no /etc/ssl/private/server.key root@host:/etc/ssl/private/server.key"
+      - "shell: ssh -o StrictHostKeyChecking=no root@host 'systemctl restart app'"
+    negative_examples:
+      - "shell: ssh -o UserKnownHostsFile=/etc/ssh/ssh_known_hosts root@host 'uptime'"
+    recommendation: "Pre-populate `~/.ssh/known_hosts` (or `/etc/ssh/ssh_known_hosts`) from a trusted source (`ssh-keyscan` over a side channel, SSHFP DNS records under DNSSEC, or a configuration-management distribution) before the playbook runs, then leave `StrictHostKeyChecking=yes` (the default). For ephemeral fleets, use SSH certificates with `@cert-authority` lines so individual host keys do not need to be pre-known."
+    cwe: ['CWE-295', 'CWE-322']
+    owasp_appsec: ["A02:2021", "A07:2021"]
+    owasp_asvs: [V9.2.1, V9.2.3]
+    mitre_attack: ['T1557']
+    cis_controls: ['CIS-3.10', 'CIS-12.6']
+    nist_controls: ['SC-8', 'SC-8(1)', 'SC-23']
     pci_dss: ['4.2.1']
     hipaa: ['164.312(e)(1)']
     soc2: ['CC6.7']
@@ -1307,13 +1349,34 @@ patterns:
     severity: "HIGH"
     title: "ansible.builtin.uri With validate_certs: false (Disables TLS Certificate Validation)"
     description: "An `ansible.builtin.uri` / `uri` task sets `validate_certs: false`. Every HTTPS request issued by the module proceeds even when the peer's TLS certificate is expired, self-signed, hostname-mismatched, or signed by a chain the system doesn't trust. Any on-path attacker can present their own certificate and the Ansible control node will POST credentials, tokens, secret-values, or PII directly to them. This is the #1 source of credential leakage in Ansible-driven CI pipelines (2023 GitLab-CI data showed 38% of `uri:` tasks in public repos had this misconfiguration)."
-    regex: "(?ms)(?:ansible\\.builtin\\.uri|^[\\t ]*uri)\\s*:[\\s\\S]{0,1500}?\\bvalidate_certs\\s*:\\s*(?:false|False|no|No|0)\\b"
+    regex: "(?ms)(?:ansible\\.builtin\\.uri|^[\\t ]*uri)\\s*:[\\s\\S]{0,1500}?\\bvalidate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#)"
     positive_examples:
       - |2-
         uri:
             url: "{{ url }}/admin/"
             status_code: 200
             validate_certs: false
+      - |2-
+        uri:
+            url: "{{ url }}/admin/"
+            validate_certs: 'no'
+      - |2-
+        ansible.builtin.uri:
+            url: "{{ url }}/admin/"
+            validate_certs: "false"
+      - |2-
+        uri:
+            url: "{{ url }}/api"
+            validate_certs: 0
+    negative_examples:
+      - |2-
+        uri:
+            url: "{{ url }}/admin/"
+            validate_certs: true
+      - |2-
+        uri:
+            url: "{{ url }}/admin/"
+            validate_certs: 'true'
     multiline: true
     window: 40
     recommendation: "Remove `validate_certs: false`. For genuine self-signed endpoints (internal CAs), pass `ca_path: /etc/pki/ca-trust/source/anchors/internal.crt` instead; for test endpoints, use `--tags test` gating rather than permanently disabling validation. Audit with `grep -rn 'validate_certs:\\s*false' playbooks/ roles/`."

--- a/src/ansible_security_scanner/patterns/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/operational_security.yml
@@ -652,6 +652,32 @@ patterns:
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
 
+  # -- Password Expiry Disabled -----------------------------------------------
+
+  - id: "password_expiry_disabled"
+    category: "operational_security"
+    severity: "HIGH"
+    title: "Account Password Expiry Disabled"
+    description: "A task disables password aging on a Linux account: `chage -M -1`, `chage -M 99999`, `chage -E -1`, `passwd -x -1`, `passwd -x 99999`, `usermod -e ''`, or `usermod -e 1`. Removing expiry on a privileged or service account defeats periodic-rotation controls and is a common persistence move after credential theft."
+    regex: "(?:chage\\s+[^\\n]*?(?:-[ME][\\s=]+(?:-1|9{4,5}\\b)|--(?:maxdays|expiredate)[\\s=]+(?:-1|9{4,5}\\b))|passwd\\s+[^\\n]*?-x[\\s=]+(?:-1|9{4,5}\\b)|usermod\\s+[^\\n]*?-e[\\s=]+(?:''|\"\"|-1|1\\b))"
+    positive_examples:
+      - "chage -M 99999 svc_user"
+      - "passwd -x -1 svc"
+      - "usermod -e '' svc"
+    negative_examples:
+      - "chage -M 90 svc_user"
+      - "passwd -x 90 svc"
+    recommendation: "Keep aging enabled. For human accounts pin `PASS_MAX_DAYS` to a policy value (commonly 90) in `/etc/login.defs`; for service accounts use short-lived credentials from a secret manager or a CA-signed-key flow rather than disabling expiry. Audit with `chage -l <user>` and `awk -F: '($5==\"\" || $5>365)' /etc/shadow` (root-only)."
+    cwe: ['CWE-262', 'CWE-521']
+    mitre_attack: ['T1098', 'T1098.004']
+    cis_controls: ['CIS-5.2', 'CIS-5.3']
+    nist_controls: ['IA-5', 'AC-2']
+    pci_dss: ['8.3.9']
+    hipaa: ['164.308(a)(5)(ii)(D)']
+    soc2: ['CC6.1', 'CC6.2']
+    owasp_appsec: ["A07:2021"]
+    owasp_asvs: [V2.1.1, V2.1.2]
+
   # -- Proxy Credential Exposure ----------------------------------------------
 
   - id: "proxy_credential_exposure"

--- a/src/ansible_security_scanner/patterns/privilege_escalation.yml
+++ b/src/ansible_security_scanner/patterns/privilege_escalation.yml
@@ -145,10 +145,22 @@ patterns:
     category: "privilege_escalation"
     severity: "HIGH"
     title: "World-Writable Permissions on Sensitive Path"
-    description: "Setting 777/666 or o+w on system paths enables privilege escalation"
-    regex: "(?:mode:\\s*[\"']?0?(?:777|666)[\"']?|chmod\\s+(?:-R\\s+)?(?:777|666|o\\+w))"
+    description: "Setting any world-writable mode (octal ending in 2/3/6/7, symbolic +w / o+w / a+w / ugo+w / o=rwx) on system paths or invoking chmod / setfacl with those forms enables privilege escalation: any local user can replace the file's contents."
+    regex: "mode\\s*:\\s*['\"]?(?:0?[0-7]{2}[2367]|[2367])['\"]?(?=\\s|$|#|,)|chmod\\s+(?:-[A-Za-z]+\\s+)*['\"]?(?:0?[0-7]{2}[2367]|[2367])\\b|(?:mode\\s*:\\s*['\"]?|chmod\\s+(?:-[A-Za-z]+\\s+)*)(?:(?=[ugoa]*[oa])[ugoa]+\\+w|(?<![ugoa])\\+w(?=[\\s'\"]))|(?:mode\\s*:\\s*['\"]?|chmod\\s+(?:-[A-Za-z]+\\s+)*)(?:(?=[ugoa]*[oa])[ugoa]+=[rxw]*w[rxw]*)|setfacl\\s+[^\\n]*?-m\\s+[^\\n]*?o:[rxw]*w[rxw]*"
     positive_examples:
       - "mode: \"0777\""
+      - "mode: '0666'"
+      - "mode: 'a+w'"
+      - "mode: 'o+w'"
+      - "mode: 'ugo+w'"
+      - "chmod 666 /etc/sudoers.d/foo"
+      - "chmod a+w /etc/sudoers.d/foo"
+      - "chmod o=rwx /etc/cron.d/job"
+    negative_examples:
+      - "mode: '0750'"
+      - "mode: 'g+w'"
+      - "chmod g+w /etc/x"
+      - "chmod u+x /usr/local/bin/x"
     recommendation: "Replace 0777 / 0666 / o+w with the least-permissive mode that still satisfies the workload (typically 0640 for files and 0750 for directories), and use group ownership rather than world-write to share access between services."
     cwe: ['CWE-732']
     owasp_asvs: [V5.3.1]

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -2607,12 +2607,25 @@ patterns:
     severity: "HIGH"
     title: "ansible.builtin.yum With validate_certs: false (Disables Mirror TLS Validation)"
     description: "An `ansible.builtin.yum` / `yum` task sets `validate_certs: false`. Yum will fetch repo metadata and RPM packages from the configured mirror URLs without verifying the mirror's TLS certificate chain. Any on-path attacker (rogue WiFi, ARP-spoof, compromised CDN edge, malicious VPN gateway) can swap out RPMs for trojanized versions before they reach the target host - especially dangerous because RPMs execute pre/post install scriptlets as root."
-    regex: "(?ms)(?:ansible\\.builtin\\.yum|^[\\t ]*yum)\\s*:[\\s\\S]{0,800}?\\bvalidate_certs\\s*:\\s*(?:false|False|no|No|0)\\b"
+    regex: "(?ms)(?:ansible\\.builtin\\.yum|^[\\t ]*yum)\\s*:[\\s\\S]{0,800}?\\bvalidate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#)"
     positive_examples:
       - |2-
         yum:
                 # ...
                 validate_certs: false
+      - |2-
+        yum:
+                name: foo
+                validate_certs: 'no'
+      - |2-
+        ansible.builtin.yum:
+                name: foo
+                validate_certs: "false"
+    negative_examples:
+      - |2-
+        yum:
+                name: foo
+                validate_certs: true
     multiline: true
     window: 30
     recommendation: "Remove `validate_certs: false` from every yum task. If your internal mirror genuinely uses a self-signed cert, distribute the CA bundle via `ansible.builtin.copy` into `/etc/pki/ca-trust/source/anchors/` + `ansible.builtin.command: update-ca-trust` - never disable validation. Pair with GPG validation (`disable_gpg_check: false`, which is the default) and pin repos with `gpgcheck=1` + `repo_gpgcheck=1` in the `.repo` file."
@@ -2631,12 +2644,25 @@ patterns:
     severity: "HIGH"
     title: "ansible.builtin.yum With sslverify: false (Disables Repo-Level SSL Verification)"
     description: "An `ansible.builtin.yum` / `yum` task sets `sslverify: false`. This writes `sslverify=0` into the repo config, disabling SSL verification of the mirror URLs at the yum-daemon level (lower in the stack than `validate_certs:`, and harder to audit after the fact because it persists in `/etc/yum.repos.d/*.repo`). Equivalent to making every subsequent `yum install` vulnerable to mirror-swap attacks, not just this one task."
-    regex: "(?ms)(?:ansible\\.builtin\\.yum|^[\\t ]*yum)\\s*:[\\s\\S]{0,800}?\\bsslverify\\s*:\\s*(?:false|False|no|No|0)\\b"
+    regex: "(?ms)(?:ansible\\.builtin\\.yum|^[\\t ]*yum)\\s*:[\\s\\S]{0,800}?\\bsslverify\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#)"
     positive_examples:
       - |2-
         ansible.builtin.yum:
                     # ...
                     sslverify: False
+      - |2-
+        yum:
+                    name: foo
+                    sslverify: 'no'
+      - |2-
+        ansible.builtin.yum:
+                    name: foo
+                    sslverify: "false"
+    negative_examples:
+      - |2-
+        yum:
+                    name: foo
+                    sslverify: true
     multiline: true
     window: 30
     recommendation: "Remove `sslverify: false` from yum tasks. For self-signed internal mirrors: distribute the CA bundle to `/etc/pki/ca-trust/source/anchors/` and run `update-ca-trust`. Audit existing hosts with `ansible -m shell -a 'grep -rE \"^sslverify\\s*=\\s*0\" /etc/yum.repos.d/'`."
@@ -2680,12 +2706,25 @@ patterns:
     severity: "HIGH"
     title: "ansible.builtin.dnf With validate_certs: false (Disables Mirror TLS Validation)"
     description: "An `ansible.builtin.dnf` / `dnf` task sets `validate_certs: false`. DNF fetches repo metadata and RPMs without TLS certificate-chain validation on the configured mirror URLs. Equivalent risk to `yum_validate_certs_false` - MITM-mirror-swap attacks deliver trojanized packages that execute root-level scriptlets on install."
-    regex: "(?ms)(?:ansible\\.builtin\\.dnf|^[\\t ]*dnf)\\s*:[\\s\\S]{0,800}?\\bvalidate_certs\\s*:\\s*(?:false|False|no|No|0)\\b"
+    regex: "(?ms)(?:ansible\\.builtin\\.dnf|^[\\t ]*dnf)\\s*:[\\s\\S]{0,800}?\\bvalidate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:\\s|$|#)"
     positive_examples:
       - |2-
         ansible.builtin.dnf:
                 # ...
                 validate_certs: false
+      - |2-
+        dnf:
+                name: foo
+                validate_certs: 'no'
+      - |2-
+        ansible.builtin.dnf:
+                name: foo
+                validate_certs: "false"
+    negative_examples:
+      - |2-
+        dnf:
+                name: foo
+                validate_certs: true
     multiline: true
     window: 30
     recommendation: "Remove `validate_certs: false`. For self-signed internal mirrors: distribute the CA to `/etc/pki/ca-trust/source/anchors/` + run `update-ca-trust`. Pair with `disable_gpg_check: false` (default) and `repo_gpgcheck=1` in the repo config."

--- a/src/ansible_security_scanner/patterns/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/system_compromise.yml
@@ -1055,6 +1055,31 @@ patterns:
     hipaa: ['164.312(a)(2)(iv)', '164.312(e)(1)']
     soc2: ['CC6.7']
 
+  - id: "ssh_keygen_empty_passphrase_privileged_key"
+    category: "system_compromise"
+    severity: "HIGH"
+    title: "ssh-keygen Generates Privileged Key With Empty Passphrase"
+    description: "A task runs `ssh-keygen` with `-N ''` (empty passphrase) AND a destination under `/root/.ssh/`, `/home/root/.ssh/`, or a system-account home (`-f /etc/...`, `-f /var/...`). An at-rest passphraseless private key for a privileged account becomes a one-shot lateral-movement primitive: any host-level read (backup theft, container layer leak, snapshot mount, or a follow-on file-disclosure CVE) yields a usable login credential against every host the corresponding public key has been distributed to. Server host keys (which need to be passphraseless to start sshd unattended) are covered by the existing weak-hostkey rule and explicitly excluded here."
+    regex: "ssh-keygen\\s+[^\\n]*?-[NP]\\s+(?:''|\"\")[^\\n]*?-f\\s+(?:/root/\\.ssh/|/home/root/\\.ssh/|/etc/(?!ssh/ssh_host_)|/var/lib/|/opt/|/srv/|/data/)|ssh-keygen\\s+[^\\n]*?-f\\s+(?:/root/\\.ssh/|/home/root/\\.ssh/|/etc/(?!ssh/ssh_host_)|/var/lib/|/opt/|/srv/|/data/)[^\\n]*?-[NP]\\s+(?:''|\"\")"
+    multiline: true
+    window: 6
+    positive_examples:
+      - "ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519"
+      - "ssh-keygen -t rsa -b 4096 -f /root/.ssh/id_rsa -N ''"
+    negative_examples:
+      - "ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key"
+      - "ssh-keygen -t ed25519 -N '$PASSPHRASE' -f /root/.ssh/id_ed25519"
+    recommendation: "Avoid generating long-lived passphraseless private keys for privileged accounts. Use SSH certificates signed by a short-TTL CA (`ssh-keygen -s ca -I host-cert -V +1h`) so individual keys are not persistent secrets, or use agent-forwarded keys protected by an OS keyring. If a passphraseless key is unavoidable for a service account, isolate it in a dedicated unprivileged user, restrict the matching `authorized_keys` entry with `from=`, `command=`, `no-port-forwarding`, and rotate it on a short cadence."
+    cwe: ['CWE-321', 'CWE-522', 'CWE-798']
+    owasp_appsec: ["A07:2021"]
+    owasp_asvs: [V2.4.1]
+    mitre_attack: ['T1098.004', 'T1552.004']
+    cis_controls: ['CIS-3.11', 'CIS-5.2']
+    nist_controls: ['IA-5', 'SC-12', 'SC-28']
+    pci_dss: ['3.5.1', '8.6.2']
+    hipaa: ['164.312(a)(2)(iv)']
+    soc2: ['CC6.1']
+
   - id: "byovd_known_vulnerable_kernel_driver_install"
     category: "system_compromise"
     severity: "CRITICAL"

--- a/src/ansible_security_scanner/patterns/unauthorized_cloud_access.yml
+++ b/src/ansible_security_scanner/patterns/unauthorized_cloud_access.yml
@@ -950,10 +950,26 @@ patterns:
     category: "unauthorized_cloud_access"
     severity: "CRITICAL"
     title: "Docker Privileged Mode"
-    description: "Runs a Docker container in privileged mode, granting full host access"
-    regex: "docker\\s+run.*--privileged|privileged:\\s*true"
+    description: "Runs a Docker container in privileged mode (`docker run --privileged`, `--privileged=true`, or YAML `privileged: true`/`yes`/`on`/`1`), granting full host access including all capabilities and direct device-node mounts. Container escape becomes trivial (mount /dev/sda, write /etc/cron.d on the host)."
+    regex: "docker\\s+run\\s+[^\\n]*?--privileged(?![=\\w])|docker\\s+run\\s+[^\\n]*?--privileged\\s*=\\s*['\"]?(?:true|yes|y|on|1)\\b|(?:^|\\s)privileged\\s*:\\s*['\"]?(?:true|yes|y|on|1)['\"]?(?=\\s|$|#|,)"
     positive_examples:
       - "privileged: true"
+      - "privileged: 'true'"
+      - "privileged: yes"
+      - "privileged: Yes"
+      - "privileged: 1"
+      - "privileged: on"
+      - "  privileged: \"true\""
+      - "docker run --privileged my/img"
+      - "docker run --privileged=true my/img"
+      - "docker run --privileged=yes my/img"
+    negative_examples:
+      - "privileged: false"
+      - "privileged: 'false'"
+      - "privileged: no"
+      - "privileged: 0"
+      - "non_privileged: true"
+      - "unprivileged: true"
     recommendation: "Never run containers in privileged mode; use specific capabilities instead"
     cwe: ["CWE-250"]
     owasp_asvs: [V13.4.5, V15.2.3]

--- a/src/ansible_security_scanner/patterns/unsafe_permissions.yml
+++ b/src/ansible_security_scanner/patterns/unsafe_permissions.yml
@@ -8,12 +8,31 @@ patterns:
     severity: "HIGH"
     title: "World Writable Files"
     description: >-
-        mode: '0777' is set on a file resource, or chmod 777 is invoked. Any local
-        user can rewrite the path's contents, defeating integrity assumptions of
-        every later task.
-    regex: "mode:\\s*[\"']?0?777[\"']?|chmod.*777"
+        mode: '0777' is set on a file resource, or chmod 777 / chmod a+w / chmod o+w
+        is invoked. Any local user can rewrite the path's contents, defeating
+        integrity assumptions of every later task.
+    regex: "mode\\s*:\\s*['\"]?(?:0?[0-7]{2}[2367]|[2367])['\"]?(?=\\s|$|#|,)|chmod\\s+(?:-[A-Za-z]+\\s+)*['\"]?(?:0?[0-7]{2}[2367]|[2367])\\b|(?:mode\\s*:\\s*['\"]?|chmod\\s+(?:-[A-Za-z]+\\s+)*)(?:(?=[ugoa]*[oa])[ugoa]+\\+w|(?<![ugoa])\\+w(?=[\\s'\"]))|(?:mode\\s*:\\s*['\"]?|chmod\\s+(?:-[A-Za-z]+\\s+)*)(?:(?=[ugoa]*[oa])[ugoa]+=[rxw]*w[rxw]*)|setfacl\\s+[^\\n]*?-m\\s+[^\\n]*?o:[rxw]*w[rxw]*"
     positive_examples:
       - "mode: \"0777\""
+      - "mode: '0666'"
+      - "mode: '0773'"
+      - "mode: 0666"
+      - "mode: 'a+w'"
+      - "mode: 'o+w'"
+      - "mode: 'ugo+w'"
+      - "chmod 777 /etc/foo"
+      - "chmod -R 666 /var/data"
+      - "chmod a+w /opt/secret"
+      - "chmod o=rwx /etc/x"
+      - "setfacl -m o:rwx /etc/x"
+    negative_examples:
+      - "mode: '0775'"
+      - "mode: '0700'"
+      - "mode: '0640'"
+      - "mode: 'g+w'"
+      - "mode: 'u+w'"
+      - "chmod g+w /etc/x"
+      - "chmod u+x /usr/local/bin/x"
     recommendation: "Replace mode: '0777' / chmod 777 with the most restrictive mode that satisfies the workload (typically 0640 for files, 0750 for directories) and use group ownership rather than world-writability to share access."
     cwe: ["CWE-732"]
     owasp_asvs: [V5.3.1]
@@ -684,6 +703,54 @@ patterns:
     cwe: ["CWE-522", "CWE-732"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V5.3.1]
+
+  - id: "private_key_copied_outside_dot_ssh"
+    category: "unsafe_permissions"
+    severity: "HIGH"
+    title: "Private Key Copied Or Linked Outside ~/.ssh"
+    description: "A shell task uses `cp`, `mv`, `ln`, or `install` on a path matching `id_rsa`, `id_ed25519`, `id_ecdsa`, `*.pem`, or `*.key` whose destination is NOT a `.ssh/` directory. Common destinations are `/home/root/.ssh/` (which is not root's real home on standard Linux), `/tmp`, `/var/tmp`, `/srv`, `/opt`, or shared directories. Off-`.ssh/` private keys typically inherit the surrounding directory's umask (often 0755) and bypass tooling that audits `~/.ssh/` for mode 0600."
+    regex: "(?m)^\\s*(?:-\\s+)?(?:ansible\\.builtin\\.)?(?:shell|command):\\s*(?=[|>]|\\S)[\\s\\S]{0,400}?(?:\\b(?:cp|mv|install|ln(?:\\s+-s)?|rsync(?:\\s+-[avzrlpt]+)?)\\s+[^\\n]*?(?:id_(?:rsa|ed25519|ecdsa|dsa)|\\.pem|\\.key)\\b[^\\n]*?\\s+(?:/home/root\\b|/tmp\\b|/var/tmp\\b|/srv\\b|/opt\\b|/mnt\\b|/media\\b|/data\\b|/var/log\\b)[^\\n]*|\\bcat\\s+[^\\n]*?(?:id_(?:rsa|ed25519|ecdsa|dsa)|\\.pem|\\.key)\\b[^\\n]*?>\\s*(?:/home/root/|/tmp/|/var/tmp/|/srv/|/opt/|/mnt/|/media/|/data/|/var/log/)|\\bdd\\s+[^\\n]*?if=[^\\n]*?(?:id_(?:rsa|ed25519|ecdsa|dsa)|\\.pem|\\.key)\\b[^\\n]*?of=(?:/home/root/|/tmp/|/var/tmp/|/srv/|/opt/|/mnt/|/media/|/data/|/var/log/)|\\btar\\s+[^\\n]*?(?:-c[^\\n]*?-f|cf|czf|cjf|cJf|cvf|czvf)\\s+(?:/home/root/|/tmp/|/var/tmp/|/srv/|/opt/|/mnt/|/media/|/data/|/var/log/)[^\\n]*?(?:\\.ssh\\b|id_(?:rsa|ed25519|ecdsa|dsa)|\\.pem|\\.key))"
+    multiline: true
+    window: 10
+    positive_examples:
+      - "shell: cp /root/.ssh/id_rsa /home/root/.ssh/id_rsa"
+      - "shell: cp /etc/ssl/private/server.key /tmp/server.key"
+    negative_examples:
+      - "shell: cp /root/.ssh/id_rsa /home/svc/.ssh/id_rsa"
+    recommendation: "Keep private keys under the owning user's `~/.ssh/` directory with mode 0700 on the directory and 0600 on the key. If a tool requires a non-standard path, render the key at runtime with `ansible.builtin.copy: mode='0600'` and remove it in an `always:` block. Note that on standard Linux, root's home is `/`, not `/home/root` - tools that hard-code `/home/root` should be configured to read `/root/.ssh` instead."
+    cwe: ["CWE-276", "CWE-522", "CWE-732"]
+    owasp_appsec: ["A01:2021"]
+    owasp_asvs: [V13.2.1, V11.2.5]
+    mitre_attack: ["T1552.004"]
+    cis_controls: ["CIS-3.3", "CIS-Secrets"]
+    nist_controls: ['AC-3', 'AC-6', 'IA-5(7)', 'SC-28']
+    pci_dss: ['3.5.1', '7.2.2']
+    hipaa: ['164.312(a)(1)', '164.312(a)(2)(iv)']
+    soc2: ['CC6.1']
+
+  - id: "tls_secret_downloaded_to_world_dir"
+    category: "unsafe_permissions"
+    severity: "HIGH"
+    title: "Private Key Or TLS Secret Downloaded Into A World-Readable Directory"
+    description: "A shell task runs `aws s3 cp`, `gcloud storage cp`, `az storage blob download`, `curl`, or `wget` and writes a file whose name suggests a private key or TLS secret (`*.key`, `*.pem`, `*privatekey*`, `*secret*`) into `/tmp`, `/var/tmp`, `/dev/shm`, or `/srv/<world-readable>`. The destination directory is world-readable on every standard distribution, and the downloader does not enforce a restrictive `mode:` the way `ansible.builtin.copy` would; the secret is exposed for the entire interval before it is moved or removed."
+    regex: "(?m)^\\s*(?:-\\s+)?(?:ansible\\.builtin\\.)?(?:shell|command):\\s*(?=[|>]|\\S)[\\s\\S]{0,600}?(?:(?:aws\\s+s3\\s+cp|aws\\s+s3api\\s+get-object|gcloud\\s+storage\\s+cp|gsutil\\s+cp|az\\s+storage\\s+blob\\s+download|oci\\s+os\\s+object\\s+get|rclone\\s+(?:copy|copyto)|curl\\s+[^\\n]*?(?:-o|--output)\\s+|wget\\s+[^\\n]*?(?:-O\\s+|--output-document[\\s=]+))[^\\n]*?(?:/tmp/|/var/tmp/|/dev/shm/)[^\\n]*?(?:\\.key\\b|\\.pem\\b|privatekey|private_key|secret\\.[A-Za-z0-9]+)|(?:curl|wget)\\s+[^\\n]*?\\b(?:\\.key\\b|\\.pem\\b|privatekey|private_key)[^\\n]*?>\\s*(?:/tmp/|/var/tmp/|/dev/shm/))"
+    multiline: true
+    window: 10
+    positive_examples:
+      - "shell: aws s3 cp s3://bucket/server.key /tmp/server.key"
+      - "shell: curl -sSL https://internal/secret.pem -o /var/tmp/secret.pem"
+    negative_examples:
+      - "shell: aws s3 cp s3://bucket/server.key /etc/ssl/private/server.key"
+    recommendation: "Download the secret directly into its final mode-0600 location (`/etc/ssl/private/`, `/etc/pki/tls/private/`) or stream it into a `umask 077`-protected directory under `/run/<service>` (tmpfs, root-owned). When using `ansible.builtin.get_url` or `ansible.builtin.copy`, set `mode: '0600'` and `owner:`/`group:` to the consuming service account. Avoid staging private keys in `/tmp` even briefly."
+    cwe: ["CWE-276", "CWE-732"]
+    owasp_appsec: ["A01:2021", "A04:2021"]
+    owasp_asvs: [V13.2.1, V11.2.5]
+    mitre_attack: ["T1552.004"]
+    cis_controls: ["CIS-3.3", "CIS-Secrets"]
+    nist_controls: ['AC-3', 'AC-6', 'SC-28']
+    pci_dss: ['3.5.1', '7.2.2']
+    hipaa: ['164.312(a)(1)', '164.312(a)(2)(iv)']
+    soc2: ['CC6.1']
 
   - id: "ansible_cfg_callback_whitelist_unpinned"
     category: "unsafe_permissions"

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -156,6 +156,7 @@ rules_by_category:
     - powershell_encoded_command
     - process_substitution
     - raw_encoded_powershell
+    - secret_piped_to_text_processor
     - secret_var_in_command_argv
     - shell_pipe_to_interpreter
     - shell_inline_compound_command
@@ -254,6 +255,7 @@ rules_by_category:
     - elastic_apm_secret_token_or_api_key_literal
     - entra_client_secret_literal
     - facebook_access_token
+    - factory_default_credential_in_basic_auth
     - gcp_service_account_private_key_inline
     - github_personal_access_token_literal
     - github_token
@@ -369,6 +371,7 @@ rules_by_category:
     - redis_no_auth_protected_mode_disabled
     - saml_acs_or_oidc_issuer_plaintext_http
     - saml_assertion_no_signature_verify
+    - shell_ssh_scp_strict_host_key_disabled
     - sshd_weak_ciphers_3des_arcfour_cbc_or_hmac_md5
     - ssl_verification_disabled
     - telnet_usage
@@ -675,6 +678,7 @@ rules_by_category:
     - otel_collector_grpc_or_http_listener_bound_to_wildcard_interface
     - package_gpg_check_disabled
     - pam_module_manipulation
+    - password_expiry_disabled
     - powershell_execution_policy_set_localmachine_bypass
     - print_spooler_service_enabled_on_domain_controller
     - proc_sysrq_trigger
@@ -914,6 +918,7 @@ rules_by_category:
     - runc_leaky_vessels_vulnerable_install
     - setuid_binary_creation_compromise
     - shadow_file_access
+    - ssh_keygen_empty_passphrase_privileged_key
     - sshd_weak_hostkey_dsa_or_rsa_under_2048
     - system_service_manipulation
     - systemd_timer_persistence_world_writable_unit
@@ -1145,6 +1150,8 @@ rules_by_category:
     - inventory_winrm_ignore_cert_validation
     - legitimate_config_permissions
     - lineinfile_no_backup_on_sensitive_file
+    - private_key_copied_outside_dot_ssh
+    - private_key_written_outside_canonical_dir_ast
     - raw_module_with_become
     - recursive_permission_change
     - setfacl_mass_permission_grant
@@ -1158,6 +1165,7 @@ rules_by_category:
     - ssh_weak_hostkey_algorithms_reenabled
     - sticky_bit_removal
     - template_mode_executable_to_system_path
+    - tls_secret_downloaded_to_world_dir
     - winrm_cert_validation_ignore
     - world_readable_sensitive
     - world_writable_files

--- a/src/ansible_security_scanner/synthetic_rule_frameworks.py
+++ b/src/ansible_security_scanner/synthetic_rule_frameworks.py
@@ -79,6 +79,17 @@ SYNTHETIC_RULE_FRAMEWORKS: dict[str, FrameworkTags] = {
         "owasp_appsec": ["A01:2021", "A04:2021"],
         "owasp_asvs": ["V5.3.1", "V14.2.2"],
     },
+    "private_key_written_outside_canonical_dir_ast": {
+        "cwe": ["CWE-276", "CWE-522", "CWE-732"],
+        "mitre_attack": ["T1552.004"],
+        "cis_controls": ["CIS-3.3", "CIS-Secrets"],
+        "nist_controls": ["AC-3", "AC-6", "IA-5(7)", "SC-28"],
+        "pci_dss": ["3.5.1", "7.2.2"],
+        "hipaa": ["164.312(a)(1)", "164.312(a)(2)(iv)"],
+        "soc2": ["CC6.1"],
+        "owasp_appsec": ["A01:2021"],
+        "owasp_asvs": ["V13.2.1", "V11.2.5"],
+    },
     # Supply-chain: dynamic includes, URL-based pulls
     "include_role_from_url": {
         "cwe": ["CWE-829", "CWE-494"],

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -150,6 +150,36 @@
           -p "{\"data\":{\"tls.key\":\"$TLS_KEY\"}}"
       no_log: true
 
+    # --- operational_security: password_expiry_disabled ---
+    - name: disable password aging on service account
+      ansible.builtin.shell: chage -M 99999 svc_user
+
+    # --- hardcoded_credentials: factory_default_credential_in_basic_auth ---
+    - name: probe appliance with vendor default
+      ansible.builtin.shell: curl -sk -u admin:welcome https://appliance.example/api/health
+
+    # --- command_injection: secret_piped_to_text_processor ---
+    - name: read secret and pipe through jq
+      ansible.builtin.shell: aws secretsmanager get-secret-value --secret-id app | jq -r '.SecretString'
+      no_log: true
+
+    # --- system_compromise: ssh_keygen_empty_passphrase_privileged_key ---
+    - name: generate root key with empty passphrase
+      ansible.builtin.shell: ssh-keygen -t ed25519 -N '' -f /root/.ssh/id_ed25519
+
+    # --- unsafe_permissions: private_key_copied_outside_dot_ssh ---
+    - name: copy root key to non-canonical home
+      ansible.builtin.shell: cp /root/.ssh/id_rsa /home/root/.ssh/id_rsa
+
+    # --- insecure_communication: shell_ssh_scp_strict_host_key_disabled ---
+    - name: scp key with strict host key disabled
+      ansible.builtin.shell: |
+        scp -o StrictHostKeyChecking=no /etc/ssl/private/example.key root@host.example:/etc/ssl/private/example.key
+
+    # --- unsafe_permissions: tls_secret_downloaded_to_world_dir ---
+    - name: stage tls key in world-readable temp
+      ansible.builtin.shell: aws s3 cp s3://bucket/server.key /tmp/server.key
+
     # --- webhook_exposure.yml ---
     - name: Send to Slack webhook
       ansible.builtin.uri:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -223,8 +223,12 @@ _MULTI_BAD_REQUIRED_RULE_IDS: frozenset[str] = frozenset(
         # file-scope post-filter on a multi-file scan.
         "slsa_provenance_verification_missing",
         # Credential and supply-chain patterns that must fire on the
-        # defaults / install task files.
-        "hardcoded_credentials",
+        # defaults / install task files. ``plaintext_password_should_be_vaulted``
+        # is the high-fidelity, named-variable rule that supersedes the
+        # generic ``hardcoded_credentials`` AST emission (see overlap
+        # suppression in ``file_scanner.py``); landing the named-rule
+        # finding is the strictly stronger signal.
+        "plaintext_password_should_be_vaulted",
         "stripe_api_key",
         "aws_access_key",
         # The fixture's `image: "nginx:latest"` line fires both
@@ -245,7 +249,7 @@ _MULTI_BAD_REQUIRED_RULE_IDS: frozenset[str] = frozenset(
 # benign pattern-tuning doesn't tickle this gate, but tight enough
 # that a silent ~50% regression (e.g. TaintTracker or extract_all_tasks
 # shape detection breaking) surfaces immediately.
-_MULTI_BAD_MIN_FINDINGS = 30
+_MULTI_BAD_MIN_FINDINGS = 29
 
 
 def test_multi_example_bad_known_findings(multi_example_bad_json):


### PR DESCRIPTION
Extends existing rules to close bypasses found while auditing scanner coverage:

- `insecure_protocol_usage`: add `tftp://`, `rsync://`
- `uri_module_validate_certs_false`, `yum_validate_certs_false`, `dnf_validate_certs_false`, `yum_sslverify_false`, `helm_repo_plaintext_http_skip_tls_verify`: accept quoted booleans (`'no'`, `"false"`), `off`, `n`
- `world_writable_files`, `dangerous_world_writable`: catch a wider octal range plus symbolic `a+w` / `o+w` / `ugo+w` / `o=rwx` and `setfacl ... o:rwx`
- `docker_privileged`: accept `yes`, `on`, `1`, `--privileged=true`
- `curl_with_credentials`: drop the quoting requirement, add `--user`/`--user=`, `-K config`, `--netrc`/`--netrc-file`, `wget --user/--password`, and HTTPie `-a`
- `aws_access_key`: add `ASIA` (STS) alongside `AKIA`
- `plaintext_password_should_be_vaulted`: accept unquoted scalars, expand the secret-shaped suffix list (`*_creds`, `rootpw`, `dbpw`, `access_key`, `secret_key`, `secret_token`), exclude YAML truthy/falsy/numeric literals to avoid FPs

Adds `private_key_written_outside_canonical_dir_ast`, an AST rule that flags `copy` / `template` / `get_url` writing private-key-shaped material (`id_rsa`, `*.key`, `*.pem`, `privatekey`) to a non-canonical destination. The existing regex rules only see `shell:` / `command:` strings, so a playbook using the native module bypassed them.

Adds seven new rules for gaps observed during a playbook audit:

- `password_expiry_disabled`
- `factory_default_credential_in_basic_auth`
- `secret_piped_to_text_processor`
- `ssh_keygen_empty_passphrase_privileged_key`
- `private_key_copied_outside_dot_ssh`
- `shell_ssh_scp_strict_host_key_disabled`
- `tls_secret_downloaded_to_world_dir`

`tests/test_integration.py` `_MULTI_BAD_REQUIRED_RULE_IDS` and `_MULTI_BAD_MIN_FINDINGS` updated to reflect the named-variable rule (`plaintext_password_should_be_vaulted`) now correctly superseding the generic AST `hardcoded_credentials` finding via the existing overlap suppression.