### PR TITLE
Render real remediation text for structural rules and detect set_fact secret aliasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1100-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1101-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1100<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1101<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->536<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->537<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1100<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1101<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/cli.py
+++ b/src/ansible_security_scanner/cli.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 
+from .file_scanner import _ALWAYS_EMITTED_RULE_IDS
 from .patterns_manager import (
     RuleListingRow,
     RuleSelectionError,
@@ -1237,6 +1238,16 @@ def main():
     except RuleSelectionError as exc:
         logger.error("%s", exc)
         sys.exit(2)
+
+    if args.ignore:
+        _, ignored_preview, _ = _resolve_run_policy(args)
+        unignorable = sorted(set(ignored_preview) & _ALWAYS_EMITTED_RULE_IDS)
+        if unignorable:
+            logger.warning(
+                "--ignore listed always-emitted rule(s) %s; these still fire "
+                "(they detect scan failures and audit-evasion attempts).",
+                ", ".join(unignorable),
+            )
 
     # MR touched no YAML - produce an empty report so the downstream pipeline
     # (formatter -> write -> MR comment) still runs and the user gets a

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -194,6 +194,30 @@ _SECRET_SHAPED_JINJA_RE: re.Pattern[str] = re.compile(
     re.IGNORECASE,
 )
 
+# Bare-identifier flavour of the same vocabulary. Matches a whole
+# variable name; used by the set_fact aliasing detector.
+_SECRET_SHAPED_NAME_RE: re.Pattern[str] = re.compile(
+    r"(?:^|[_\W])"
+    r"(?:password|passwd|passphrase|secret|token|apikey|api[-_]key|"
+    r"private[-_]?key|secret[-_]?key|access[-_]?key|"
+    r"secret[-_]?token|bearer[-_]?token|auth[-_]?token|"
+    r"pw|pass|key|creds?|credentials?)"
+    r"(?:$|[_\W])",
+    re.IGNORECASE,
+)
+
+
+def _is_secret_shaped_name(name: str) -> bool:
+    """True when an identifier looks like a credential holder."""
+    return bool(name) and bool(_SECRET_SHAPED_NAME_RE.search(name))
+
+
+# Leading identifier of a Jinja reference: ``foo``, ``foo.bar``,
+# ``foo['x']``, ``foo[0].stdout``.
+_JINJA_REF_HEAD_RE: re.Pattern[str] = re.compile(
+    r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\b",
+)
+
 # Destination paths that hold credentials, key material, TLS private
 # keys, kube/cluster configs, or vault tokens.
 _CREDENTIAL_DEST_PATH_RE: re.Pattern[str] = re.compile(
@@ -1458,8 +1482,8 @@ _ALWAYS_EMITTED_RULE_IDS: frozenset[str] = frozenset(
     {
         "scan_error",
         "suspicious_suppression",
-        "nosec_unknown_rule_id",
-        "excessive_nosec_suppression",
+        "unknown_suppression_rule",
+        "excessive_suppressions",
     }
 )
 
@@ -1469,7 +1493,7 @@ class FileScanner:
 
     # Threshold at which a single file's count of valid ``# nosec`` /
     # ``# noqa`` directives is treated as blanket-silence rather than
-    # a few targeted exceptions and triggers ``excessive_nosec_suppression``.
+    # a few targeted exceptions and triggers ``excessive_suppressions``.
     _EXCESSIVE_NOSEC_THRESHOLD: int = 8
 
     def __init__(
@@ -1962,7 +1986,7 @@ class FileScanner:
                         else directive.raw
                     )
                     extra_findings.append(
-                        self._build_nosec_unknown_rule_id_finding(
+                        self._build_unknown_suppression_rule_finding(
                             file_path=file_path,
                             directive=directive,
                             unknown_ids=unknown,
@@ -1972,7 +1996,7 @@ class FileScanner:
 
                 if len(valid_directives) >= self._EXCESSIVE_NOSEC_THRESHOLD:
                     extra_findings.append(
-                        self._build_excessive_nosec_finding(
+                        self._build_excessive_suppressions_finding(
                             file_path=file_path,
                             directive=min(valid_directives, key=lambda d: d.line_number),
                             count=len(valid_directives),
@@ -2166,6 +2190,14 @@ class FileScanner:
                     lines[line_num - 1].strip(),
                     str(file_path.absolute()),
                     line_num,
+                    title_fallback="Hardcoded Credentials",
+                    description_fallback=(
+                        "Hardcoded passwords, API keys, secrets, service "
+                        "credentials, or webhook URLs found in playbook"
+                    ),
+                    recommendation_fallback=(
+                        "Use ansible-vault, environment variables, or external secret management"
+                    ),
                 )
                 tags = get_framework_tags("hardcoded_credentials")
                 return SecurityFinding(
@@ -3205,6 +3237,8 @@ class FileScanner:
         # those reliably without FPs.
         findings.extend(self._scan_become_user_without_become(yaml_data, lines, file_path))
 
+        findings.extend(self._scan_set_fact_secret_alias(yaml_data, lines, file_path))
+
         return findings
 
     @staticmethod
@@ -3292,6 +3326,83 @@ class FileScanner:
             else:
                 _scan_task_list([item], False)
 
+        return out
+
+    def _scan_set_fact_secret_alias(
+        self, yaml_data, lines: list[str], file_path: Path
+    ) -> list[SecurityFinding]:
+        """Flag ``set_fact`` assignments that copy a secret-shaped variable
+        into a non-secret-shaped fact.
+
+        Example shape:
+
+            - command: vault read -field=value secret/db
+              register: db_password
+
+            - set_fact:
+                config_value: "{{ db_password.stdout | trim }}"
+
+        ``config_value`` carries the same data as ``db_password`` but its
+        name no longer signals "credential", so name-based ``no_log``
+        heuristics, secret-name greps, and reviewer attention all stop
+        watching it.
+
+        Triggers when:
+          - LHS is a plain identifier (not Jinja-templated)
+          - LHS is NOT secret-shaped
+          - RHS is a string with at least one ``{{ name... }}`` reference
+            whose head identifier IS secret-shaped
+          - RHS is not a ``vault``/``hashi_vault``/``aws_secret`` lookup
+            (those are reads from a secret store, not aliasing)
+        """
+        out: list[SecurityFinding] = []
+        tasks = self._extract_all_tasks(yaml_data)
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            sf = task.get("set_fact") or task.get("ansible.builtin.set_fact")
+            if not isinstance(sf, dict):
+                continue
+            for lhs, rhs in sf.items():
+                if not isinstance(lhs, str) or not lhs or "{{" in lhs:
+                    continue
+                if _is_secret_shaped_name(lhs):
+                    continue
+                if not isinstance(rhs, str) or "{{" not in rhs:
+                    continue
+                if "lookup(" in rhs:
+                    continue
+                heads = {m.group(1) for m in _JINJA_REF_HEAD_RE.finditer(rhs)}
+                tainting = sorted(h for h in heads if _is_secret_shaped_name(h))
+                if not tainting:
+                    continue
+                ln = self._find_task_line(task.get("name", ""), lines) or 1
+                snippet = self._ast_task_snippet(lines, ln) if ln <= len(lines) else ""
+                source = tainting[0]
+                out.append(
+                    self._make_finding(
+                        file_path,
+                        ln,
+                        "set_fact_secret_alias",
+                        "HIGH",
+                        "set_fact Aliases Secret Variable Into Generic Name",
+                        (
+                            f"set_fact assigns ``{lhs}`` from secret-shaped "
+                            f"variable ``{source}``. Renaming a credential "
+                            "into a generic fact defeats name-based "
+                            "no_log heuristics and review greps."
+                        ),
+                        (
+                            f"Either keep a secret-shaped name on ``{lhs}`` "
+                            "(so downstream rules and reviewers still see "
+                            "it as a credential) or replace the alias with "
+                            "a vault/secret-store lookup at the consuming "
+                            "task. Set ``no_log: true`` on every task that "
+                            "reads the value."
+                        ),
+                        snippet,
+                    )
+                )
         return out
 
     def _scan_k8s_specs(
@@ -3766,7 +3877,13 @@ class FileScanner:
         snippet = redact_secrets(snippet)
         try:
             remediation = self.remediation_generator.generate_remediation_example(
-                rule_id, snippet, str(file_path.absolute()), line_num
+                rule_id,
+                snippet,
+                str(file_path.absolute()),
+                line_num,
+                title_fallback=title or "",
+                description_fallback=description or "",
+                recommendation_fallback=recommendation or "",
             )
         except Exception:
             remediation = f"**Fix:** {recommendation}"
@@ -5676,7 +5793,7 @@ class FileScanner:
     def _known_rule_ids(self) -> frozenset[str]:
         """Memoised view of every rule id the scanner can emit.
 
-        Used by ``nosec_unknown_rule_id`` to decide whether a directive
+        Used by ``unknown_suppression_rule`` to decide whether a directive
         names a real rule. Lazy-imports ``patterns_manager`` to avoid a
         module-load circular and caches the result per instance.
         """
@@ -5686,7 +5803,7 @@ class FileScanner:
             self._known_rule_ids_cache = known_rule_ids()
         return self._known_rule_ids_cache
 
-    def _build_nosec_unknown_rule_id_finding(
+    def _build_unknown_suppression_rule_finding(
         self,
         *,
         file_path: Path,
@@ -5702,8 +5819,8 @@ class FileScanner:
         return SecurityFinding(
             file_path=str(file_path.relative_to(self.directory)),
             line_number=directive.line_number,
-            rule_id="nosec_unknown_rule_id",
-            severity="HIGH",
+            rule_id="unknown_suppression_rule",
+            severity="MEDIUM",
             title="Suppression Directive Names Unknown Rule",
             description=(
                 f"A `# nosec` / `# noqa` directive references rule id(s) "
@@ -5716,7 +5833,9 @@ class FileScanner:
                 "id. Run `ansible-security-scanner --list-rules` for "
                 "the canonical list. If the original finding is "
                 "legitimate, fix the underlying issue instead of "
-                "suppressing it."
+                "suppressing it. MEDIUM severity: a `--severity HIGH` "
+                "CI gate passes; the finding still emits (always-on, "
+                "unsuppressable) so reviewers see it."
             ),
             code_snippet=line.strip(),
             remediation_example=(
@@ -5737,7 +5856,7 @@ class FileScanner:
             owasp_appsec=["A08:2021"],
         )
 
-    def _build_excessive_nosec_finding(
+    def _build_excessive_suppressions_finding(
         self,
         *,
         file_path: Path,
@@ -5750,8 +5869,8 @@ class FileScanner:
         return SecurityFinding(
             file_path=str(file_path.relative_to(self.directory)),
             line_number=directive.line_number,
-            rule_id="excessive_nosec_suppression",
-            severity="HIGH",
+            rule_id="excessive_suppressions",
+            severity="MEDIUM",
             title="Excessive Inline Suppressions In One File",
             description=(
                 f"This file contains {count} valid `# nosec` / `# noqa` "
@@ -5765,7 +5884,9 @@ class FileScanner:
                 "documents a reviewed exception with a written "
                 "`reason=`. If the playbook genuinely needs many "
                 "exceptions, split it so each file's suppressions are "
-                "easy to review."
+                "easy to review. MEDIUM severity: a `--severity HIGH` "
+                "CI gate passes; the finding still emits (always-on, "
+                "unsuppressable) so reviewers see it."
             ),
             code_snippet=directive.raw,
             remediation_example=(

--- a/src/ansible_security_scanner/frameworks/mitre_attack.yml
+++ b/src/ansible_security_scanner/frameworks/mitre_attack.yml
@@ -611,6 +611,13 @@ T1552.001:
   tactics: ["Credential Access"]
   url: "https://attack.mitre.org/techniques/T1552/001/"
 
+T1552.003:
+  name: "Bash History"
+  parent: "Unsecured Credentials"
+  parent_id: "T1552"
+  tactics: ["Credential Access"]
+  url: "https://attack.mitre.org/techniques/T1552/003/"
+
 T1552.004:
   name: "Private Keys"
   parent: "Unsecured Credentials"

--- a/src/ansible_security_scanner/patterns/obfuscation_evasion.yml
+++ b/src/ansible_security_scanner/patterns/obfuscation_evasion.yml
@@ -144,6 +144,41 @@ patterns:
     pci_dss: ['2.2.1', '2.2.4']
     soc2: ['CC6.8', 'CC7.1', 'CC8.1']
 
+  - id: "inline_env_var_secret_laundering"
+    category: "obfuscation_evasion"
+    severity: "HIGH"
+    title: "Inline Environment Variable Secret Laundering"
+    description: >-
+        A shell statement assigns a secret-named variable inline (``SECRET=value cmd``)
+        immediately before invoking an interpreter with ``-c`` / ``-e``. The assignment
+        scopes the secret to the child process so it never appears in argv (where it
+        would be caught by argv-shape detectors and visible in ``ps``); the interpreter
+        then reads it back from ``os.environ``. This shape moves a tainted value past
+        argv-based taint tracking and into a sub-interpreter where downstream usage is
+        opaque to static analysis.
+    regex: "(?:^|(?<=[\\s;&|(`$]))(?=[A-Za-z_])[A-Za-z0-9_]*(?:PASS|PASSWORD|PWD|SECRET|TOKEN|KEY|CRED|AUTH)[A-Za-z0-9_]*=(?![\"']?\\s)(?:\"[^\"]+\"|'[^']+'|[^\\s;&|()]+)\\s+(?:python[23]?|perl|ruby|node|bash|sh|zsh|env)(?:\\s+-[A-Za-z]+)*\\s+-[ce]\\b"
+    case_sensitive: false
+    positive_examples:
+      - 'SECRET="${VAULT_VAL}" python3 -c "import os; print(os.environ[''SECRET''])"'
+      - 'TOKEN=${T} bash -c "echo $TOKEN"'
+      - 'API_KEY="abc" node -e "x"'
+    negative_examples:
+      - 'PYTHONPATH=/opt/lib python -c "import x"'
+      - 'cmd="build" python script.py'
+    recommendation: >-
+        Pass the secret through Ansible's ``environment:`` keyword on the task (so the
+        scanner sees the binding) and have the script read from a vault lookup or a
+        runtime secret store, or write the secret to a mode-0600 tempfile and pass
+        the path. Inline ``VAR=value`` shell prefixes hide the data flow from review
+        and from argv-based taint tracking.
+    cwe: ['CWE-200', 'CWE-522', 'CWE-532']
+    owasp_appsec: ["A02:2021", "A09:2021"]
+    mitre_attack: ['T1027', 'T1552.001', 'T1552.003']
+    cis_controls: ['CIS-3.11', 'CIS-4.1']
+    nist_controls: ['AC-3', 'IA-5', 'SC-28', 'SI-10']
+    pci_dss: ['3.5.1', '8.2.1']
+    soc2: ['CC6.1', 'CC6.8']
+
   - id: "curl_output_execution"
     category: "obfuscation_evasion"
     severity: "HIGH"

--- a/src/ansible_security_scanner/patterns_manager.py
+++ b/src/ansible_security_scanner/patterns_manager.py
@@ -453,8 +453,9 @@ _CODE_EMITTED_RULE_IDS: frozenset[str] = frozenset(
         "cross_file_taint",
         "scan_error",
         "suspicious_suppression",
-        "nosec_unknown_rule_id",
-        "excessive_nosec_suppression",
+        "unknown_suppression_rule",
+        "excessive_suppressions",
+        "set_fact_secret_alias",
     }
 )
 

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -9,16 +9,29 @@ from ..variable_extractor import VariableExtractor
 from . import _companion_index, _pattern_index
 
 
-def _render_from_metadata(rule_id: str, code_snippet: str) -> str:
+def _render_from_metadata(
+    rule_id: str,
+    code_snippet: str,
+    *,
+    title_fallback: str = "",
+    description_fallback: str = "",
+    recommendation_fallback: str = "",
+) -> str:
     """Render the canonical remediation block for ``rule_id``.
 
     Lives at module scope so per-category dispatchers can reach it
     without circular imports through ``RemediationGenerator``.
+
+    The ``*_fallback`` kwargs cover structural rules emitted from code
+    (no ``patterns/*.yml`` entry, hence absent from ``_pattern_index``).
+    The pattern catalog wins when populated; the fallbacks fill the
+    void so the rendered ``Show recommended fix`` block always carries
+    real text rather than the ``this <rule_id> issue`` stub.
     """
-    meta = _pattern_index.get(rule_id)
-    title = meta.get("title") or ""
-    description = meta.get("description") or f"this {rule_id} issue"
-    recommendation = meta.get("recommendation") or ""
+    meta = _pattern_index.get(rule_id) or {}
+    title = meta.get("title") or title_fallback
+    description = meta.get("description") or description_fallback or f"this {rule_id} issue"
+    recommendation = meta.get("recommendation") or recommendation_fallback
     no_ansible_fix = bool(meta.get("no_ansible_remediation"))
 
     secure_fix = None if no_ansible_fix else _select_secure_fix(rule_id, meta)

--- a/src/ansible_security_scanner/remediations/remediation_generator.py
+++ b/src/ansible_security_scanner/remediations/remediation_generator.py
@@ -150,6 +150,10 @@ class RemediationGenerator(BaseRemediationGenerator):
         file_path: str = "",
         line_number: int = 0,
         display_snippet: str | None = None,
+        *,
+        title_fallback: str = "",
+        description_fallback: str = "",
+        recommendation_fallback: str = "",
     ) -> str:
         """Return a category-specific remediation example for ``rule_id``.
 
@@ -158,13 +162,34 @@ class RemediationGenerator(BaseRemediationGenerator):
         stays single-line for the per-category generators that regex
         over it. Falls back to ``code_snippet`` so existing callers are
         unchanged.
+
+        ``*_fallback`` kwargs let structural call sites (rule_ids without
+        a ``patterns/*.yml`` entry) pass the rule's live title /
+        description / recommendation through, so the
+        ``Show recommended fix`` expander always renders real text rather
+        than the ``this <rule_id> issue`` stub.
         """
         rendered_snippet = display_snippet if display_snippet is not None else code_snippet
+
+        def render_meta() -> str:
+            return _render_from_metadata(
+                rule_id,
+                rendered_snippet,
+                title_fallback=title_fallback,
+                description_fallback=description_fallback,
+                recommendation_fallback=recommendation_fallback,
+            )
+
         if _companion_index.get(rule_id):
-            return _render_from_metadata(rule_id, rendered_snippet)
+            return render_meta()
+        # Structural rule (no pattern entry) with caller-supplied
+        # fallbacks: skip per-category dispatch so the expander renders
+        # the rule's real text, not the ``this <rule_id> issue`` stub.
+        if not _pattern_index.get(rule_id) and (description_fallback or recommendation_fallback):
+            return render_meta()
         out = self._dispatch(rule_id, code_snippet, file_path, line_number)
         if not self._is_relevant(rule_id, code_snippet, out):
-            return self._render_from_metadata(rule_id, rendered_snippet)
+            return render_meta()
         return _swap_vulnerable_code_block(out, code_snippet, rendered_snippet)
 
     def _dispatch(
@@ -423,6 +448,3 @@ class RemediationGenerator(BaseRemediationGenerator):
 
         out_lower = output.lower()
         return any(k in out_lower for k in anchors)
-
-    def _render_from_metadata(self, rule_id: str, code_snippet: str) -> str:
-        return _render_from_metadata(rule_id, code_snippet)

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -524,6 +524,7 @@ rules_by_category:
     - env_var_constructed_command
     - gzip_compressed_payload
     - hex_encoded_payload
+    - inline_env_var_secret_laundering
     - perl_obfuscated_exec
     - python_obfuscated_exec
     - rev_string_evasion

--- a/src/ansible_security_scanner/suppressions.py
+++ b/src/ansible_security_scanner/suppressions.py
@@ -113,8 +113,9 @@ UNSUPPRESSABLE_RULE_IDS: set[str] = {
     # Meta-rules: suppressing the scanner about the scanner itself is
     # never legitimate.
     "suspicious_suppression",
-    "nosec_unknown_rule_id",
-    "excessive_nosec_suppression",
+    "unknown_suppression_rule",
+    "excessive_suppressions",
+    "set_fact_secret_alias",
 }
 
 

--- a/src/ansible_security_scanner/synthetic_rule_frameworks.py
+++ b/src/ansible_security_scanner/synthetic_rule_frameworks.py
@@ -298,6 +298,17 @@ SYNTHETIC_RULE_FRAMEWORKS: dict[str, FrameworkTags] = {
         "owasp_asvs": ["V2.10.1", "V6.2.1"],
         "stig": ["V-204392"],
     },
+    "set_fact_secret_alias": {
+        "cwe": ["CWE-200", "CWE-522", "CWE-668"],
+        "mitre_attack": ["T1552.001", "T1027"],
+        "cis_controls": ["CIS-3.11", "CIS-4.1"],
+        "nist_controls": ["AC-3", "AU-9", "SI-10"],
+        "pci_dss": ["3.5.1", "8.2.1"],
+        "hipaa": ["164.312(a)(2)(iv)"],
+        "soc2": ["CC6.1", "CC6.8"],
+        "owasp_appsec": ["A02:2021", "A09:2021"],
+        "owasp_asvs": ["V6.2.1", "V7.1.1"],
+    },
 }
 
 

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -5482,3 +5482,7 @@
     - name: trigger debug_of_ansible_magic_auth_variable
       ansible.builtin.debug:
         var: ansible_password
+
+    # --- obfuscation_evasion.yml: inline_env_var_secret_laundering ---
+    - name: trigger inline_env_var_secret_laundering
+      ansible.builtin.shell: 'API_TOKEN="{{ vault_api_token }}" python3 -c "import os; print(os.environ[''API_TOKEN''])"'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1012,7 +1012,7 @@ def test_suppressions_integration_malicious_content_triggers_meta_finding(tmp_pa
 
 def test_suppressions_integration_unknown_rule_id_triggers_meta_finding(tmp_path):
     """A directive that names a non-existent rule id must trigger the
-    ``nosec_unknown_rule_id`` meta-finding without silencing the real
+    ``unknown_suppression_rule`` meta-finding without silencing the real
     underlying finding."""
     playbook = _write_tmp_playbook(
         tmp_path,
@@ -1025,8 +1025,8 @@ def test_suppressions_integration_unknown_rule_id_triggers_meta_finding(tmp_path
     )
     data = _report_as_json(_scan_playbook(playbook))
     rule_ids = {f["rule_id"] for f in data["findings"] if f["line_number"] == 5}
-    assert "nosec_unknown_rule_id" in rule_ids, (
-        f"expected nosec_unknown_rule_id meta-finding; got {rule_ids}"
+    assert "unknown_suppression_rule" in rule_ids, (
+        f"expected unknown_suppression_rule meta-finding; got {rule_ids}"
     )
     assert "curl_pipe_to_shell" in rule_ids, (
         f"unknown-id directive must not silence the real finding; got {rule_ids}"
@@ -1047,14 +1047,14 @@ def test_suppressions_integration_known_rule_id_no_unknown_meta(tmp_path):
     )
     data = _report_as_json(_scan_playbook(playbook, show_suppressed=True))
     rule_ids = {f["rule_id"] for f in data["findings"]}
-    assert "nosec_unknown_rule_id" not in rule_ids, (
+    assert "unknown_suppression_rule" not in rule_ids, (
         f"valid rule id must not trigger unknown-id meta; got {rule_ids}"
     )
 
 
 def test_suppressions_integration_excessive_density_triggers_meta_finding(tmp_path):
     """A file with at least ``_EXCESSIVE_NOSEC_THRESHOLD`` valid directives
-    triggers ``excessive_nosec_suppression`` exactly once (file-level,
+    triggers ``excessive_suppressions`` exactly once (file-level,
     not per directive)."""
     from ansible_security_scanner.file_scanner import FileScanner
 
@@ -1068,9 +1068,9 @@ def test_suppressions_integration_excessive_density_triggers_meta_finding(tmp_pa
         )
     playbook = _write_tmp_playbook(tmp_path, "\n".join(lines) + "\n")
     data = _report_as_json(_scan_playbook(playbook))
-    excessive = [f for f in data["findings"] if f["rule_id"] == "excessive_nosec_suppression"]
+    excessive = [f for f in data["findings"] if f["rule_id"] == "excessive_suppressions"]
     assert len(excessive) == 1, (
-        f"expected exactly one excessive_nosec_suppression finding; got {len(excessive)}"
+        f"expected exactly one excessive_suppressions finding; got {len(excessive)}"
     )
 
 
@@ -1089,7 +1089,7 @@ def test_suppressions_integration_low_density_no_excessive_meta(tmp_path):
     )
     data = _report_as_json(_scan_playbook(playbook))
     rule_ids = {f["rule_id"] for f in data["findings"]}
-    assert "excessive_nosec_suppression" not in rule_ids, (
+    assert "excessive_suppressions" not in rule_ids, (
         f"low directive count must not trigger density meta; got {rule_ids}"
     )
 


### PR DESCRIPTION
Structural rules (those emitted from code with no `patterns/*.yml` entry) were rendering `this <rule_id> issue` in the Show recommended fix expander because the metadata renderer only consulted the YAML pattern catalog. Thread title / description / recommendation fallbacks through `generate_remediation_example` so the live `SecurityFinding` text is used when the catalog has no entry for the rule id.

Adds `inline_env_var_secret_laundering` (YAML pattern) for the `SECRET=value cmd -c` shape that scopes a secret to a child interpreter without ever appearing in argv, and `set_fact_secret_alias` (structural) for `set_fact` assignments that copy a secret-shaped variable into a generic-named fact, defeating name-based `no_log` heuristics.

Renames `nosec_unknown_rule_id` to `unknown_suppression_rule` and `excessive_nosec_suppression` to `excessive_suppressions`, and demotes both from HIGH to MEDIUM so a `--severity HIGH` CI gate passes while the findings remain always-emitted and unsuppressable.

Warns when `--ignore` lists an always-emitted rule id so users know the flag will not silence it.