### PR TITLE
Speed up file scanner and fix data exfiltration false positives

### DIFF
--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -5401,7 +5401,15 @@ class FileScanner:
             else:
                 line_mode.append(p)
 
-        # Single-line pass
+        # Both passes share one fast-reject shortcut: a pattern that does not
+        # match the whole file text cannot match any single line or window, so
+        # one search up front lets us skip the per-line loop for every pattern
+        # that is absent from the file - the common case.
+        full_text = "\n".join(lines)
+
+        # Single-line pass. ``^``/``$`` anchored patterns are exempt from the
+        # shortcut: those anchors match differently against the whole text than
+        # against one line, so the up-front search could wrongly reject them.
         for pattern_obj in line_mode:
             compiled_single = getattr(pattern_obj, "_compiled", None)
             if compiled_single is None:
@@ -5409,6 +5417,12 @@ class FileScanner:
                     compiled_single = re.compile(pattern_obj.regex, re.IGNORECASE)
                 except re.error:
                     continue
+            if (
+                "^" not in pattern_obj.regex
+                and "$" not in pattern_obj.regex
+                and not compiled_single.search(full_text)
+            ):
+                continue
             pid = pattern_obj.id
             for line_num, line in enumerate(lines, 1):
                 key = (pid, line_num)
@@ -5454,7 +5468,8 @@ class FileScanner:
         # finding to the line of the first line within the window that
         # contains a piece of the match (so reports point to the anchor, not
         # a later line). If we cannot localise, we fall back to the window
-        # start line.
+        # start line. A window is always a contiguous slice of ``full_text``,
+        # so the same fast-reject applies.
         for pattern_obj in window_mode:
             win = max(1, int(getattr(pattern_obj, "window", 10) or 10))
             compiled = getattr(pattern_obj, "_compiled_multiline", None)
@@ -5463,6 +5478,8 @@ class FileScanner:
                     compiled = re.compile(pattern_obj.regex, re.IGNORECASE | re.MULTILINE)
                 except re.error:
                     continue
+            if not compiled.search(full_text):
+                continue
             pid = pattern_obj.id
             total = len(lines)
             for start_idx in range(total):

--- a/src/ansible_security_scanner/patterns/data_exfiltration.yml
+++ b/src/ansible_security_scanner/patterns/data_exfiltration.yml
@@ -28,13 +28,25 @@ patterns:
     title: "Credential File Search"
     description: >-
         find -name searches for SSH keys (id_rsa/id_dsa/id_ecdsa/id_ed25519),
-        PEM/p12/pfx files, or `credentials`/`config` filenames - the canonical
+        PEM/p12/pfx files, or a `credentials` filename - the canonical
         reconnaissance step before credential theft.
-    regex: "find.*-name.*(?:id_rsa|id_dsa|id_ecdsa|id_ed25519|\\.pem|\\.key|\\.p12|\\.pfx|credentials|config)"
+    # Match only a positive ``-name``/``-iname`` predicate: ``(?<!! )`` rejects
+    # the ``! -name 'cluster.key'`` exclusion form (protecting files from a
+    # ``-delete``/``-prune`` is the opposite of hunting credentials). The
+    # token list is restricted to high-confidence credential artifacts; bare
+    # ``config`` and ``.key`` are dropped because ``kubeconfig`` / ``*.config``
+    # / ``cluster.key`` housekeeping are common benign shapes.
+    regex: "find\\b[^\\n]*?(?<!! )-i?name\\s+\\S*(?:id_rsa|id_dsa|id_ecdsa|id_ed25519|\\.pem|\\.p12|\\.pfx|credentials)"
     positive_examples:
       - |2
             - ansible.builtin.shell: find /home -name id_rsa
-    recommendation: "find -name id_rsa / *.pem / *.key / credentials is a credential-discovery primitive; if the play actually needs to manage SSH keys, target known paths explicitly and use ansible.builtin.find with file_type and a strict pattern: list, never a recursive credential sweep."
+      - "    shell: find / -iname '*.pem'"
+      - "    shell: find /root -name credentials"
+    negative_examples:
+      - "    shell: sudo find \"$DQLITE\" -maxdepth 1 -type f ! -name 'cluster.key' -delete"
+      - "    shell: find /etc -name '*.config' -prune"
+      - "    shell: find ~/.kube -name kubeconfig -delete"
+    recommendation: "find -name id_rsa / *.pem / *.p12 / credentials is a credential-discovery primitive; if the play actually needs to manage SSH keys, target known paths explicitly and use ansible.builtin.find with file_type and a strict pattern: list, never a recursive credential sweep."
     cwe: ['CWE-200', 'CWE-522']
     owasp_appsec: ["A01:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V14.2.2]
@@ -98,7 +110,12 @@ patterns:
     # so Jinja comparisons like ``count > 0`` and XML tag tails like
     # ``form>`` are excluded. The target must look like a path (letters
     # and ``/`` / ``.`` / ``~`` / ``$`` / backtick / a variable ref).
-    regex: "(?:(?:^|[\\s;|&])(?:netstat|ss|ifconfig|arp|route)\\b|\\bip\\s+(?:route|addr|link|neigh))\\b[^\\n]*?>>?[ \\t]*(?:['\\\"]?(?:[/~.$]|\\{\\{|\\$\\(|/dev/)|[A-Za-z][\\w./-]*\\.(?:txt|log|out|csv|json|xml|tmp|dat))"
+    # The ``>`` must be a stdout redirect, not a file-descriptor redirect:
+    # ``(?<![0-9&])`` rejects ``2>``/``&>`` so the ``2>/dev/null`` idiom on a
+    # benign ``ip route`` lookup is not read as persisting recon output. A
+    # ``/dev/null``/``/dev/std*`` target is a discard/stream, never a file,
+    # so it is excluded as well.
+    regex: "(?:(?:^|[\\s;|&])(?:netstat|ss|ifconfig|arp|route)\\b|\\bip\\s+(?:route|addr|link|neigh))\\b[^\\n]*?(?<![0-9&])>>?[ \\t]*(?:['\\\"]?(?:[/~.$]|\\{\\{|\\$\\(|/dev/(?!null|std))|[A-Za-z][\\w./-]*\\.(?:txt|log|out|csv|json|xml|tmp|dat))"
     positive_examples:
       - "    shell: netstat -an > /tmp/netstat.out"
       - "    shell: ss -tnp >> /tmp/connections.log"
@@ -117,6 +134,8 @@ patterns:
               msg: "count is {{ count > threshold }}"
       - "    shell: netstat -an"
       - "    shell: ss -tnp"
+      - "    shell: CURRENT_IP=$(ip route get 1 2>/dev/null | awk '{print $7}')"
+      - "    shell: ip addr show eth0 2>/dev/null"
     recommendation: "Persisting netstat / ss / ip-route output to a file is the System Network Configuration Discovery (T1016) signature; if the data is genuinely needed for operations, capture it via ansible.builtin.setup or a purpose-built fact module and store the result in the controller's fact cache rather than a host file."
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]


### PR DESCRIPTION
Adds a whole-file fast-reject in the scanner: a pattern that does not match the joined file text skips its per-line and per-window loops. Worst-case files (large, long lines) drop from ~22s to ~6s. Anchored single-line patterns are exempt since their anchors mean something different against one line.

Fixes two false positives in data_exfiltration.yml:

- credential_file_search now ignores `! -name` exclusion clauses and drops the noisy bare `config` and `.key` tokens.
- network_configuration_collection no longer treats file-descriptor redirects like `2>/dev/null` as persisting recon output.