### PR TITLE
Build release binaries on manylinux for older glibc compatibility

### DIFF
--- a/.github/workflows/scanner-release.yml
+++ b/.github/workflows/scanner-release.yml
@@ -129,8 +129,12 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
+            # manylinux_2_28_x86_64 (AlmaLinux 8, glibc 2.28), digest-pinned
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64@sha256:05f1974519caad9792a661784d9b94fd00e6b0c5b65572cd3f112548494bf4cf
           - arch: arm64
             runner: ubuntu-24.04-arm
+            # manylinux_2_28_aarch64 (AlmaLinux 8, glibc 2.28), digest-pinned
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64@sha256:710dcd0cc3fb34288236ffa66e89c31aa2cbffb9026ac670caadc94f56b4e454
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -170,23 +174,28 @@ jobs:
           fi
           echo "version=${v#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Install scanner from wheel + PyInstaller
+      - name: Build standalone binary on manylinux (glibc 2.28 floor)
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-recommends binutils
-          python -m pip install --upgrade pip
-          pip install --require-hashes -c .github/constraints.txt pyinstaller
-          pip install dist/*.whl
-
-      - name: Build standalone binary
-        run: |
-          pyinstaller --onefile \
-            --name ansible-security-scanner \
-            --collect-data ansible_security_scanner \
-            --collect-submodules ansible_security_scanner \
-            --console \
-            --distpath build-bin \
-            src/ansible_security_scanner/__main__.py
+          set -euo pipefail
+          # Build the PyInstaller binary inside manylinux_2_28 so it links
+          # against glibc 2.28. A binary built on the ubuntu-24.04 runner
+          # (glibc 2.39) cannot load on RHEL/Rocky 9 (glibc 2.34): glibc is
+          # backward but not forward compatible. Building against the older
+          # floor lets the .deb/.rpm run on every currently supported distro.
+          image="${{ matrix.manylinux }}"
+          docker run --rm -v "$PWD:/io" -w /io "$image" bash -euc '
+            export PATH=/opt/python/cp312-cp312/bin:$PATH
+            python -m pip install --upgrade pip
+            pip install --require-hashes -c .github/constraints.txt pyinstaller
+            pip install dist/*.whl
+            pyinstaller --onefile \
+              --name ansible-security-scanner \
+              --collect-data ansible_security_scanner \
+              --collect-submodules ansible_security_scanner \
+              --console \
+              --distpath build-bin \
+              src/ansible_security_scanner/__main__.py
+          '
 
       - name: Smoke test binary
         run: |
@@ -254,7 +263,10 @@ jobs:
           set -euo pipefail
           rpm=$(ls out/*.rpm | head -n1)
           rpm_name=$(basename "$rpm")
-          docker run --rm -v "$PWD/out:/pkgs:ro" rockylinux:9 sh -euc "
+          # rockylinux:9 (glibc 2.34) digest-pinned: lowest-glibc distro we
+          # claim support for, so the rpm install here proves the manylinux
+          # build floor is low enough.
+          docker run --rm -v "$PWD/out:/pkgs:ro" rockylinux:9@sha256:d7be1c094cc5845ee815d4632fe377514ee6ebcf8efaed6892889657e5ddaaa6 sh -euc "
             dnf install -y /pkgs/${rpm_name} >/dev/null
             ansible-security-scanner --list-rules >/dev/null
           "


### PR DESCRIPTION
The release workflow built the standalone PyInstaller binary on the ubuntu-24.04 runner, which links against glibc 2.39. The resulting `.deb` and `.rpm` failed to load on RHEL/Rocky 9 (glibc 2.34) with `GLIBC_2.38 not found`, since glibc is backward but not forward compatible.

The binary is now built inside `manylinux_2_28` (glibc 2.28), so the packages run on every currently supported distro. The manylinux and rockylinux container images are pinned by digest.