### PR TITLE
Render Secure Fix Examples only from curated companion entries

### DIFF
--- a/src/ansible_security_scanner/link_resolver.py
+++ b/src/ansible_security_scanner/link_resolver.py
@@ -125,7 +125,7 @@ def _normalize_cwe(raw: str) -> str | None:
     m = _CWE_RE.match(s)
     if m:
         return f"CWE-{int(m.group(1))}"
-    if s.isdigit():
+    if s.isascii() and s.isdigit():
         return f"CWE-{int(s)}"
     return None
 

--- a/src/ansible_security_scanner/patterns/remediations/README.md
+++ b/src/ansible_security_scanner/patterns/remediations/README.md
@@ -1,10 +1,9 @@
 # Companion Remediation Files
 
-Each YAML file in this directory carries hand-written `Secure Fix` Ansible
+Each YAML file in this directory carries hand-written `secure_fix` Ansible
 snippets keyed by `rule_id`. The remediation renderer
 (`src/ansible_security_scanner/remediations/base.py::_render_from_metadata`)
-looks here when the matching pattern in `../<category>.yml` does not carry
-a `negative_examples:` field.
+emits the companion entry verbatim under `✅ Secure Fix Example`.
 
 This separation keeps pattern definitions (rule, regex, severity, metadata)
 distinct from remediation guidance (the safe Ansible to ship instead),
@@ -37,6 +36,18 @@ The relevance contract (`test_remediation_is_relevant_to_the_rule`) plus
 this Secure Fix block contract together guarantee every rule produces
 output that mentions the rule's own keywords AND ships a copy-pasteable
 Ansible fix.
+
+## `negative_examples` is not a remediation source
+
+`negative_examples:` on a pattern is a regex non-match fixture - inputs the
+rule must NOT flag. Many are intentionally degenerate strings chosen to
+exercise the regex's negative space, so surfacing them as
+`✅ Secure Fix Example` produces misleading guidance. The renderer accepts
+exactly three sources, in order:
+
+1. A `secure_fix:` entry in this directory.
+2. A tailored handler under `remediations/<category>.py`.
+3. `no_ansible_remediation: true` on the rule (procedural-only response).
 
 ## When a rule has no Ansible-task fix
 

--- a/src/ansible_security_scanner/patterns/remediations/ansible_hygiene.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ansible_hygiene.yml
@@ -133,3 +133,11 @@ remediations:
       # The application bearer token is fetched at runtime from
       # community.hashi_vault.vault_kv2_get('secret/app/api', 'token').
       # Cleartext examples like `# token: abc123` MUST be deleted.
+
+  debug_of_ansible_magic_auth_variable:
+    secure_fix: |
+      - name: Verify connectivity without printing the credential
+        ansible.builtin.ping:
+      - name: Log only non-sensitive identity
+        ansible.builtin.debug:
+          msg: "running as {{ ansible_user }}@{{ inventory_hostname }}"

--- a/src/ansible_security_scanner/patterns/remediations/command_injection.yml
+++ b/src/ansible_security_scanner/patterns/remediations/command_injection.yml
@@ -1,0 +1,91 @@
+# Companion Secure Fix snippets for command_injection rules.
+
+remediations:
+
+  command_chaining:
+    secure_fix: |
+      - name: Remove old build dir
+        ansible.builtin.file:
+          path: "/tmp/{{ name }}"
+          state: absent
+      - name: Restart service after cleanup
+        ansible.builtin.systemd:
+          name: app
+          state: restarted
+
+  curl_with_credentials:
+    secure_fix: |
+      - name: REST call with vault-sourced basic auth
+        ansible.builtin.uri:
+          url: https://controller.example.com/api/health
+          method: GET
+          url_username: "{{ vault_api_user }}"
+          url_password: "{{ vault_api_password }}"
+          force_basic_auth: true
+          validate_certs: true
+          status_code: 200
+        no_log: true
+
+  environment_variable_execution:
+    secure_fix: |
+      - name: Forward only allow-listed remote subcommands as argv
+        ansible.builtin.command:
+          argv:
+            - /usr/local/bin/forced-handler
+            - "{{ allowed_subcommand }}"
+        when: allowed_subcommand in ['status', 'reload', 'health']
+
+  eval_usage:
+    secure_fix: |
+      - name: Dispatch on a known action key
+        ansible.builtin.shell: |
+          case "{{ action | quote }}" in
+            start)  systemctl start app ;;
+            stop)   systemctl stop  app ;;
+            reload) systemctl reload app ;;
+            *) echo "unsupported action" >&2 ; exit 2 ;;
+          esac
+        args:
+          executable: /bin/bash
+
+  interpreter_inline_code_execution:
+    secure_fix: |
+      - name: Run vetted script with values on argv
+        ansible.builtin.script: "files/ingest.py {{ payload_id | quote }}"
+
+  secret_piped_to_text_processor:
+    secure_fix: |
+      - name: Read secret with the matching lookup plugin
+        ansible.builtin.set_fact:
+          app_secret: "{{ lookup('community.aws.aws_secret', 'app') }}"
+        no_log: true
+
+  secret_var_in_command_argv:
+    secure_fix: |
+      - name: Render secret to a 0600 tempfile
+        ansible.builtin.copy:
+          dest: /run/app/token
+          content: "{{ vault_api_token }}"
+          owner: app
+          group: app
+          mode: '0600'
+        no_log: true
+      - name: Pass the path on argv, not the value
+        ansible.builtin.command:
+          argv: [/usr/local/bin/app-cli, --token-file, /run/app/token]
+
+  shell_inline_compound_command:
+    secure_fix: |
+      - name: Run argv directly, no shell parser involved
+        ansible.builtin.command:
+          argv: [/usr/local/bin/app-tool, --target, "{{ target }}"]
+
+  subshell_execution:
+    secure_fix: |
+      - name: Resolve the dynamic value once
+        ansible.builtin.command: hostname
+        register: host_fact
+        changed_when: false
+      - name: Use the registered value as argv
+        ansible.builtin.command:
+          argv: [/usr/bin/tool, --arg, "{{ host_fact.stdout }}"]

--- a/src/ansible_security_scanner/patterns/remediations/dangerous_modules.yml
+++ b/src/ansible_security_scanner/patterns/remediations/dangerous_modules.yml
@@ -1,0 +1,18 @@
+# Companion Secure Fix snippets for dangerous_modules rules.
+
+remediations:
+
+  assemble_module_unsafe:
+    secure_fix: |
+      - name: Validate fragment dir is on the allow-list
+        ansible.builtin.assert:
+          that: fragment_dir in ['/etc/myapp/fragments', '/etc/myapp/extra-fragments']
+          fail_msg: "fragment_dir is not on the allow-list"
+      - name: Concatenate fragments from a controller-trusted directory
+        ansible.builtin.assemble:
+          src: "{{ fragment_dir }}"
+          dest: /etc/myapp/full.conf
+          owner: root
+          group: root
+          mode: '0640'
+          validate: "/usr/sbin/myapp -t -c %s"

--- a/src/ansible_security_scanner/patterns/remediations/data_exfiltration.yml
+++ b/src/ansible_security_scanner/patterns/remediations/data_exfiltration.yml
@@ -1,0 +1,40 @@
+# Companion Secure Fix snippets for data_exfiltration rules.
+
+remediations:
+
+  network_configuration_collection:
+    secure_fix: |
+      - name: Collect network state via Ansible facts
+        ansible.builtin.setup:
+          gather_subset:
+            - network
+            - interfaces
+        register: net_facts
+      - name: Persist to the controller, not the managed host
+        delegate_to: localhost
+        ansible.builtin.copy:
+          dest: "{{ playbook_dir }}/artifacts/{{ inventory_hostname }}-net.json"
+          content: "{{ net_facts | to_nice_json }}"
+          mode: '0600'
+
+  network_data_exfiltration:
+    secure_fix: |
+      - name: Capture on-host with restricted perms
+        ansible.builtin.command:
+          argv:
+            - tcpdump
+            - -w
+            - "/var/log/cap/{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic }}.pcap"
+            - -G
+            - '60'
+            - -W
+            - '1'
+        async: 65
+        poll: 0
+      - name: Ship to org-owned object store with IAM auth
+        amazon.aws.s3_object:
+          bucket: incident-pcaps
+          object: "{{ inventory_hostname }}/{{ ansible_date_time.iso8601_basic }}.pcap"
+          src: "/var/log/cap/{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic }}.pcap"
+          mode: put
+          encrypt: true

--- a/src/ansible_security_scanner/patterns/remediations/external_urls.yml
+++ b/src/ansible_security_scanner/patterns/remediations/external_urls.yml
@@ -1,0 +1,12 @@
+# Companion Secure Fix snippets for external_urls rules.
+
+remediations:
+
+  ip_address_url:
+    secure_fix: |
+      - name: Address the endpoint by hostname
+        ansible.builtin.uri:
+          url: https://api.internal.example.com/v1/health
+          method: GET
+          validate_certs: true
+          status_code: 200

--- a/src/ansible_security_scanner/patterns/remediations/hardcoded_credentials.yml
+++ b/src/ansible_security_scanner/patterns/remediations/hardcoded_credentials.yml
@@ -1,0 +1,99 @@
+# Companion Secure Fix snippets for hardcoded_credentials rules.
+
+remediations:
+
+  aws_access_key:
+    secure_fix: |
+      - name: Use IAM role / instance profile, no static keys
+        amazon.aws.s3_object:
+          bucket: app-artifacts
+          object: build.tar.gz
+          mode: get
+          dest: /opt/app/build.tar.gz
+
+  aws_secret_key:
+    secure_fix: |
+      - name: Resolve identity from IAM role, not a static secret
+        amazon.aws.aws_caller_info:
+        register: caller
+
+  factory_default_credential_in_basic_auth:
+    secure_fix: |
+      - name: First-boot rotation off the vendor default
+        ansible.builtin.uri:
+          url: https://controller.example.com/api/admin/password
+          method: POST
+          body_format: json
+          body:
+            current: "{{ vault_factory_default_password }}"
+            new:     "{{ vault_admin_password }}"
+          headers:
+            Authorization: "Basic {{ ('admin:' ~ vault_factory_default_password) | b64encode }}"
+          validate_certs: true
+          status_code: 200
+        no_log: true
+
+  hardcoded_username:
+    secure_fix: |
+      - name: Provision a least-privilege service account
+        ansible.builtin.user:
+          name: app_svc
+          system: true
+          shell: /usr/sbin/nologin
+          create_home: false
+      - name: Grant only the rules the play actually needs
+        community.general.sudoers:
+          name: app_svc-restart
+          user: app_svc
+          commands:
+            - /usr/bin/systemctl restart app
+          nopassword: false
+          state: present
+      - name: Subsequent tasks become the service account
+        ansible.builtin.systemd:
+          name: app
+          state: restarted
+        become: true
+        become_user: app_svc
+
+  heroku_api_key:
+    secure_fix: |
+      - name: Source the Heroku API key from Vault
+        community.general.heroku_collaborator:
+          api_key: "{{ vault_heroku_api_key }}"
+          user: ops@example.com
+          apps: [my-app]
+          state: present
+        no_log: true
+
+  plaintext_credential_key_var:
+    secure_fix: |
+      app_license_key:  "{{ vault_app_license_key }}"
+      hmac_signing_key: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/app').data.data.hmac_key }}"
+
+  plaintext_password_should_be_vaulted:
+    secure_fix: |
+      db_password: "{{ vault_db_password }}"
+      api_token:   "{{ vault_api_token }}"
+      jwt_secret:  "{{ vault_jwt_secret }}"
+
+  url_encoded_credentials:
+    secure_fix: |
+      - name: Login form with structured body, secret from Vault
+        ansible.builtin.uri:
+          url: https://app.example.com/login
+          method: POST
+          body_format: form-urlencoded
+          body:
+            username: "{{ user_name }}"
+            password: "{{ vault_user_password }}"
+            realm: corp
+          status_code: 200
+          return_content: true
+        no_log: true
+
+  uuid_like_secret:
+    secure_fix: |
+      api_key:    "{{ vault_app_api_key }}"
+      hec_token:  "{{ vault_hec_token }}"
+      auth_token: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/pagerduty').data.data.routing_key }}"

--- a/src/ansible_security_scanner/patterns/remediations/insecure_communication.yml
+++ b/src/ansible_security_scanner/patterns/remediations/insecure_communication.yml
@@ -718,3 +718,70 @@ remediations:
         # NEVER: validate_certs: false; if cert is internal, install
         # the internal CA into the system trust store (/etc/pki/...) or
         # pass `client_cert`/`client_key` for mTLS.
+
+  curl_wget_insecure_flag_in_shell_task:
+    secure_fix: |
+      - name: Install the internal CA so TLS verification can succeed
+        ansible.builtin.copy:
+          src: files/internal-ca.crt
+          dest: /usr/local/share/ca-certificates/internal-ca.crt
+          owner: root
+          group: root
+          mode: '0644'
+      - name: Refresh the system trust store
+        ansible.builtin.command: update-ca-certificates
+      - name: Fetch artefact with TLS verification enabled
+        ansible.builtin.get_url:
+          url: https://internal.example.com/build.tar.gz
+          dest: /opt/app/build.tar.gz
+          checksum: "sha256:{{ build_sha256 }}"
+          validate_certs: true
+          mode: '0644'
+
+  helm_repo_plaintext_http_skip_tls_verify:
+    secure_fix: |
+      - name: Helm repository over HTTPS with full TLS verification
+        kubernetes.core.helm_repository:
+          name: mychart
+          repo_url: https://charts.example.com/
+          validate_certs: true
+
+  insecure_protocol_usage:
+    secure_fix: |
+      - name: Fetch artefact over HTTPS with a pinned checksum
+        ansible.builtin.get_url:
+          url: https://artifacts.internal.example.com/app/app-1.2.3.tgz
+          dest: /opt/app/app-1.2.3.tgz
+          checksum: "sha256:{{ app_sha256 }}"
+          validate_certs: true
+          mode: '0644'
+
+  shell_ssh_scp_strict_host_key_disabled:
+    secure_fix: |
+      - name: Seed the host key from a trusted, out-of-band source
+        ansible.builtin.known_hosts:
+          name: ops-bastion.internal.example.com
+          key: "{{ bastion_host_key }}"
+          path: /etc/ssh/ssh_known_hosts
+          state: present
+      - name: SSH with default StrictHostKeyChecking
+        ansible.builtin.command:
+          argv:
+            - ssh
+            - -o
+            - UserKnownHostsFile=/etc/ssh/ssh_known_hosts
+            - ops-bastion.internal.example.com
+            - uptime
+
+  ssl_verification_disabled:
+    secure_fix: |
+      - name: REST call with TLS verification against the system trust store
+        ansible.builtin.uri:
+          url: https://api.internal.example.com/v1/health
+          validate_certs: true
+          status_code: 200
+      - name: REST call verifying against an internal CA bundle
+        ansible.builtin.uri:
+          url: https://api.corp.internal/v1/health
+          ca_path: /etc/pki/ca-trust/source/anchors/internal-ca.pem
+          validate_certs: true

--- a/src/ansible_security_scanner/patterns/remediations/jinja_lookup_rce.yml
+++ b/src/ansible_security_scanner/patterns/remediations/jinja_lookup_rce.yml
@@ -1,0 +1,30 @@
+# Companion Secure Fix snippets for jinja_lookup_rce rules.
+
+remediations:
+
+  jinja_in_set_fact_unsafe:
+    secure_fix: |
+      - name: Resolve the secret via a vault-aware lookup
+        ansible.builtin.set_fact:
+          api_token: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/app').data.data.token }}"
+        no_log: true
+
+  lookup_env_leak:
+    secure_fix: |
+      - name: Pull the token from the secrets backend
+        ansible.builtin.set_fact:
+          deploy_token: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/ci').data.data.deploy_token }}"
+        no_log: true
+
+  lookup_file_traversal:
+    secure_fix: |
+      - name: Reject paths outside the trusted prefix
+        ansible.builtin.assert:
+          that:
+            - cert_path is string
+            - cert_path.startswith('/etc/myapp/certs/')
+            - "'..' not in cert_path"
+          fail_msg: "cert_path must live under /etc/myapp/certs/"
+      - name: Read the validated certificate
+        ansible.builtin.set_fact:
+          cert_pem: "{{ lookup('ansible.builtin.file', cert_path) }}"

--- a/src/ansible_security_scanner/patterns/remediations/k8s_insecure_spec.yml
+++ b/src/ansible_security_scanner/patterns/remediations/k8s_insecure_spec.yml
@@ -311,3 +311,22 @@ remediations:
                     apiVersions: ["v1"]
                     operations: ["CREATE","UPDATE"]
                     resources: ["pods"]
+
+  k8s_wildcard_rbac:
+    secure_fix: |
+      - name: Least-privilege Role with explicit verbs, resources, and apiGroups
+        kubernetes.core.k8s:
+          state: present
+          definition:
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: app-reader
+              namespace: app
+            rules:
+              - apiGroups: [""]
+                resources: [pods, configmaps]
+                verbs: [get, list, watch]
+              - apiGroups: [apps]
+                resources: [deployments]
+                verbs: [get, list, watch]

--- a/src/ansible_security_scanner/patterns/remediations/lateral_movement.yml
+++ b/src/ansible_security_scanner/patterns/remediations/lateral_movement.yml
@@ -30,3 +30,12 @@ remediations:
             ansible_port: 5986
             ansible_winrm_server_cert_validation: validate
           mode: '0640'
+
+  delegate_to_external_host:
+    secure_fix: |
+      - name: Delegate to a literal, controller-trusted host
+        ansible.builtin.command: /usr/local/bin/run-on-bastion.sh
+        delegate_to: ops-bastion.internal.example.com
+      - name: Delegate to the first member of a validated inventory group
+        ansible.builtin.command: /usr/local/bin/run-on-master.sh
+        delegate_to: "{{ groups['kube_master'][0] }}"

--- a/src/ansible_security_scanner/patterns/remediations/malicious_activity.yml
+++ b/src/ansible_security_scanner/patterns/remediations/malicious_activity.yml
@@ -112,3 +112,19 @@ remediations:
           query: "{{ ddl_statement }}"
         register: ddl_result
         failed_when: ddl_result.rowcount is not defined
+
+  data_exfiltration_curl:
+    secure_fix: |
+      - name: Ship diagnostic to an org-owned, IAM-authenticated object store
+        amazon.aws.s3_object:
+          bucket: ops-diagnostics
+          object: "{{ inventory_hostname }}/{{ ansible_date_time.iso8601_basic }}.tgz"
+          src: /tmp/diagnostic.tgz
+          mode: put
+          encrypt: true
+      - name: Block known anonymous-upload sinks at egress
+        community.general.ufw:
+          rule: deny
+          direction: out
+          to: any
+          comment: "T1567 anonymous upload sinks"

--- a/src/ansible_security_scanner/patterns/remediations/obfuscation_evasion.yml
+++ b/src/ansible_security_scanner/patterns/remediations/obfuscation_evasion.yml
@@ -1,0 +1,11 @@
+# Companion Secure Fix snippets for obfuscation_evasion rules.
+
+remediations:
+
+  inline_env_var_secret_laundering:
+    secure_fix: |
+      - name: Bind secret via Ansible's environment: keyword, scoped to the task
+        ansible.builtin.command: python3 /opt/app/ingest.py
+        environment:
+          APP_SECRET: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/app').data.data.secret }}"
+        no_log: true

--- a/src/ansible_security_scanner/patterns/remediations/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/remediations/operational_security.yml
@@ -483,3 +483,69 @@ remediations:
           --restricted-services=storage.googleapis.com,bigquery.googleapis.com
           --enable-vpc-accessible-services
           --vpc-allowed-services=RESTRICTED-SERVICES
+
+  docker_sock_abuse:
+    secure_fix: |
+      - name: Container runtime metrics with no docker.sock bind-mount
+        community.docker.docker_container:
+          name: cadvisor
+          image: gcr.io/cadvisor/cadvisor:v0.49.1
+          read_only: true
+          volumes:
+            - /:/rootfs:ro
+            - /var/lib/docker:/var/lib/docker:ro
+            - /sys:/sys:ro
+          state: started
+      - name: Mediate Docker API access via a read-only socket proxy
+        community.docker.docker_container:
+          name: docker-socket-proxy
+          image: tecnativa/docker-socket-proxy:0.3.0
+          env:
+            CONTAINERS: "1"
+            IMAGES:     "1"
+            POST:       "0"
+            DELETE:     "0"
+          volumes:
+            - /var/run/docker.sock:/var/run/docker.sock:ro
+          published_ports: ["127.0.0.1:2375:2375"]
+          state: started
+
+  falco_runtime_security_agent_disabled_or_masked:
+    secure_fix: |
+      - name: Ensure Falco is installed
+        ansible.builtin.package:
+          name: falco
+          state: present
+      - name: Falco runs at boot
+        ansible.builtin.systemd:
+          name: falco
+          enabled: true
+          state: started
+      - name: Tune noisy rules locally rather than disabling the service
+        ansible.builtin.copy:
+          dest: /etc/falco/falco_rules.local.yaml
+          content: |
+            - rule: Write below etc
+              exceptions:
+                - name: known_package_manager_writes
+                  fields: [proc.name]
+                  values: [apt, dpkg, rpm, dnf]
+          owner: root
+          group: root
+          mode: '0644'
+        notify: restart falco
+
+  password_expiry_disabled:
+    secure_fix: |
+      - name: Set the system-wide maximum password age
+        ansible.builtin.lineinfile:
+          path: /etc/login.defs
+          regexp: '^PASS_MAX_DAYS\b'
+          line: 'PASS_MAX_DAYS   90'
+          owner: root
+          group: root
+          mode: '0644'
+      - name: Apply the rotation policy to a specific account
+        ansible.builtin.command:
+          cmd: chage -M 90 svc_user
+        changed_when: false

--- a/src/ansible_security_scanner/patterns/remediations/privilege_escalation.yml
+++ b/src/ansible_security_scanner/patterns/remediations/privilege_escalation.yml
@@ -56,3 +56,20 @@ remediations:
           data: 0
           type: dword
           state: present
+
+  dangerous_world_writable:
+    secure_fix: |
+      - name: Sensitive directory with group-restricted access
+        ansible.builtin.file:
+          path: /etc/myapp
+          state: directory
+          owner: root
+          group: myapp
+          mode: '0750'
+      - name: Sensitive file readable only to owner and service group
+        ansible.builtin.file:
+          path: /etc/myapp/secret.conf
+          state: file
+          owner: root
+          group: myapp
+          mode: '0640'

--- a/src/ansible_security_scanner/patterns/remediations/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/remediations/system_compromise.yml
@@ -503,3 +503,27 @@ remediations:
           name: SafeDllSearchMode
           data: 1
           type: dword
+
+  ssh_keygen_empty_passphrase_privileged_key:
+    secure_fix: |
+      - name: Issue a short-TTL host certificate signed by an SSH CA
+        ansible.builtin.command:
+          argv:
+            - ssh-keygen
+            - -s
+            - /etc/ssh/ca
+            - -I
+            - "host-{{ inventory_hostname }}"
+            - -h
+            - -V
+            - "+1h"
+            - /etc/ssh/ssh_host_ed25519_key.pub
+        no_log: true
+      - name: Service account authorized_keys with from= and command= restrictions
+        ansible.builtin.copy:
+          dest: /home/svc/.ssh/authorized_keys
+          content: |
+            from="10.0.0.0/8",command="/usr/local/bin/svc-restart",restrict ssh-ed25519 AAAA... svc@controller
+          owner: svc
+          group: svc
+          mode: '0600'

--- a/src/ansible_security_scanner/patterns/remediations/template_injection.yml
+++ b/src/ansible_security_scanner/patterns/remediations/template_injection.yml
@@ -86,3 +86,44 @@ remediations:
           resolve_entities=False, no_network=True, dtd_validation=False,
           load_dtd=False, recover=False)
       tree = etree.parse(path, parser)
+
+  jinja2_lookup_pipe_in_template:
+    secure_fix: |
+      - name: Resolve the lookup once in a reviewable task
+        ansible.builtin.set_fact:
+          install_dir: "{{ lookup('pipe', '/usr/local/bin/get-install-dir') }}"
+      - name: Render the template against the resolved fact
+        ansible.builtin.template:
+          src: app.conf.j2
+          dest: /etc/app/app.conf
+          mode: '0640'
+
+  template_command_substitution:
+    secure_fix: |
+      - name: Resolve the dynamic value with a registered command
+        ansible.builtin.command: /usr/bin/sha512sum myapp.tar.gz
+        register: sha_result
+        changed_when: false
+      - name: Use the registered value with a quoted interpolation
+        ansible.builtin.shell: "echo {{ sha_result.stdout.split()[0] | quote }}"
+
+  template_in_sql_query:
+    secure_fix: |
+      - name: Parameterised query using named_args
+        community.postgresql.postgresql_query:
+          login_host: "{{ db_host }}"
+          login_user: "{{ db_user }}"
+          login_password: "{{ vault_db_password }}"
+          db: "{{ db_name }}"
+          query: "UPDATE users SET role = %(role)s WHERE id = %(id)s"
+          named_args:
+            role: "{{ role }}"
+            id:   "{{ user_id }}"
+
+  unquoted_template_variable:
+    secure_fix: |
+      - name: Run argv directly so no shell parses the interpolation
+        ansible.builtin.command:
+          argv: [/usr/local/bin/echo-tool, "{{ user_input }}"]
+      - name: When a shell is required, fully quote the interpolation
+        ansible.builtin.shell: "echo {{ user_input | quote }}"

--- a/src/ansible_security_scanner/patterns/remediations/unauthorized_cloud_access.yml
+++ b/src/ansible_security_scanner/patterns/remediations/unauthorized_cloud_access.yml
@@ -1158,3 +1158,22 @@ remediations:
             restrict_public_buckets: true
           policy: "{{ lookup('file', 'policies/private-only.json') }}"
           state: present
+
+  gcp_compute_firewall_ssh_rdp_open_to_world:
+    secure_fix: |
+      - name: Restrict SSH ingress to corporate egress NAT only
+        google.cloud.gcp_compute_firewall:
+          name: ssh-from-corp
+          network: { selfLink: "{{ vpc_self_link }}" }
+          direction: INGRESS
+          source_ranges:
+            - 203.0.113.0/24
+            - 198.51.100.0/24
+          allowed:
+            - ip_protocol: tcp
+              ports: ['22']
+          target_tags: [bastion]
+          state: present
+      - name: Connect via IAP TCP forwarding instead of a public IP
+        ansible.builtin.command:
+          argv: [gcloud, compute, ssh, "{{ vm_name }}", --tunnel-through-iap]

--- a/src/ansible_security_scanner/patterns/remediations/unsafe_permissions.yml
+++ b/src/ansible_security_scanner/patterns/remediations/unsafe_permissions.yml
@@ -230,3 +230,104 @@ remediations:
         UserKnownHostsFile ~/.ssh/known_hosts
         VerifyHostKeyDNS yes
         UpdateHostKeys ask
+
+  delegate_to_dynamic_host:
+    secure_fix: |
+      - name: Static delegate target (no Jinja in delegate_to)
+        ansible.builtin.command: /usr/local/bin/run-on-bastion.sh
+        delegate_to: ops-bastion.internal.example.com
+      - name: Validate the host belongs to a known group before delegating
+        ansible.builtin.assert:
+          that: target_host in groups['kube_master']
+          fail_msg: "target_host is not a kube_master inventory member"
+      - name: Delegate to the validated host
+        ansible.builtin.command: /usr/local/bin/run-on-master.sh
+        delegate_to: "{{ target_host }}"
+
+  git_accept_hostkey_yes:
+    secure_fix: |
+      - name: Seed the git remote host key from a trusted source
+        ansible.builtin.known_hosts:
+          name: github.com
+          key: "{{ github_host_key }}"
+          path: /etc/ssh/ssh_known_hosts
+          state: present
+      - name: Clone with default StrictHostKeyChecking
+        ansible.builtin.git:
+          repo: git@github.com:example/config.git
+          dest: /opt/config
+          accept_hostkey: false
+
+  inventory_group_vars_all_contains_plaintext_secret:
+    secure_fix: |
+      db_password:    "{{ vault_db_password }}"
+      api_token:      "{{ vault_api_token }}"
+      jwt_secret:     "{{ vault_jwt_secret }}"
+      private_ssh_key: "{{ lookup('community.hashi_vault.vault_kv2_get', path='secret/ssh').data.data.private_key }}"
+
+  private_key_copied_outside_dot_ssh:
+    secure_fix: |
+      - name: Render the key into the owning user's ~/.ssh
+        ansible.builtin.copy:
+          dest: /home/svc/.ssh/id_ed25519
+          content: "{{ vault_svc_ssh_private_key }}"
+          owner: svc
+          group: svc
+          mode: '0600'
+        no_log: true
+      - block:
+          - name: Stage a temporary key under a 0700 directory
+            ansible.builtin.copy:
+              dest: /run/svc/key
+              content: "{{ vault_svc_ssh_private_key }}"
+              owner: svc
+              group: svc
+              mode: '0600'
+            no_log: true
+          - name: Use the staged key
+            ansible.builtin.command: /usr/local/bin/svc-tool --key /run/svc/key
+        always:
+          - name: Remove the staged key
+            ansible.builtin.file:
+              path: /run/svc/key
+              state: absent
+
+  tls_secret_downloaded_to_world_dir:
+    secure_fix: |
+      - name: Pre-create the secret directory
+        ansible.builtin.file:
+          path: /etc/ssl/private
+          state: directory
+          owner: root
+          group: ssl-cert
+          mode: '0710'
+      - name: Download the key directly into its final location
+        amazon.aws.s3_object:
+          bucket: tls-private
+          object: app/server.key
+          mode: get
+          dest: /etc/ssl/private/server.key
+          overwrite: different
+      - name: Lock down the downloaded key
+        ansible.builtin.file:
+          path: /etc/ssl/private/server.key
+          owner: app
+          group: app
+          mode: '0600'
+
+  world_writable_files:
+    secure_fix: |
+      - name: Sensitive file readable only to owner and service group
+        ansible.builtin.file:
+          path: /etc/myapp/config.yml
+          state: file
+          owner: root
+          group: myapp
+          mode: '0640'
+      - name: Sensitive directory traversable only by owner and service group
+        ansible.builtin.file:
+          path: /var/lib/myapp
+          state: directory
+          owner: myapp
+          group: myapp
+          mode: '0750'

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -34,7 +34,7 @@ def _render_from_metadata(
     recommendation = meta.get("recommendation") or recommendation_fallback
     no_ansible_fix = bool(meta.get("no_ansible_remediation"))
 
-    secure_fix = None if no_ansible_fix else _select_secure_fix(rule_id, meta)
+    secure_fix = None if no_ansible_fix else _select_secure_fix(rule_id)
     if secure_fix:
         secure_block = f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
     elif no_ansible_fix:
@@ -58,12 +58,12 @@ def _render_from_metadata(
     )
 
 
-def _select_secure_fix(rule_id: str, meta: dict) -> str | None:
-    """Return rule-local ``negative_examples[0]`` if present, else the
-    companion-file entry, else None."""
-    for example in meta.get("negative_examples") or []:
-        if isinstance(example, str) and example.strip():
-            return example.rstrip("\n")
+def _select_secure_fix(rule_id: str) -> str | None:
+    """Return the curated companion-file fix for ``rule_id``, or ``None``.
+
+    ``negative_examples`` are regex non-match fixtures, not curated secure
+    code, so they are intentionally not consulted as a remediation source.
+    """
     return _companion_index.get(rule_id)
 
 

--- a/src/ansible_security_scanner/remediations/malicious_activity.py
+++ b/src/ansible_security_scanner/remediations/malicious_activity.py
@@ -5,7 +5,6 @@ Malicious activity remediation generator for Ansible Security Scanner
 
 import re
 
-from . import _pattern_index
 from .base import BaseRemediationGenerator, _render_from_metadata
 
 
@@ -876,17 +875,3 @@ This code contains patterns consistent with malicious activity and should be rem
 
         body = self._generate_generic_malicious_fix(code_snippet)
         return context_callout + body
-
-    def _generate_pattern_driven_fix(self, rule_id: str, code_snippet: str) -> str:
-        meta = _pattern_index.get(rule_id)
-        description = meta.get("description") or f"this {rule_id} pattern"
-        recommendation = meta.get("recommendation") or ""
-        negs = meta.get("negative_examples") or []
-        secure_block = f"\n**Secure Fix Example:**\n```yaml\n{negs[0]}\n```\n" if negs else ""
-        rec_block = f"\n**Recommendation:**\n{recommendation}\n" if recommendation else ""
-        return (
-            f"\n**Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
-            f"\n**What this rule detects ({rule_id}):**\n{description}\n"
-            f"{rec_block}"
-            f"{secure_block}"
-        )

--- a/src/ansible_security_scanner/remediations/supply_chain.py
+++ b/src/ansible_security_scanner/remediations/supply_chain.py
@@ -5,8 +5,7 @@ Remediation generator for supply chain integrity issues
 
 from __future__ import annotations
 
-from . import _pattern_index
-from .base import BaseRemediationGenerator
+from .base import BaseRemediationGenerator, _render_from_metadata
 
 
 class SupplyChainRemediationGenerator(BaseRemediationGenerator):
@@ -267,18 +266,7 @@ class SupplyChainRemediationGenerator(BaseRemediationGenerator):
 """
 
     def _generate_pattern_driven_fix(self, rule_id: str, code_snippet: str) -> str:
-        meta = _pattern_index.get(rule_id)
-        description = meta.get("description") or f"this {rule_id} issue"
-        recommendation = meta.get("recommendation") or ""
-        negs = meta.get("negative_examples") or []
-        secure_block = f"\n**Secure Fix Example:**\n```yaml\n{negs[0]}\n```\n" if negs else ""
-        rec_block = f"\n**Recommendation:**\n{recommendation}\n" if recommendation else ""
-        return (
-            f"\n**Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
-            f"\n**What this rule detects ({rule_id}):**\n{description}\n"
-            f"{rec_block}"
-            f"{secure_block}"
-        )
+        return _render_from_metadata(rule_id, code_snippet)
 
     # Ecosystem remediation generators
     def _generate_role_meta_unpinned_fix(self, code_snippet: str) -> str:

--- a/src/ansible_security_scanner/remediations/system_compromise.py
+++ b/src/ansible_security_scanner/remediations/system_compromise.py
@@ -3,7 +3,6 @@
 System compromise remediation generator for Ansible Security Scanner
 """
 
-from . import _pattern_index
 from .base import BaseRemediationGenerator, _render_from_metadata
 
 
@@ -465,37 +464,6 @@ This command creates unauthorized privilege escalation paths, allowing attackers
 """
 
         return template
-
-    def _generate_metadata_compromise_fix(self, rule_id: str, code_snippet: str) -> str:
-        """Build a rule-specific remediation from the pattern's own metadata.
-
-        The rule's ``title``, ``description``, ``recommendation`` and
-        ``negative_examples`` (when present) carry far better context than
-        any category-level boilerplate could - so render them. When a rule
-        has no recommendation we still emit the rule's title and description
-        verbatim, which beats the legacy "perform legitimate maintenance"
-        template that had no relationship to the actual finding.
-        """
-        meta = _pattern_index.get(rule_id)
-        title = meta.get("title") or rule_id
-        description = meta.get("description") or ""
-        recommendation = meta.get("recommendation") or ""
-        negs = meta.get("negative_examples") or []
-
-        secure_block = ""
-        if negs:
-            secure_block = f"\n**\u2705 Secure Fix Example:**\n```yaml\n{negs[0]}\n```\n"
-
-        rec_block = ""
-        if recommendation:
-            rec_block = f"\n**\U0001f6e0 Recommendation:**\n{recommendation}\n"
-
-        return (
-            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
-            f"\n**\U0001f50d {title} ({rule_id}):**\n{description}\n"
-            f"{rec_block}"
-            f"{secure_block}"
-        )
 
     def _generate_generic_compromise_fix(self, code_snippet: str) -> str:
         """Legacy boilerplate fallback. Retained for backward compatibility

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -307,9 +307,18 @@ def test_remediation_is_relevant_to_the_rule(
 
 
 _SECURE_FIX_BLOCK_RE = re.compile(
-    r"\*\*\u2705[^*\n]+:\*\*\s*\n(?:[^\n]*\n){0,3}```ya?ml\n",
-    re.MULTILINE,
+    r"\*\*\u2705[^*\n]+:\*\*\s*\n(?:[^\n]*\n){0,3}```ya?ml\n(?P<body>.*?)\n```",
+    re.MULTILINE | re.DOTALL,
 )
+
+
+def _companion_fix_hint(rule_id: str, category: str, companion_path) -> str:
+    return (
+        f"  Add a `secure_fix:` entry for `{rule_id}` in {companion_path},\n"
+        f"  or implement a tailored handler in remediations/{category}.py,\n"
+        f"  or set `no_ansible_remediation: true` on the rule if the correct\n"
+        f"  response is procedural."
+    )
 
 
 @pytest.mark.parametrize(
@@ -322,9 +331,10 @@ def test_remediation_includes_secure_fix_yaml_block(
     rule_id: str,
     category: str,
 ) -> None:
-    """Every rule must carry a concrete ``✅ Secure Fix`` YAML block, or
-    set ``no_ansible_remediation: true`` if the correct response is
-    procedural rather than configurable from Ansible."""
+    """Every rule must render a curated ``✅ Secure Fix`` YAML block or set
+    ``no_ansible_remediation: true``. ``negative_examples`` are regex
+    non-match fixtures and are explicitly not accepted as a fix source.
+    """
     meta = _PI.get(rule_id)
     if meta.get("no_ansible_remediation"):
         return
@@ -332,9 +342,6 @@ def test_remediation_includes_secure_fix_yaml_block(
     out = remediation_generator.generate_remediation_example(
         rule_id, "shell: echo placeholder", file_path="test.yml", line_number=1
     )
-
-    if _SECURE_FIX_BLOCK_RE.search(out):
-        return
 
     yml_path = PATTERNS_DIR / f"{category}.yml"
     if not yml_path.exists():
@@ -345,27 +352,32 @@ def test_remediation_includes_secure_fix_yaml_block(
                 break
 
     companion_path = (
-        PATTERNS_DIR / "remediations" / yml_path.name
-        if yml_path
-        else PATTERNS_DIR / "remediations" / f"{category}.yml"
+        PATTERNS_DIR / "remediations" / (yml_path.name if yml_path else f"{category}.yml")
     )
+    fix_hint = _companion_fix_hint(rule_id, category, companion_path)
 
-    pytest.fail(
-        f"{rule_id}: remediation has no `\u2705 Secure Fix` YAML block.\n"
-        f"  category: {category}\n"
-        f"  pattern file: {yml_path}\n"
-        f"\n"
-        f"  Fix one of THREE ways:\n"
-        f"    (a) Add `negative_examples:` to the rule in {yml_path.name}.\n"
-        f"    (b) Add a `secure_fix:` entry under this rule_id in {companion_path}.\n"
-        f"    (c) Add a tailored handler in remediations/<category>.py.\n"
-        f"\n"
-        f"  Or set `no_ansible_remediation: true` on the rule if the\n"
-        f"  correct response is procedural.\n"
-        f"\n"
-        f"  Remediation excerpt (first 320 chars):\n"
-        f"    {out[:320]!r}"
-    )
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    if not match:
+        pytest.fail(
+            f"{rule_id}: remediation has no `\u2705 Secure Fix` YAML block.\n"
+            f"{fix_hint}\n"
+            f"\n  Remediation excerpt (first 320 chars):\n    {out[:320]!r}"
+        )
+
+    rendered_body = match.group("body").strip()
+    negative_bodies = {
+        ex.rstrip("\n").strip()
+        for ex in (meta.get("negative_examples") or [])
+        if isinstance(ex, str)
+    }
+    if rendered_body in negative_bodies:
+        pytest.fail(
+            f"{rule_id}: rendered Secure Fix YAML matches a "
+            f"`negative_examples` fixture verbatim. Negative examples are "
+            f"regex non-match fixtures, not curated remediation Ansible.\n"
+            f"{fix_hint}\n"
+            f"\n  rendered body (first 320 chars):\n    {rendered_body[:320]!r}"
+        )
 
 
 class TestMaliciousActivityDirect:


### PR DESCRIPTION
## Summary

- Stop reading `negative_examples` (regex non-match fixtures) as a Secure Fix source in `remediations/base.py`; the renderer now emits the companion-file entry verbatim or omits the block.
- Author curated `secure_fix:` entries for the 51 rules that previously relied on the fallback, across new and existing files under `patterns/remediations/`.
- Tighten `test_remediation_includes_secure_fix_yaml_block` to fail if the rendered Secure Fix YAML matches any `negative_examples` body, and refresh `patterns/remediations/README.md` accordingly.
- Guard `link_resolver._normalize_cwe` against Unicode digits so the existing resolver fuzz test no longer crashes on inputs like `'\u00b9'`.