### PR TITLE
Pin manylinux build images to immutable dated tags

### DIFF
--- a/.github/workflows/scanner-release.yml
+++ b/.github/workflows/scanner-release.yml
@@ -129,12 +129,16 @@ jobs:
         include:
           - arch: amd64
             runner: ubuntu-24.04
-            # manylinux_2_28_x86_64 (AlmaLinux 8, glibc 2.28), digest-pinned
-            manylinux: quay.io/pypa/manylinux_2_28_x86_64@sha256:05f1974519caad9792a661784d9b94fd00e6b0c5b65572cd3f112548494bf4cf
+            # manylinux_2_28_x86_64 (AlmaLinux 8, glibc 2.28). Pinned to an
+            # immutable dated tag plus digest: the dated tag is never reused, so
+            # the digest stays resolvable (the rolling :latest tag's old digests
+            # get garbage-collected out from under a bare digest pin).
+            manylinux: quay.io/pypa/manylinux_2_28_x86_64:2026.06.14-5@sha256:893d0c9d73a8262503fa32f40160aae0299c10cecfc04396c9802a712cab1831
           - arch: arm64
             runner: ubuntu-24.04-arm
-            # manylinux_2_28_aarch64 (AlmaLinux 8, glibc 2.28), digest-pinned
-            manylinux: quay.io/pypa/manylinux_2_28_aarch64@sha256:710dcd0cc3fb34288236ffa66e89c31aa2cbffb9026ac670caadc94f56b4e454
+            # manylinux_2_28_aarch64 (AlmaLinux 8, glibc 2.28). Pinned to an
+            # immutable dated tag plus digest (see amd64 note above).
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64:2026.06.14-5@sha256:f926f192db8589bdfbc6d4af4820d8cb76661f1349ab136259b33b94f4606f05
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read


### PR DESCRIPTION
The manylinux_2_28 build images were pinned by bare digest of the rolling `:latest` tag. quay garbage-collects those old digests, so the release failed with `manifest unknown`. Repinned to immutable dated tags plus their digests so the digests stay resolvable while keeping integrity verification.