### PR TITLE
Guard overlap-group ordering and tighten APM and Splunk HEC rules

### DIFF
--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -5,6 +5,7 @@ File scanning logic for Ansible Security Scanner
 
 from __future__ import annotations
 
+import itertools
 import logging
 import re
 import threading
@@ -1132,8 +1133,14 @@ _OVERLAP_SUPPRESSION_GROUPS: tuple[tuple[str, ...], ...] = (
         "twitter_api_key",
         "google_api_key",
         "youtube_api_key",
-        "github_token",
+        # Order must agree with the dedicated
+        # ``(github_personal_access_token_literal, github_token)`` group
+        # above: the "literal" rule is the canonical winner. If the two
+        # github rule IDs are ordered inconsistently across groups, a line
+        # that fires BOTH loses each rule in the *other* group and both get
+        # annihilated - silently dropping a real GitHub PAT leak.
         "github_personal_access_token_literal",
+        "github_token",
         "slack_bot_or_app_token_literal",
         "heroku_api_key",
         "mailchimp_api_key",
@@ -1196,6 +1203,38 @@ def _apply_overlap_suppression(
         if all(loc_winners.get(gi, (None, None))[1] == f.rule_id for gi, _ in groups):
             kept.append(f)
     return kept
+
+
+def _validate_overlap_groups_consistent(
+    groups: tuple[tuple[str, ...], ...],
+) -> None:
+    """Fail loudly if two rules are ordered inconsistently across groups.
+
+    ``_apply_overlap_suppression`` only keeps a finding when its rule is
+    the winner (lowest position) of EVERY group it appears in. If rules
+    ``A`` and ``B`` co-occur in two groups with opposite relative order,
+    then a line firing both loses ``A`` in the group where ``B`` ranks
+    higher AND loses ``B`` in the group where ``A`` ranks higher - so
+    BOTH get annihilated and a real finding silently vanishes. This guard
+    turns that latent ordering bug into an immediate, obvious failure.
+    """
+    # ``first_seen[(a, b)]`` (a < b lexicographically) records whether ``a``
+    # ranked before ``b`` the first time the pair was observed in any group.
+    first_seen: dict[tuple[str, str], bool] = {}
+    for group in groups:
+        position = {rid: i for i, rid in enumerate(group)}
+        for a, b in itertools.combinations(sorted(group), 2):
+            before = position[a] < position[b]
+            if first_seen.setdefault((a, b), before) != before:
+                raise ValueError(
+                    f"Inconsistent overlap-suppression ordering for rules "
+                    f"{a!r} and {b!r}: they appear in different relative order "
+                    "across groups, which would mutually annihilate both "
+                    "findings when they co-fire on the same line."
+                )
+
+
+_validate_overlap_groups_consistent(_OVERLAP_SUPPRESSION_GROUPS)
 
 
 def _normalize_display_snippet(snippet: str) -> str:

--- a/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
+++ b/src/ansible_security_scanner/patterns/hardcoded_credentials.yml
@@ -1835,9 +1835,14 @@ patterns:
     severity: "HIGH"
     title: "Elastic APM secret_token Or api_key Inline Literal In Playbook / Jinja"
     description: "A task renders an Elastic APM agent config (`elastic-apm.yml`, `elasticapm.ini`, env `ELASTIC_APM_SECRET_TOKEN=` / `ELASTIC_APM_API_KEY=`) with a literal, hex/base64-looking value of length ≥32 characters, not a Jinja `{{ }}` expression or Ansible Vault reference. APM secret tokens authenticate trace-data submission; an attacker with the token can POISON trace data (injecting fake spans to mask intrusion), EXFILTRATE legitimate traces (containing DB queries, request bodies, header values), or overflow the APM server with DoS. The long-lived nature of APM tokens + common log-collection into the same cluster make them a high-value credential secondary to the primary ES creds."
-    regex: "(?:(?:ELASTIC_APM_|apm\\.|elastic_apm\\.|apm-server\\.)?(?:secret_token|api_key|token))\\s*[:=]\\s*['\"]?[A-Za-z0-9+/=_-]{32,}['\"]?(?!\\s*\\{\\{)|ELASTIC_APM_(?:SECRET_TOKEN|API_KEY)\\s*[:=]\\s*['\"][A-Za-z0-9+/=_-]{32,}['\"](?!.*\\{\\{)"
+    regex: "(?:ELASTIC_APM_(?:SECRET_TOKEN|API_KEY)|(?:apm\\.|elastic_apm\\.|apm-server\\.)(?:secret_token|api_key|token))\\s*[:=]\\s*['\"]?[A-Za-z0-9+/=_-]{32,}['\"]?(?!\\s*\\{\\{)"
     positive_examples:
-      - "api_key: \"wa9aerahhie0eekee9iaphoorovooyia\""
+      - "ELASTIC_APM_SECRET_TOKEN=wa9aerahhie0eekee9iaphoorovooyia12345"
+      - "elastic_apm.api_key: \"wa9aerahhie0eekee9iaphoorovooyia12345\""
+    negative_examples:
+      - "token = bc77efcf-fc60-494f-b80c-52701d7901d4"
+      - "GIT_TOKEN: \"ghp_EXAMPLEEXAMPLEEXAMPLEEXAMPLEEXAMPLEX\""
+      - "docker_logging_splunk_token=25534e1a-8238-460e-b338-12b8fc3e2199"
     multiline: false
     recommendation: "Inject APM tokens at runtime via Ansible Vault or a runtime env-injection tool (systemd `EnvironmentFile=`, k8s secret mount). For containerized apps, mount the secret as a file and set `ELASTIC_APM_SECRET_TOKEN_FILE=/run/secrets/apm-token` (Elastic APM agent ≥1.x supports this). Rotate tokens quarterly via the Kibana -> APM -> Agent Configuration UI. Restrict APM-server ingest RBAC to the specific agent role only (no cluster-wide privileges). Audit for leaked tokens in git history via `git log -p --all | grep -E 'ELASTIC_APM_(SECRET_TOKEN|API_KEY)\\s*[:=]\\s*[^\\{]'` - any non-templated match is a rotation trigger."
     cwe: ['CWE-312', 'CWE-522', 'CWE-798']
@@ -1936,10 +1941,15 @@ patterns:
     category: "hardcoded_credentials"
     severity: "HIGH"
     title: "Splunk HEC (HTTP Event Collector) token hardcoded in playbook"
-    description: "A Splunk HEC token is hardcoded as `Authorization: Splunk <uuid>` or as `HEC_TOKEN`/`splunk_hec_token` literal. HEC tokens allow unauthenticated event submission on the configured index - a leaked token lets an attacker (1) pollute SIEM data with forged events to hide real intrusions, (2) consume license entitlement (DoS via ingest-quota exhaustion), (3) potentially trigger correlation-search actions that take operational effect. Observability-vendor tokens are under-scanned compared to cloud-provider keys."
-    regex: "Authorization\\s*:\\s*['\"]?Splunk\\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['\"]?|(?:SPLUNK_HEC_TOKEN|HEC_TOKEN|splunk_hec_token)\\s*[:=]\\s*['\"]?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['\"]?"
+    description: "A Splunk HEC token is hardcoded as `Authorization: Splunk <uuid>`, as a `HEC_TOKEN`/`splunk_hec_token` literal, or as a bare `token = <uuid>` line inside a Splunk HEC `[http]` / `[http://<name>]` input stanza (e.g. an `inputs.conf` block rendered by `blockinfile`/`copy`). HEC tokens allow unauthenticated event submission on the configured index - a leaked token lets an attacker (1) pollute SIEM data with forged events to hide real intrusions, (2) consume license entitlement (DoS via ingest-quota exhaustion), (3) potentially trigger correlation-search actions that take operational effect. Observability-vendor tokens are under-scanned compared to cloud-provider keys."
+    regex: "Authorization\\s*:\\s*['\"]?Splunk\\s+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['\"]?|(?:SPLUNK_HEC_TOKEN|HEC_TOKEN|splunk_hec_token)\\s*[:=]\\s*['\"]?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['\"]?|\\[http(?:s)?(?:://[^\\]\\n]*)?\\][\\s\\S]{0,300}?\\btoken\\s*=\\s*['\"]?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['\"]?"
+    multiline: true
+    window: 30
     positive_examples:
       - "Authorization:Splunk 00000000-0000-0000-0000-000000000000"
+      - "[http://splunkcom-tutorial]\n          token = bc77efcf-fc60-494f-b80c-52701d7901d4"
+    negative_examples:
+      - "[http://splunkcom-tutorial]\n          token = {{ vault_hec_token }}"
     recommendation: "Store HEC tokens in Vault; reference via `lookup` at playbook runtime. Create per-source HEC tokens with a narrow `Allowed Indexes` list (never `main` / `*`) and a narrow `Default Source Type`. Enable HEC `enableSSL: true` and `requireClientCert: true` for mutual TLS on event submission. Monitor ingest volume per-token for anomalous spikes. Rotate HEC tokens quarterly AND immediately on any repo exposure. For high-sensitivity indexes (authentication, audit), use Splunk Forwarder with client-cert auth instead of HEC."
     cwe: ['CWE-312', 'CWE-798']
     owasp_appsec: ["A04:2021", "A07:2021"]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -249,7 +249,14 @@ _MULTI_BAD_REQUIRED_RULE_IDS: frozenset[str] = frozenset(
 # benign pattern-tuning doesn't tickle this gate, but tight enough
 # that a silent ~50% regression (e.g. TaintTracker or extract_all_tasks
 # shape detection breaking) surfaces immediately.
-_MULTI_BAD_MIN_FINDINGS = 29
+#
+# Lowered from 29 to 28 when ``elastic_apm_secret_token_or_api_key_literal``
+# was tightened to require real APM context: it previously double-counted
+# the fixture's ``webapp_api_key: "sk_live_..."`` Stripe key as an "Elastic
+# APM" finding (a misclassification). That key is still detected by the
+# correct ``stripe_api_key`` / ``stripe_live_secret_key_literal`` rules,
+# so removing the duplicate FP is a quality improvement, not a regression.
+_MULTI_BAD_MIN_FINDINGS = 28
 
 
 def test_multi_example_bad_known_findings(multi_example_bad_json):


### PR DESCRIPTION
Overlap suppression keeps a finding only when its rule is the lowest-positioned member of every group it belongs to. If two rules appear in opposite relative order across two groups, a line firing both loses each rule in the other group and both findings vanish silently. This adds an import-time check that raises on any such inconsistency, and reorders the github rule pair so the literal rule is the consistent winner.

Tightens `elastic_apm_secret_token_or_api_key_literal` to require real APM context (`ELASTIC_APM_*` or `apm.`/`elastic_apm.`/`apm-server.` prefixes), so it stops double-counting unrelated long tokens such as the Stripe key in the fixture. Extends the Splunk HEC rule to catch a bare `token = <uuid>` assignment inside an `inputs.conf` `[http]` stanza.