### PR TITLE
Detect basic auth on uri tasks with validate_certs disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1101-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1102-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1101<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1102<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->412<!--/CRIT--> critical**, <!--HIGH-->537<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->413<!--/CRIT--> critical**, <!--HIGH-->537<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1101<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1102<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/patterns/insecure_communication.yml
+++ b/src/ansible_security_scanner/patterns/insecure_communication.yml
@@ -1390,6 +1390,57 @@ patterns:
     hipaa: ['164.312(e)(1)']
     soc2: ['CC6.7']
 
+  - id: "basic_auth_without_tls_verification"
+    category: "insecure_communication"
+    severity: "CRITICAL"
+    title: "ansible.builtin.uri Sends Basic-Auth Credentials With validate_certs: false"
+    description: "An `ansible.builtin.uri` / `uri` task sets both `force_basic_auth: true` and `validate_certs: false` on the same task. `force_basic_auth: true` ships `Authorization: Basic <base64(user:password)>` in the very first request without waiting for a `401` challenge, so the credential is on the wire on every retry. With `validate_certs: false` on the same task, an on-path attacker presenting any TLS certificate receives the basic-auth credential and recovers the password with one base64 decode."
+    regex: "(?ms)(?:ansible\\.builtin\\.uri|^[\\t ]*uri)\\s*:(?:(?!^\\s*-\\s+(?:name|block|hosts|ansible\\.builtin\\.))[\\s\\S]){0,1500}?(?:\\bforce_basic_auth\\s*:\\s*['\"]?(?:true|yes|on|1)['\"]?(?:(?!^\\s*-\\s+(?:name|block|hosts|ansible\\.builtin\\.))[\\s\\S]){0,1500}?\\bvalidate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?|\\bvalidate_certs\\s*:\\s*['\"]?(?:false|no|0|off|n)['\"]?(?:(?!^\\s*-\\s+(?:name|block|hosts|ansible\\.builtin\\.))[\\s\\S]){0,1500}?\\bforce_basic_auth\\s*:\\s*['\"]?(?:true|yes|on|1)['\"]?)"
+    positive_examples:
+      - |2-
+        - name: post update
+          uri:
+            url: "{{ api_base }}/v1/items"
+            method: POST
+            user: admin
+            password: "{{ vault_admin_password }}"
+            force_basic_auth: yes
+            validate_certs: no
+      - |2-
+        ansible.builtin.uri:
+          url: "{{ controller }}/api/v1/login"
+          user: ops
+          password: "{{ vault_ops_password }}"
+          validate_certs: false
+          force_basic_auth: true
+    negative_examples:
+      - |2-
+        - name: post update
+          uri:
+            url: "https://api.internal.example.com/v1/items"
+            method: POST
+            user: ops
+            password: "{{ vault_ops_password }}"
+            force_basic_auth: yes
+            validate_certs: yes
+      - |2-
+        - name: fetch token
+          uri:
+            url: "https://idp.internal/oauth/token"
+            validate_certs: false
+    multiline: true
+    window: 40
+    recommendation: "Set `validate_certs: true` on every `uri:` task that uses `force_basic_auth: true`. For internal CAs, install the bundle into the system trust store or pass `ca_path: /etc/pki/ca-trust/source/anchors/internal-ca.pem` instead of disabling validation. Add `no_log: true` to the task so the password is not written to logs."
+    cwe: ['CWE-295', 'CWE-300', 'CWE-319', 'CWE-522']
+    owasp_appsec: ["A02:2021", "A07:2021"]
+    owasp_asvs: [V12.3.4, V14.2.1]
+    mitre_attack: ['T1040', 'T1557', 'T1078']
+    cis_controls: ['CIS-3.10', 'CIS-15.4']
+    nist_controls: ['IA-5', 'SC-8', 'SC-8(1)', 'SC-23']
+    pci_dss: ['4.1', '4.2.1', '8.3.1']
+    hipaa: ['164.312(a)(2)(iv)', '164.312(e)(1)']
+    soc2: ['CC6.1', 'CC6.7']
+
   - id: "uri_module_url_plaintext_http"
     category: "insecure_communication"
     severity: "HIGH"

--- a/src/ansible_security_scanner/patterns/remediations/insecure_communication.yml
+++ b/src/ansible_security_scanner/patterns/remediations/insecure_communication.yml
@@ -719,6 +719,22 @@ remediations:
         # the internal CA into the system trust store (/etc/pki/...) or
         # pass `client_cert`/`client_key` for mTLS.
 
+  basic_auth_without_tls_verification:
+    secure_fix: |
+      - name: REST call with basic auth, full cert validation
+        ansible.builtin.uri:
+          url: "https://api.internal.example.com/v1/items"
+          method: POST
+          url_username: "{{ vault_api_user }}"
+          url_password: "{{ vault_api_password }}"
+          force_basic_auth: true
+          validate_certs: true
+          ca_path: /etc/pki/ca-trust/source/anchors/internal-ca.pem
+          body_format: json
+          body: { name: "{{ item_name }}" }
+          status_code: 201
+        no_log: true
+
   curl_wget_insecure_flag_in_shell_task:
     secure_fix: |
       - name: Install the internal CA so TLS verification can succeed

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -337,6 +337,7 @@ rules_by_category:
     - azure_db_server_ssl_enforcement_disabled
     - azure_redis_non_ssl_port_enabled
     - azure_webapp_https_only_disabled
+    - basic_auth_without_tls_verification
     - bind_named_conf_open_recursion
     - consul_acl_default_policy_allow
     - curl_wget_insecure_flag_in_shell_task

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -5347,6 +5347,15 @@
         method: GET
         validate_certs: false
 
+    - name: trigger uri basic auth without tls verification
+      ansible.builtin.uri:
+        url: https://self-signed.badssl.com/api
+        method: POST
+        user: admin
+        password: "{{ vault_admin_password }}"
+        force_basic_auth: yes
+        validate_certs: no
+
     - name: trigger uri plaintext http url
       ansible.builtin.uri:
         url: http://internal-api.example.com/v1/register


### PR DESCRIPTION
Adds `basic_auth_without_tls_verification` (CRITICAL) - fires when an `ansible.builtin.uri` / `uri` task sets both `force_basic_auth: true` and `validate_certs: false` on the same task. The combination ships the basic-auth credential to whatever certificate an on-path attacker presents.