### PR TITLE
Generate dynamic Ansible remediations for every finding

### DIFF
--- a/src/ansible_security_scanner/patterns/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/ai_ml_security.yml
@@ -156,7 +156,6 @@ patterns:
     positive_examples:
       - "pickle.load"
     recommendation: "Never load pickle files from untrusted sources; use safetensors format for ML models"
-    no_ansible_remediation: true
     cve: ["CVE-2024-12029", "CVE-2024-3568"]
     nist_controls: ['SI-3', 'SI-10', 'CM-11']
     soc2: ['CC7.1']
@@ -176,7 +175,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Pin model URLs to specific versions and verify SHA256 checksums"
-    no_ansible_remediation: true
     nist_controls: ['CM-11', 'SA-10', 'SI-7']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0010', 'AML.T0011.000']
@@ -193,7 +191,6 @@ patterns:
     positive_examples:
       - "aws sagemaker create-"
     recommendation: "SageMaker provisioning should go through approved ML pipelines, not Ansible"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'AC-6', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0040', 'AML.T0034']
@@ -208,7 +205,6 @@ patterns:
     positive_examples:
       - "aws bedrock invoke"
     recommendation: "Bedrock access should go through approved API gateways with cost controls"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'AC-6', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0040', 'AML.T0034']
@@ -226,7 +222,6 @@ patterns:
     positive_examples:
       - "gcloud ai "
     recommendation: "Vertex AI provisioning should go through approved ML pipelines"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'AC-6', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0040', 'AML.T0034']
@@ -241,7 +236,6 @@ patterns:
     positive_examples:
       - "environment: azureml://registries/azureml/environments/sklearn-1.5/labels/latest"
     recommendation: "Azure ML provisioning should go through approved ML pipelines"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'AC-6', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0040', 'AML.T0034']
@@ -258,7 +252,6 @@ patterns:
     positive_examples:
       - "description: Please enter the AWS instance type to use, e.g. 'g6.2xlarge'."
     recommendation: "GPU instance launches must be approved and tagged with a cost center and expiration"
-    no_ansible_remediation: true
     nist_controls: ['AC-6', 'CM-7', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0034']
@@ -289,7 +282,6 @@ patterns:
     positive_examples:
       - "buildah config --cmd \"jupyter lab --ip=0.0.0.0 --no-browser\" {{ container_id }}"
     recommendation: "Jupyter servers should be deployed through approved platforms with authentication"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'IA-2', 'SC-7']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0049', 'AML.T0050']
@@ -306,7 +298,6 @@ patterns:
     positive_examples:
       - "wp_cli_completion_url: \"https://raw.githubusercontent.com/wp-cli/wp-cli/v{{ wp_cli_version }}/utils/wp-completion.bash\""
     recommendation: "Sanitize and validate all user input before including in LLM prompts; use input guardrails"
-    no_ansible_remediation: true
     nist_controls: ['SI-10', 'SI-3']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0051', 'AML.T0051.001']
@@ -323,7 +314,6 @@ patterns:
     positive_examples:
       - "mlflow run"
     recommendation: "MLflow access should go through approved ML pipeline orchestration"
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'AC-6', 'AU-12']
     soc2: ['CC7.1']
     mitre_atlas: ['AML.T0010', 'AML.T0018']
@@ -406,7 +396,6 @@ patterns:
     multiline: true
     window: 60
     recommendation: "Never pipe raw LLM output to shell. Parse the LLM response as structured JSON with a strict schema (JSON-Schema / Pydantic). Allowlist exactly the commands / arguments the workflow needs and invoke them explicitly by name with validated arguments - not via string interpolation. Add a second-pass classifier that rejects outputs containing shell metacharacters (`;`, `&`, `|`, backticks)."
-    no_ansible_remediation: true
     cwe: ["CWE-77", "CWE-94", "CWE-1427"]
     owasp_appsec: ["A03:2021"]
     owasp_llm: ["LLM01", "LLM02"]
@@ -451,7 +440,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Never `pickle.load` attacker-controlled data; prefer safetensors (`safetensors.torch.load_file`) which is pure data. If you must use pickle for a model, compute the SHA-256 against a known-good value first and fail the task on mismatch. Run the loader as an unprivileged user (`become: false` for this task) inside a restricted container with `readOnlyRootFilesystem: true`."
-    no_ansible_remediation: true
     cwe: ["CWE-250", "CWE-502"]
     cve: ["CVE-2024-12029", "CVE-2024-3568"]
     owasp_appsec: ["A08:2021"]
@@ -497,7 +485,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Never bind an unconstrained shell tool to an LLM agent. If shell capability is required, wrap it in an allowlist+argv-validation shim: `Tool(name='ls_project', func=lambda _: subprocess.run(['ls', PROJECT_DIR], check=True, capture_output=True).stdout)`. Run all tool executions in a locked-down sandbox (gVisor, Firecracker, or a per-request disposable container with no secrets and no outbound network). Apply guardrails (NeMo Guardrails, Llama Guard 3) before the tool-dispatch step."
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-94', 'CWE-1427']
     cve: ["CVE-2023-36258", "CVE-2023-44467"]
     owasp_appsec: ["A03:2021"]
@@ -562,7 +549,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "NEVER expose a generic `shell` / `exec` tool through MCP. Define narrow, parameterised tools per operation (e.g., `git_status(repo: str)`, `read_file(path: str)` constrained to an allowlisted root). If a shell-style tool is unavoidable (operator-only diagnostic MCP): (a) run the MCP server in a throw-away container with a read-only rootfs, no network, non-root UID, dropped capabilities, seccomp strict, (b) apply an allowlist of commands + argument patterns (argparse + enum, not regex), (c) require the MCP client to pass a fresh per-invocation OAuth/PAT bound to the current user, never a long-lived shared secret, (d) log every tool call with full arguments to an append-only audit sink, (e) run an adversarial prompt-injection test suite (PromptBench, Garak) before exposing the tool to an end-user LLM. Review Anthropic MCP security guidance (Nov 2024) and disable any community MCP server with `shell`/`exec`/`eval` sinks by default."
-    no_ansible_remediation: true
     cwe: ['CWE-77', 'CWE-78', 'CWE-94', 'CWE-1427']
     cve: ["CVE-2025-49596"]
     owasp_appsec: ["A03:2021"]
@@ -585,7 +571,6 @@ patterns:
     multiline: true
     window: 20
     recommendation: "Never ingest arbitrary URLs into a production RAG index. Maintain an explicit domain allowlist (config file, code-reviewed) and reject ingestion requests that resolve outside it. Canonicalise every URL (lowercased scheme/host, strip fragments, resolve redirects, re-check against allowlist at final hop to prevent SSRF/open-redirect poisoning). Sanitise every ingested document through: (a) HTML -> text with `bleach` or `readability` stripping `<script>`, HTML comments, zero-width characters, and known prompt-injection markers (`<|im_start|>`, `[INST]`, `###`), (b) an LLM-based prompt-injection classifier (Rebuff, Lakera Guard, Meta Prompt Guard) with a strict threshold, (c) content-type + size guards (reject `text/html` > 1 MB, reject binaries). Quarantine newly-ingested chunks for 24 h before promoting to the live index. Log every ingested URL + SHA-256 of content and alert on anomalies. Review OWASP LLM Top-10 v1.1 LLM03 and NIST AI 100-2 (2024) adversarial-ML profile."
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-918', 'CWE-1427']
     owasp_appsec: ["A03:2021", "A10:2021"]
     owasp_llm: ["LLM01", "LLM03"]

--- a/src/ansible_security_scanner/patterns/ansible_specific.yml
+++ b/src/ansible_security_scanner/patterns/ansible_specific.yml
@@ -122,7 +122,6 @@ patterns:
     positive_examples:
       - "community: public"
     recommendation: "Use SNMPv3 with authentication; store community strings in Vault"
-    no_ansible_remediation: true
     cwe: ['CWE-259', 'CWE-798']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V13.2.3, V13.3.1]
@@ -144,7 +143,6 @@ patterns:
     positive_examples:
       - "terraform.tfstate"
     recommendation: "Use remote state backends (S3, Consul) with encryption; never access tfstate directly from playbooks"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-522']
     owasp_appsec: ["A01:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V14.2.2]
@@ -175,7 +173,6 @@ patterns:
     multiline: true
     window: 8
     recommendation: "Do not distribute kubeconfig files via playbooks. Use short-lived tokens from OIDC / IAM-integrated service accounts (e.g., ``aws eks get-token``, ``gcloud container clusters get-credentials --internal-ip``) that generate a kubeconfig on the local host from ambient cloud identity. For service accounts, use ``kubernetes.core.k8s`` with a token fetched at runtime from Vault / AWS Secrets Manager - never from a file that follows the playbook."
-    no_ansible_remediation: true
     positive_examples:
       - |2-
             ansible.builtin.slurp:
@@ -225,7 +222,6 @@ patterns:
     positive_examples:
       - "CI_JOB_TOKEN:xxx"
     recommendation: "CI/CD tokens should only be used via masked environment variables, never hardcoded"
-    no_ansible_remediation: true
     cwe: ['CWE-522', 'CWE-532']
     owasp_appsec: ["A04:2021", "A09:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V16.2.5]
@@ -248,7 +244,6 @@ patterns:
     positive_examples:
       - "echo$CI_JOB_TOKEN"
     recommendation: "Never echo CI/CD tokens; use no_log: true and masked variables"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-532']
     owasp_appsec: ["A01:2021", "A09:2021"]
     owasp_asvs: [V16.2.5, V14.2.2]
@@ -270,7 +265,6 @@ patterns:
     positive_examples:
       - "redis-cli -h "
     recommendation: "Always use Redis AUTH and TLS; never connect without credentials"
-    no_ansible_remediation: true
     cwe: ['CWE-306']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V6.2.1]
@@ -289,7 +283,6 @@ patterns:
     positive_examples:
       - "shell: curl -XPUT localhost:9200/_all/_settings -d '{\"index.routing.allocation.disable_allocation\":\"false\" }'"
     recommendation: "Enable Elasticsearch security features (X-Pack) with authentication and TLS"
-    no_ansible_remediation: true
     cwe: ['CWE-306']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V6.2.1]
@@ -311,7 +304,6 @@ patterns:
     positive_examples:
       - "mongo --host"
     recommendation: "Enable MongoDB authentication and use SCRAM-SHA-256; never connect without auth"
-    no_ansible_remediation: true
     cwe: ['CWE-306']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V6.2.1]
@@ -332,7 +324,6 @@ patterns:
     positive_examples:
       - "New-Object Net.WebClientDownloadString"
     recommendation: "Download files to disk with checksum verification instead of executing from memory"
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -351,7 +342,6 @@ patterns:
     positive_examples:
       - "Invoke-Expression x"
     recommendation: "Avoid Invoke-Expression; use explicit cmdlets with validated parameters"
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-95']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1059.001']
@@ -369,7 +359,6 @@ patterns:
     positive_examples:
       - 'HKLM\RunOnce\'
     recommendation: "Registry persistence should only be configured through approved GPO or SCCM"
-    no_ansible_remediation: true
     cwe: ['CWE-506']
     mitre_attack: ['T1547.001']
     cis_controls: ['CIS-4.1', 'CIS-10.1']
@@ -628,7 +617,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Run `buildah` as an unprivileged user with `--isolation=rootless` (the default when not root). For CI, run the entire build job under a `UID/GID != 0` user via the runner's user-spec - don't `become: root` just to call buildah. If you need to cross-compile or access privileged syscalls, run the build inside a gVisor or Kata-containers sandbox rather than giving buildah real root."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-269']
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.4.5, V15.2.3]

--- a/src/ansible_security_scanner/patterns/anti_forensics.yml
+++ b/src/ansible_security_scanner/patterns/anti_forensics.yml
@@ -12,7 +12,6 @@ patterns:
     positive_examples:
       - "touch -t 00000000"
     recommendation: "File timestomping is a forensic evasion technique; remove immediately and investigate"
-    no_ansible_remediation: true
     cwe: ['CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -32,7 +31,6 @@ patterns:
     positive_examples:
       - "command: /usr/sbin/setenforce 0"
     recommendation: "SELinux should always be enforcing in production; use targeted policies for application exceptions"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1562.001']
     cis_controls: ['CIS-4.1', 'CIS-10.1']
@@ -50,7 +48,6 @@ patterns:
     positive_examples:
       - "sudo systemctl stop apparmor.service"
     recommendation: "AppArmor profiles should not be disabled; create proper profiles for applications"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1562.001']
     cis_controls: ['CIS-4.1', 'CIS-10.1']
@@ -68,7 +65,6 @@ patterns:
     positive_examples:
       - "systemctl stop auditd"
     recommendation: "The audit daemon must remain running; investigate why someone is attempting to disable it"
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -88,7 +84,6 @@ patterns:
     positive_examples:
       - "journalctl --flush"
     recommendation: "Journal logs should only be managed by system log rotation policies"
-    no_ansible_remediation: true
     cwe: ['CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -108,7 +103,6 @@ patterns:
     positive_examples:
       - "> /utmp"
     recommendation: "Login records must not be tampered with; investigate this as a potential incident"
-    no_ansible_remediation: true
     cwe: ['CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -128,7 +122,6 @@ patterns:
     positive_examples:
       - "{{ \"invoke-rc.d rsyslog rotate > /dev/null\""
     recommendation: "Syslog should only forward to authorized log aggregation servers"
-    no_ansible_remediation: true
     cwe: ['CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -148,7 +141,6 @@ patterns:
     positive_examples:
       - "- seccomp=unconfined"
     recommendation: "Never disable seccomp in production; create appropriate seccomp profiles"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1562.001', 'T1611']
     cis_controls: ['CIS-4.1', 'CIS-Docker']
@@ -166,7 +158,6 @@ patterns:
     positive_examples:
       - "ulimit -c unlimited"
     recommendation: "Core dumps should be disabled or restricted to prevent credential extraction"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-212']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -186,7 +177,6 @@ patterns:
     positive_examples:
       - "vssadmin delete shadows /all"
     recommendation: "Ansible playbooks should NEVER delete shadow copies in production. If this is legitimate disk-maintenance automation: (1) explicitly document and sign the playbook, (2) gate behind AWX/Tower job-template approval with multi-party RBAC, (3) run only on narrowly-scoped hosts (not domain-wide), (4) log via Windows Event ID 524 (backup catalog deleted), 8224 (VSS delete). Detection: Sysmon Event ID 1 (ProcessCreate) for `vssadmin.exe delete shadows`, `wmic shadowcopy delete`, `wbadmin delete catalog`, `bcdedit /set recoveryenabled No`, plus Windows Event ID 524. Prevention: Controlled Folder Access + Defender for Endpoint ASR rule `c1db55a8-c604-4b9b-aa9c-9b79fad0e9f8` (use advanced protection against ransomware) + WDAC policy blocking vssadmin for non-admin contexts. If this playbook ever runs unexpectedly, isolate the host, preserve volatile memory, and invoke IR - shadow deletion is Initial Access + Impact combined."
-    no_ansible_remediation: true
     cwe: ['CWE-73', 'CWE-732', 'CWE-1104']
     owasp_appsec: ["A04:2021", "A06:2021"]
     owasp_asvs: [V5.3.2, V5.3.1]
@@ -273,7 +263,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Never render `discard`/`~`/`stop` rsyslog actions or `never,exit` auditd rules from configuration management. Legitimate log-volume control belongs in a separate forwarder layer (rsyslog `omfwd` with rate-limit, Fluent Bit tail+filter with metrics) and should NEVER happen at the local rsyslog/auditd layer on a monitored host - filtering at the source destroys forensic evidence. If a playbook writes to `/etc/rsyslog.d/` or `/etc/audit/rules.d/`, the content should be additive (new file-watches, new destinations) only. Pre-commit lint: reject any rsyslog conf containing `discard`, `~`, or ` stop\\b` actions; reject any audit rules file containing `-a never,`. Runtime detection: add an auditd watch on the rule directories themselves (`-w /etc/audit/rules.d/ -p wa -k audit_rule_tamper`, `-w /etc/rsyslog.d/ -p wa -k rsyslog_tamper`) and forward those events off-host to a SIEM that owns the detection for this anti-forensic class. Verify running config matches committed config: `augenrules --check` + `rsyslogd -N1 -f /etc/rsyslog.conf` and alert on drift. For playbook CI, add a pre-deploy check that greps every rendered template for the listed fingerprints and fails the run."
-    no_ansible_remediation: true
     cwe: ['CWE-117', 'CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V14.2.1]

--- a/src/ansible_security_scanner/patterns/binary_planting.yml
+++ b/src/ansible_security_scanner/patterns/binary_planting.yml
@@ -49,7 +49,6 @@ patterns:
     positive_examples:
       - "alias sudo="
     recommendation: "Aliases that shadow security-sensitive commands can intercept credentials"
-    no_ansible_remediation: true
     cwe: ['CWE-506']
     mitre_attack: ['T1546.004']
     cis_controls: ['CIS-4.1']
@@ -69,7 +68,6 @@ patterns:
     positive_examples:
       - "and ``fail_json_aws()`` when passed an ``AnsibleAWSError`` exception (https://github.com/ansible-collections/amazon.aws/pull/1997)."
     recommendation: "Shell functions that shadow system commands can intercept credentials and arguments"
-    no_ansible_remediation: true
     cwe: ['CWE-506']
     mitre_attack: ['T1546.004']
     cis_controls: ['CIS-4.1']

--- a/src/ansible_security_scanner/patterns/data_destruction.yml
+++ b/src/ansible_security_scanner/patterns/data_destruction.yml
@@ -64,7 +64,6 @@ patterns:
     positive_examples:
       - "DROP TABLE #integration56yH2"
     recommendation: "Destructive database commands should never appear in playbooks; use migrations with backups"
-    no_ansible_remediation: true
     cwe: ["CWE-506"]
     mitre_attack: ["T1485", "T1490"]
     cis_controls: ["CIS-11.1", "CIS-11.2"]
@@ -111,7 +110,6 @@ patterns:
     positive_examples:
       - "mkfs.ext2 /dev/"
     recommendation: "Disk formatting destroys all data; should only happen during initial provisioning"
-    no_ansible_remediation: true
     cwe: ["CWE-400", "CWE-506"]
     owasp_asvs: []
     mitre_attack: ["T1485", "T1561.002"]

--- a/src/ansible_security_scanner/patterns/data_exfiltration.yml
+++ b/src/ansible_security_scanner/patterns/data_exfiltration.yml
@@ -310,7 +310,6 @@ patterns:
     positive_examples:
       - "rclone copy "
     recommendation: "Rclone is the #1 data exfiltration tool used by ransomware groups; remove unless explicitly authorized"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -330,7 +329,6 @@ patterns:
     positive_examples:
       - "rclone config"
     recommendation: "Rclone remote configuration enables data exfiltration; ensure this is authorized"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -350,7 +348,6 @@ patterns:
     positive_examples:
       - "mega-put"
     recommendation: "MEGA.nz CLI tools can exfiltrate data to encrypted cloud storage; remove immediately"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -373,7 +370,6 @@ patterns:
     positive_examples:
       - "azcopy copy blob.core.windows.net"
     recommendation: "AzCopy to external Azure accounts can be used for data exfiltration; verify the destination"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -393,7 +389,6 @@ patterns:
     positive_examples:
       - "wormhole send"
     recommendation: "Magic-wormhole enables encrypted P2P file transfers that bypass network monitoring; requires approval"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -413,7 +408,6 @@ patterns:
     positive_examples:
       - "croc send"
     recommendation: "Croc enables encrypted file transfers that bypass network monitoring; requires approval"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -433,7 +427,6 @@ patterns:
     positive_examples:
       - "cmd: 'python -m http.server --directory {{url_pkg_path}} {{http_port}} >/dev/null 2>&1'"
     recommendation: "Python HTTP server exposes local files over the network; ensure this is not serving sensitive data"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]

--- a/src/ansible_security_scanner/patterns/environment_hijacking.yml
+++ b/src/ansible_security_scanner/patterns/environment_hijacking.yml
@@ -12,7 +12,6 @@ patterns:
     positive_examples:
       - "    - ansible.builtin.lineinfile: { dest: /etc/hosts, line: '10.0.0.1 evil.example.com' }"
     recommendation: "Hosts file changes should use centralized DNS; review all entries for domain hijacking"
-    no_ansible_remediation: true
     cwe: ["CWE-345"]
     owasp_appsec: ["A08:2021"]
     mitre_attack: ["T1557"]
@@ -31,7 +30,6 @@ patterns:
       - |2
             - ansible.builtin.lineinfile: { dest: /etc/resolv.conf, line: 'nameserver 1.2.3.4' }
     recommendation: "DNS resolver changes must point to trusted corporate or well-known DNS servers"
-    no_ansible_remediation: true
     cwe: ["CWE-345"]
     owasp_appsec: ["A08:2021"]
     mitre_attack: ["T1557"]
@@ -49,7 +47,6 @@ patterns:
     positive_examples:
       - "    - ansible.builtin.copy: { src: rogue.conf, dest: /etc/ntp.conf }"
     recommendation: "NTP should only point to trusted, authorized time servers"
-    no_ansible_remediation: true
     cwe: ["CWE-345"]
     owasp_appsec: ["A08:2021"]
     mitre_attack: ["T1565.001"]
@@ -67,7 +64,6 @@ patterns:
     positive_examples:
       - "export PATH=~/.local/bin:$PATH"
     recommendation: "Never prepend untrusted directories to PATH; only use system paths"
-    no_ansible_remediation: true
     cwe: ["CWE-427"]
     mitre_attack: ["T1574.007"]
     cis_controls: ["CIS-4.1"]
@@ -87,7 +83,6 @@ patterns:
     positive_examples:
       - "shell: \"PYTHONPATH=$(echo {{ remote_tmp_dir }}/pip_root{{ pip_python_site_lib.stdout }}) {{ remote_tmp_dir }}/pip_root{{ pip_python_user_base.stdout }}/bin/ansible_test_pip_chdir\""
     recommendation: "PYTHONPATH should not be modified in playbooks; use virtual environments instead"
-    no_ansible_remediation: true
     cwe: ["CWE-427"]
     mitre_attack: ["T1574"]
     cis_controls: ["CIS-4.1"]
@@ -104,7 +99,6 @@ patterns:
     positive_examples:
       - "settings: {\"commandToExecute\": \"apt-get update && apt-get install -y python2 && update-alternatives --install /usr/bin/python python /usr/bin/python2 1\"}"
     recommendation: "Alternatives changes should be reviewed; only use packages from trusted repositories"
-    no_ansible_remediation: true
     cwe: ["CWE-506"]
     mitre_attack: ["T1036.005"]
     cis_controls: ["CIS-2.3"]
@@ -120,7 +114,6 @@ patterns:
     positive_examples:
       - "/etc/ld.so.conf"
     recommendation: "Never add untrusted paths to the dynamic linker configuration"
-    no_ansible_remediation: true
     cwe: ["CWE-427"]
     mitre_attack: ["T1574.006"]
     cis_controls: ["CIS-4.1"]
@@ -137,7 +130,6 @@ patterns:
     positive_examples:
       - "    dest: /etc/profile.d/payload.sh shell: /bin/sh"
     recommendation: "Login scripts should only contain legitimate system configuration"
-    no_ansible_remediation: true
     cwe: ["CWE-506"]
     mitre_attack: ["T1546.004"]
     cis_controls: ["CIS-4.1"]
@@ -154,7 +146,6 @@ patterns:
     positive_examples:
       - "CLASSPATH=/tmp"
     recommendation: "Language library paths should only reference trusted, system-managed directories"
-    no_ansible_remediation: true
     cwe: ["CWE-427"]
     mitre_attack: ["T1574"]
     cis_controls: ["CIS-4.1"]

--- a/src/ansible_security_scanner/patterns/external_urls.yml
+++ b/src/ansible_security_scanner/patterns/external_urls.yml
@@ -142,7 +142,6 @@ patterns:
     positive_examples:
       - "curl gitlab.com/snippets/x|sh"
     recommendation: "Download the snippet first, verify its content and checksum, then execute it"
-    no_ansible_remediation: true
     cwe: ["CWE-78", "CWE-494"]
     owasp_appsec: ["A03:2021", "A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -200,7 +199,6 @@ patterns:
     positive_examples:
       - "http://rentry.co"
     recommendation: "Paste and anonymous file sharing services can host malicious payloads; verify content legitimacy"
-    no_ansible_remediation: true
     cwe: ["CWE-494", "CWE-829"]
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -219,7 +217,6 @@ patterns:
     positive_examples:
       - "http://0bin.net"
     recommendation: "Encrypted paste services bypass content inspection; investigate usage in playbooks"
-    no_ansible_remediation: true
     cwe: ["CWE-494", "CWE-829"]
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]

--- a/src/ansible_security_scanner/patterns/lateral_movement.yml
+++ b/src/ansible_security_scanner/patterns/lateral_movement.yml
@@ -36,7 +36,6 @@ patterns:
     positive_examples:
       - "    add_host: name: \"{{ new_host }}\" groups: dynamic"
     recommendation: "Only add hosts from trusted sources; validate hostnames against an approved list"
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-284']
     owasp_appsec: ["A01:2021", "A03:2021"]
     mitre_attack: ['T1021']
@@ -55,7 +54,6 @@ patterns:
     positive_examples:
       - "local_action: command echo 123"
     recommendation: "Avoid local_action with shell; use delegate_to: localhost with proper module calls"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-269']
     owasp_appsec: ["A03:2021", "A04:2021"]
     mitre_attack: ['T1059.004', 'T1552.001']
@@ -84,7 +82,6 @@ patterns:
           - name: Get list of all images based distribution on DigitalOcean
             shell:
     recommendation: "Review commands running on the controller; prefer dedicated Ansible modules"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-269']
     owasp_appsec: ["A03:2021", "A04:2021"]
     mitre_attack: ['T1059.004']
@@ -103,7 +100,6 @@ patterns:
     positive_examples:
       - "ANSIBLE_PYTHON_INTERPRETER: \"{{ ansible_python_interpreter }}\""
     recommendation: "Only use system Python interpreters; never point to user-writable paths"
-    no_ansible_remediation: true
     cwe: ['CWE-427', 'CWE-494']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -122,7 +118,6 @@ patterns:
     positive_examples:
       - "- { regexp: '#callback_plugins', line: \"callback_plugins = /usr/local/lib/python2.7/dist-packages/ara/plugins/callbacks\" }"
     recommendation: "Only use trusted, audited callback plugins from official sources"
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-829']
     owasp_appsec: ["A03:2021", "A08:2021"]
     owasp_asvs: []
@@ -141,7 +136,6 @@ patterns:
     positive_examples:
       - "lookup_plugins = {{ ara_setup_plugins.stdout }}/lookup"
     recommendation: "Only use trusted filter/lookup plugins from official Ansible collections"
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-829']
     owasp_appsec: ["A03:2021", "A08:2021"]
     owasp_asvs: []
@@ -160,7 +154,6 @@ patterns:
     positive_examples:
       - "dest: /etc/ansible/facts.d/"
     recommendation: "Audit all custom facts scripts; ensure they come from trusted sources and are not user-writable"
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-506']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1546.005']
@@ -178,7 +171,6 @@ patterns:
     positive_examples:
       - "wait_for:port:{{}}timeout:1"
     recommendation: "Ensure wait_for is only used for legitimate service readiness checks, not port scanning"
-    no_ansible_remediation: true
     cwe: ['CWE-200']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -198,7 +190,6 @@ patterns:
     positive_examples:
       - "export ANSIBLE_CONFIG=$(pwd)/ci/ansible-dev.cfg"
     recommendation: "Only use the default ansible.cfg; custom configs must be audited for security"
-    no_ansible_remediation: true
     cwe: ['CWE-427', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: []
@@ -217,7 +208,6 @@ patterns:
     positive_examples:
       - "include_role:src:http://"
     recommendation: "Only include roles from trusted, pinned sources; use requirements.yml with version locks"
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -236,7 +226,6 @@ patterns:
     positive_examples:
       - "ANSIBLE_VAULT_PASSWORD="
     recommendation: "Use ansible-vault with --ask-vault-pass or a secure vault password file with restricted permissions"
-    no_ansible_remediation: true
     cwe: ['CWE-522', 'CWE-532']
     owasp_appsec: ["A04:2021", "A09:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V16.2.5]
@@ -279,7 +268,6 @@ patterns:
     positive_examples:
       - 'ansible.windows.win_service:path:\\x'
     recommendation: "Copy the binary to local disk (ansible.windows.win_copy) with checksum verification, then install the service pointing at the local path. Never let the service manager resolve a remote UNC/URL at start time."
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -298,7 +286,6 @@ patterns:
     positive_examples:
       - "ldap_attr:msDS-AllowedToDelegateTo"
     recommendation: "Delegation attribute writes should only come from Tier-0 administrative automation. Review who has write access (should be limited to domain admins). Audit for Resource-Based Constrained Delegation abuse (see: Elad Shamir 'Wagging the Dog')."
-    no_ansible_remediation: true
     cwe: ['CWE-269', 'CWE-284']
     owasp_appsec: ["A01:2021", "A04:2021"]
     mitre_attack: ['T1134.003', 'T1558.003']

--- a/src/ansible_security_scanner/patterns/malicious_activity.yml
+++ b/src/ansible_security_scanner/patterns/malicious_activity.yml
@@ -654,7 +654,6 @@ patterns:
       - "${jndildap"
     multiline: false
     recommendation: "Remove the payload. Targets must be patched to Log4j >= 2.17.1 (or >= 2.12.4 for Java 7, >= 2.3.2 for Java 6). Short-term mitigation on legacy targets: set `-Dlog4j2.formatMsgNoLookups=true` and remove the `JndiLookup` class (`zip -q -d log4j-core-*.jar org/apache/logging/log4j/core/lookup/JndiLookup.class`). Detection: EDR/WAF/SIEM rule on the regex above across inbound HTTP headers and URL parameters."
-    no_ansible_remediation: true
     nist_controls: ['RA-5', 'SI-2', 'SI-3', 'SI-4']
     pci_dss: ['6.3.3', '11.3.1']
     soc2: ['CC7.1', 'CC7.3']
@@ -676,7 +675,6 @@ patterns:
       - "class.module.classLoader.resources.context.parent.pipeline.first.pattern="
     multiline: false
     recommendation: "Remove the payload. Patch Spring Framework to >= 5.3.18 or >= 5.2.20; on JDK <= 8 the vulnerability is not exploitable. If you cannot patch immediately, set a `WebDataBinder.setDisallowedFields` global configuration blocking `class.*`, `Class.*`, `*.class.*`, `*.Class.*`. Detection: WAF rule on the regex above; hunt for unexpected `.jsp` writes under `webapps/ROOT/`."
-    no_ansible_remediation: true
     nist_controls: ['RA-5', 'SI-2', 'SI-3', 'SI-4']
     pci_dss: ['6.3.3', '11.3.1']
     soc2: ['CC7.1', 'CC7.3']
@@ -698,7 +696,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "IMDS access from a playbook is legitimate only when the playbook runs **on the instance itself** for bootstrapping/tagging, and only via IMDSv2 (AWS: `PUT` to `/latest/api/token` then `X-aws-ec2-metadata-token` header). Never template IMDS response bodies into other `uri` tasks, logs, or files readable by CI - any of those become credential exfiltration. Enforce IMDSv2 at the instance level (`HttpTokens: required`, `HttpPutResponseHopLimit: 1`). In CI, block 169.254.169.254 with a per-job network policy or egress firewall."
-    no_ansible_remediation: true
     nist_controls: ['AC-3', 'SC-7', 'SI-4', 'SI-10']
     pci_dss: ['1.2.1', '6.2.4', '8.6.2']
     hipaa: ['164.312(a)(1)', '164.312(a)(2)(i)']
@@ -719,7 +716,6 @@ patterns:
     positive_examples:
       - "log4j2.formatMsgNoLookups=false"
     recommendation: "Upgrade log4j to 2.17.1+ and keep formatMsgNoLookups=true; do not downgrade; audit JAVA_TOOL_OPTIONS for overrides"
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-917']
     cve: ["CVE-2021-44228"]
     owasp_appsec: ["A03:2021"]
@@ -735,7 +731,6 @@ patterns:
     positive_examples:
       - "spring-beans-5.0.0.jar"
     recommendation: "Upgrade Spring Framework to 5.3.18+ / 5.2.20+ (Spring Boot 2.6.6+ / 2.5.12+); add `disallowedFields` to every `@InitBinder`"
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-917']
     cve: ["CVE-2022-22965"]
     owasp_appsec: ["A03:2021"]
@@ -751,7 +746,6 @@ patterns:
     positive_examples:
       - "/setup/setupadministrator.action"
     recommendation: "Patch Confluence DC/Server to 8.3.3+, 8.4.3+, 8.5.2+; block public access to /setup/*; audit `confluence_admin_users` for unknown accounts"
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-863']
     cve: ["CVE-2023-22515"]
     owasp_appsec: ["A01:2021", "A03:2021"]
@@ -767,7 +761,6 @@ patterns:
     positive_examples:
       - "human2.aspx"
     recommendation: "Remove the dropped file; hunt for further Cl0p indicators; patch MOVEit Transfer to June 2023+ builds; rotate all app-service credentials"
-    no_ansible_remediation: true
     cwe: ['CWE-89', 'CWE-434']
     cve: ["CVE-2023-34362"]
     owasp_appsec: ["A03:2021", "A04:2021"]
@@ -786,7 +779,6 @@ patterns:
     positive_examples:
       - "certutil -urlcache http://"
     recommendation: "Remove the task. If you genuinely need to fetch a signed binary on Windows, use `ansible.windows.win_get_url` with `checksum:` set, or `Invoke-WebRequest -UseBasicParsing` with certificate pinning. Block certutil download behaviour at policy layer via the ASR rule `Block executable content from email client and webmail` (GUID BE9BA2D9-53EA-4CDC-84E5-9B1EEEE46550) and the `BlockOfficeCommunicationAppFromCreatingChildProcesses` equivalents. Monitor with Sysmon Event ID 1 + 3 for `certutil.exe` with a URL in the command line."
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -805,7 +797,6 @@ patterns:
     positive_examples:
       - "bitsadmin /transfer http://"
     recommendation: "Remove the task. Prefer `ansible.windows.win_get_url` with a checksum. For fleet-wide mitigation, restrict BITS-initiated network I/O to `*.microsoft.com` / `*.windowsupdate.com` via the Windows Firewall service-based rule, and monitor with Sysmon Event ID 1 on `bitsadmin.exe` + Event ID 22 (DNS query) from `svchost.exe` hosting BITS to non-Microsoft hosts."
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -824,7 +815,6 @@ patterns:
     positive_examples:
       - "mshta http://"
     recommendation: "Remove the task. Block mshta entirely via ASR rule `Block all Office applications from creating child processes` and `Block Win32 API calls from Office macros`. If mshta is truly required (uncommon), use a signed, pinned local .hta and enforce AppLocker path + publisher rules."
-    no_ansible_remediation: true
     cwe: ['CWE-749', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: []
@@ -843,7 +833,6 @@ patterns:
     positive_examples:
       - "regsvr32 /i:http://"
     recommendation: "Remove the task. Disable scrobj.dll-based script-host behaviour with AppLocker's `Packaged app rules` + the explicit DLL rule denying scrobj.dll / scrrun.dll loads from user-writable paths. Complement with ASR rule `Block execution of potentially obfuscated scripts` (GUID 5BEB7EFE-FD9A-4556-801D-275E5FFC04CC)."
-    no_ansible_remediation: true
     cwe: ['CWE-749', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: []
@@ -862,7 +851,6 @@ patterns:
     positive_examples:
       - "esentutl /y /vss"
     recommendation: "Remove the task. Legitimate NTDS backup uses `wbadmin start systemstatebackup` on a DC with a dedicated backup account, not ad-hoc esentutl from Ansible. Detect at SACL layer: audit object access on `C:\\Windows\\NTDS\\` and `C:\\Windows\\System32\\config\\SYSTEM`, and alert on any non-SYSTEM user reading them."
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-732']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2, V5.3.1]
@@ -882,7 +870,6 @@ patterns:
     positive_examples:
       - "manage-bde -on -recoverypassword"
     recommendation: "Never enable BitLocker from an ad-hoc playbook. Deploy via Intune BitLocker policy / AD GPO with `Choose how BitLocker-protected operating system drives can be recovered: Save BitLocker recovery information to AD DS: Required`. Monitor `Microsoft-Windows-BitLocker/BitLocker Management` Event IDs 768/769 (key rotation) and alert on any BitLocker enablement that is not correlated to a Group Policy cycle."
-    no_ansible_remediation: true
     cwe: ['CWE-311', 'CWE-319']
     owasp_appsec: ["A02:2021", "A04:2021"]
     owasp_asvs: [V14.2.1, V12.2.1, V12.3.4]
@@ -904,7 +891,6 @@ patterns:
     multiline: true
     window: 20
     recommendation: "Remove the task immediately and treat the host inventory as compromised. Search for and remove any dropped notes across the fleet (`find /home /root -maxdepth 3 -type f \\( -iname 'HOW_TO_DECRYPT*' -o -iname 'README_FOR_DECRYPT*' -o -iname '_readme.txt' \\)`). Rotate all credentials reachable from the affected hosts. Initiate incident-response (preserve VSS snapshots before the attacker deletes them)."
-    no_ansible_remediation: true
     cwe: ['CWE-506']
     mitre_attack: ['T1486', 'T1491']
     cis_controls: ['CIS-10.1', 'CIS-17.3']
@@ -939,7 +925,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Remove the task immediately and treat the host as compromised - no production automation legitimately needs to POST to Discord / Telegram / Pastebin. Rotate credentials reachable from the host, pull network flow logs for any POST to the listed endpoints in the past 30 days, and hunt for the webhook/bot token's usage history via Discord's audit-log API or Telegram's `getMe`. Block the listed domains at the egress firewall (`discord.com`, `api.telegram.org`, `pastebin.com`) outside of narrowly-scoped ChatOps use-cases, which should use an authenticated enterprise broker (Mattermost, Slack Enterprise Grid) instead."
-    no_ansible_remediation: true
     cwe: ['CWE-506', 'CWE-912']
     mitre_attack: ['T1041', 'T1102.001', 'T1567.002']
     cis_controls: ['CIS-3.3', 'CIS-4.8', 'CIS-13.7']
@@ -959,7 +944,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Never push WDAC/AppLocker policies from an ad-hoc playbook; roll them via Intune Endpoint Security or SCCM with a documented policy-review workflow. Keep WDAC in `Enforcement` mode (`Set-RuleOption -Option 0 -Delete` removes audit-mode flag). AppLocker rules MUST be built from publisher-signature (`New-AppLockerPolicy -RuleType Publisher`) or file-path allowlists - never hash wildcards. Monitor WDAC policy changes via Windows Event Log channel `Microsoft-Windows-CodeIntegrity/Operational` event IDs 3099 (policy applied) + 3089 (signature change) forwarded to SIEM with critical alerts on unexpected changes. Verify currently-active policy: `CiTool --list-policies | Where {$_.IsEffective}`."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-732']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V5.3.1]
@@ -981,7 +965,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Treat the host that runs the playbook AND the target host as compromised - this rule only fires on literal exploit strings. Isolate both, rotate all credentials the playbook had access to, and capture volatile memory via `avml` / `winpmem` before power-off. Patch the target per the CVE (Confluence ≥ 8.5.4 / 8.6.0 for CVE-2023-22527, Jenkins ≥ 2.442 / LTS 2.426.3 for CVE-2024-23897, F5 BIG-IP per K23605346, Cisco IOS-XE per cisco-sa-iosxe-webui-privesc-j22SaA4z, vCenter ≥ 8.0 U2c for CVE-2024-37080). Do NOT re-run the offending playbook. Hunt for persistence IoCs: Confluence -> `confluence-cli`/`webworks` plugin, Jenkins -> new `/var/jenkins_home/users/*/config.xml`, IOS-XE -> `cisco_support_user` account."
-    no_ansible_remediation: true
     cwe: ['CWE-22', 'CWE-78', 'CWE-94']
     cve: ["CVE-2022-1388", "CVE-2023-20198", "CVE-2023-22527", "CVE-2024-23897", "CVE-2024-37080"]
     owasp_appsec: ["A01:2021", "A03:2021"]
@@ -1004,7 +987,6 @@ patterns:
     multiline: true
     window: 12
     recommendation: "Do NOT distribute macro-enabled Office documents via Ansible for any production workflow. Block macro execution organization-wide via Group Policy: `Computer Config -> Admin Templates -> Microsoft Office 2016 -> Security -> Block macros from running in Office files from the Internet = Enabled` + `VBA Macro Notification Settings = Disable all without notification`. For legitimate macro use (finance teams, engineering calc sheets), require **code-signed macros only** with a digital signature from an internal CA trusted in the user's cert store. Convert existing macros to Office Scripts (cloud-backed, signed, sandboxed, no VBA). Quarantine macro-enabled files at email gateway. If a playbook MUST deliver templates, deliver the non-macro variant (`.docx`, `.xlsx`). Detect: Sysmon Event ID 1 for `WINWORD.EXE`/`EXCEL.EXE` with child process (`cmd.exe`, `powershell.exe`, `wscript.exe`) - this combination is >99% malicious. Alert on any Ansible task transferring `.docm`/`.xlsm`/`.pptm` to user-writable paths."
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-506', 'CWE-829']
     owasp_appsec: ["A03:2021", "A08:2021"]
     owasp_asvs: []
@@ -1026,7 +1008,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Block `MSBuild.exe` with AppLocker or Microsoft Defender Application Control (WDAC) on hosts that do NOT legitimately compile .NET code (i.e. everything except developer workstations and build servers). Use WDAC's `--Block-MSBuild-Code-Execution` supplemental policy from Microsoft's recommended-block-list. On dev hosts where MSBuild IS legitimate, alert on MSBuild invocations with `.csproj` / `.xml` paths under user profile directories (`AppData`, `Temp`, `Downloads`, `Desktop`) - legitimate dev work uses source-controlled repos, NEVER from those paths. Detect: Sysmon Event ID 1 with `Image=*\\msbuild.exe` + `CommandLine` matching user-profile paths. For Ansible automation that needs compilation, use a dedicated build agent in a locked-down network segment with limited egress - not 'msbuild.exe from a user laptop playbook'. Audit: `Get-EventLog -LogName Application -Source 'MSBuild' -After (Get-Date).AddDays(-7)` - any entry on a non-dev host is suspicious."
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-506', 'CWE-829']
     owasp_appsec: ["A03:2021", "A08:2021"]
     owasp_asvs: []
@@ -1067,7 +1048,6 @@ patterns:
     multiline: true
     window: 30
     recommendation: "Never map a single public-facing hostname to both a public AND an RFC1918/loopback/link-local IP. For legitimate split-horizon DNS (internal-users-see-internal, external-see-external), use **views** (BIND), **policies** (PowerDNS), or **split DNS** - NOT multiple A records in the same view. Set TTLs to sane values (300-3600s); TTLs of 0/1/2 are almost always malicious or operationally broken. Configure recursive resolvers to reject responses containing private-space IPs for public-space hostnames - BIND `deny-answer-addresses { 10.0.0.0/8; 172.16.0.0/12; 192.168.0.0/16; 127.0.0.0/8; 169.254.0.0/16; } except-from { internal-domains; };`. Browser-side: use DNS-over-HTTPS (DoH) to bypass attacker-controlled local resolvers. Application-side: validate the resolved IP AFTER DNS resolution and before HTTP request (`socket.getaddrinfo` + IP-range check) - reject private IPs when you expect a public endpoint. Detect: passive DNS / Zeek scripts alerting on any hostname resolving to a mix of public + RFC1918 within a 1-hour window."
-    no_ansible_remediation: true
     cwe: ['CWE-290', 'CWE-346', 'CWE-918']
     owasp_appsec: ["A07:2021", "A10:2021"]
     mitre_attack: ['T1071.004', 'T1090', 'T1557']
@@ -1088,7 +1068,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Never transfer serialized Java objects from untrusted or unverified sources. If your application legitimately uses Java deserialization (migrate away from it - JSON or Protobuf are safer), configure **SerialKiller** (`org.nibblesec.tools.SerialKiller`) as the `ObjectInputFilter` to allow-list only specific classes. For Java 9+, use `ObjectInputFilter.Config.setSerialFilter(\"!org.apache.commons.collections.functors.*;!javax.management.BadAttributeValueExpException;...\")` on every JVM startup. Block `commons-collections` < 3.2.2 and < 4.1 (both have InvokerTransformer exposed) via Maven enforcer / Gradle dependency constraints. For runtime, enable RASP (Contrast, OpenRASP) to block deserialization call stacks that terminate in `Runtime.exec` / `ProcessBuilder`. Audit: `find / -name '*.ser' -exec xxd {} + | head -1 | grep -q 'aced 0005' && echo SUSPECT` + grep codebases for `ObjectInputStream` constructor calls without a preceding `setObjectInputFilter`. Migrate high-risk deserialization to Jackson with `ACCEPT_CASE_INSENSITIVE_PROPERTIES=false` + `@JsonTypeInfo(use = NAME)` explicit class whitelisting only."
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-502', 'CWE-915']
     cve: ["CVE-2015-4852"]
     owasp_appsec: ["A03:2021", "A08:2021"]

--- a/src/ansible_security_scanner/patterns/obfuscation_evasion.yml
+++ b/src/ansible_security_scanner/patterns/obfuscation_evasion.yml
@@ -136,7 +136,6 @@ patterns:
     positive_examples:
       - "echo ''|rev|sh"
     recommendation: "String reversal piped to a shell is an evasion technique"
-    no_ansible_remediation: true
     cwe: ['CWE-506']
     mitre_attack: ['T1027', 'T1140']
     cis_controls: ['CIS-4.1', 'CIS-10.1']

--- a/src/ansible_security_scanner/patterns/offensive_tools.yml
+++ b/src/ansible_security_scanner/patterns/offensive_tools.yml
@@ -64,7 +64,6 @@ patterns:
     positive_examples:
       - "Rubeus"
     recommendation: "Rubeus is a Kerberos attack tool; remove immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -78,7 +77,6 @@ patterns:
     positive_examples:
       - "cobaltstrike"
     recommendation: "C2 frameworks indicate an active attack; escalate to incident response immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -111,7 +109,6 @@ patterns:
     positive_examples:
       - "exploit-db"
     recommendation: "Exploit tools and references should not appear in production infrastructure code"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -157,7 +154,6 @@ patterns:
     positive_examples:
       - "my $linenum=0;"
     recommendation: "Priv-esc enumeration scripts indicate reconnaissance; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -171,7 +167,6 @@ patterns:
     positive_examples:
       - "crackmapexec smb"
     recommendation: "CrackMapExec/NetExec are offensive AD tools; remove and investigate as a potential compromise"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -185,7 +180,6 @@ patterns:
     positive_examples:
       - "evil-winrm"
     recommendation: "Evil-WinRM is an offensive remote shell tool; remove immediately and investigate"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -199,7 +193,6 @@ patterns:
     positive_examples:
       - "certipy find"
     recommendation: "Certipy is used to abuse AD CS; remove and audit AD certificate configurations"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -213,7 +206,6 @@ patterns:
     positive_examples:
       - "kerbrute userenum"
     recommendation: "Kerbrute is a Kerberos brute forcing tool; remove and investigate unauthorized access attempts"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -227,7 +219,6 @@ patterns:
     positive_examples:
       - "pypykatz lsa"
     recommendation: "Pypykatz is a credential dumping tool; remove immediately and rotate affected credentials"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -241,7 +232,6 @@ patterns:
     positive_examples:
       - "ntdsutil ifm"
     recommendation: "ntdsutil IFM creates full copies of the AD database; remove and investigate data exfiltration"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -255,7 +245,6 @@ patterns:
     positive_examples:
       - "PowerView"
     recommendation: "PowerView/PowerSploit are offensive AD tools; remove and investigate for domain compromise"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -269,7 +258,6 @@ patterns:
     positive_examples:
       - "Seatbelt-group="
     recommendation: "Seatbelt/SharpUp are offensive enumeration tools; remove and investigate host compromise"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -283,7 +271,6 @@ patterns:
     positive_examples:
       - "enum4linux"
     recommendation: "enum4linux is a network reconnaissance tool; remove and restrict SMB exposure"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -297,7 +284,6 @@ patterns:
     positive_examples:
       - "smbclient //"
     recommendation: "SMB share tools can be used for lateral movement; verify legitimate need and restrict access"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -311,7 +297,6 @@ patterns:
     positive_examples:
       - "ATTRIBUTE=$(ldapsearch -Z -LLL -x -y /etc/ssh/ldap_authorized_keys_bindpw -D \"${ldap_binddn}\" -o ldif-wrap=no -S sshPublicKey \"${ldap_filter}\" sshPublicKey | grep -v 'dn:')"
     recommendation: "ldapsearch can expose directory information; verify legitimate need and use least-privilege binds"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -325,7 +310,6 @@ patterns:
     positive_examples:
       - "rpcclient -U "
     recommendation: "rpcclient can enumerate domain objects; verify legitimate use and restrict null sessions"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -339,7 +323,6 @@ patterns:
     positive_examples:
       - "nikto -h "
     recommendation: "Nikto is a web vulnerability scanner; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -353,7 +336,6 @@ patterns:
     positive_examples:
       - "nuclei -u "
     recommendation: "Nuclei is a vulnerability scanner; remove from production infrastructure automation"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -369,7 +351,6 @@ patterns:
     positive_examples:
       - "ffuf -u "
     recommendation: "ffuf is an offensive web fuzzing tool; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -383,7 +364,6 @@ patterns:
     positive_examples:
       - "feroxbuster -u "
     recommendation: "feroxbuster is an offensive directory brute forcing tool; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -399,7 +379,6 @@ patterns:
     positive_examples:
       - "gobuster dir "
     recommendation: "gobuster is an offensive brute forcing tool; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -413,7 +392,6 @@ patterns:
     positive_examples:
       - "rustscan -a "
     recommendation: "RustScan is an offensive port scanner; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -427,7 +405,6 @@ patterns:
     positive_examples:
       - "snmpwalk -v1"
     recommendation: "SNMP enumeration can expose device configurations; verify legitimate need and use SNMPv3"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -441,7 +418,6 @@ patterns:
     positive_examples:
       - "testssl "
     recommendation: "SSL scanning tools can identify exploitable weaknesses; verify authorized security testing"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -455,7 +431,6 @@ patterns:
     positive_examples:
       - "nbtscan "
     recommendation: "nbtscan is a network reconnaissance tool; remove from production playbooks"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -469,7 +444,6 @@ patterns:
     positive_examples:
       - 'reg save HKLM\SAM'
     recommendation: "Dumping registry hives enables offline credential cracking; remove and investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -483,7 +457,6 @@ patterns:
     positive_examples:
       - "firefox_decrypt"
     recommendation: "firefox_decrypt steals saved browser credentials; remove and investigate data theft"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -497,7 +470,6 @@ patterns:
     positive_examples:
       - "SharpDPAPI  triage"
     recommendation: "DPAPI extraction tools steal protected credentials; remove immediately and rotate all secrets"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -513,7 +485,6 @@ patterns:
     positive_examples:
       - "steghide "
     recommendation: "Steganography is used for covert data exfiltration; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -540,7 +511,6 @@ patterns:
     positive_examples:
       - "stegseek 0"
     recommendation: "Steganography brute-force tools are used to extract covert payloads; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -554,7 +524,6 @@ patterns:
     positive_examples:
       - "stegoveritas "
     recommendation: "StegOveritas performs deep steganographic analysis; presence in a playbook is suspicious"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -568,7 +537,6 @@ patterns:
     positive_examples:
       - "jsteg hide "
     recommendation: "jsteg embeds data in JPEG files for covert exfiltration; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -582,7 +550,6 @@ patterns:
     positive_examples:
       - "binwalk -e "
     recommendation: "Binwalk extracts embedded payloads from files; verify this is authorized firmware analysis"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -596,7 +563,6 @@ patterns:
     positive_examples:
       - "exiftool -Comment="
     recommendation: "Writing data into image metadata can be used for covert data storage; verify intent"
-    no_ansible_remediation: true
     nist_controls: ['CA-7', 'IR-4', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.3']
@@ -689,7 +655,6 @@ patterns:
     multiline: true
     window: 25
     recommendation: "Remove the task. WMI persistence is never an appropriate CM primitive - use a signed Windows service or scheduled task enrolled through GPO / Intune. Enumerate and clean existing bindings with `Get-WmiObject -Namespace root\\subscription -Class __FilterToConsumerBinding | Remove-WmiObject`. Monitor with Sysmon Event IDs 19/20/21 (WmiEvent) and alert on any subscription whose consumer is ActiveScript or CommandLine."
-    no_ansible_remediation: true
     cwe: ['CWE-506', 'CWE-653']
     owasp_appsec: ["A04:2021"]
     mitre_attack: ['T1047', 'T1546.003']
@@ -709,7 +674,6 @@ patterns:
     multiline: true
     window: 30
     recommendation: "Never export the ADFS token-signing private key via automation. Store it in an HSM-backed key provider (`Microsoft Platform Crypto Provider` / `Microsoft Software Key Storage Provider` with non-exportable keys) and rotate it with `Update-AdfsCertificate -CertificateType Token-Signing -Urgent` immediately if exfiltration is suspected. Monitor ADFS admin log Event IDs 307/310 for certificate operations and correlate with AD 4662 on the ADFS service account. After any Golden SAML suspicion, rotate both primary and secondary token-signing certificates twice (revoke forged tokens in caches)."
-    no_ansible_remediation: true
     cwe: ['CWE-321', 'CWE-347', 'CWE-798']
     owasp_appsec: ["A02:2021", "A07:2021"]
     owasp_asvs: [V13.2.3, V13.3.1]
@@ -731,7 +695,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Disable enrollee-supplies-subject on any template that issues authentication EKUs. Audit existing templates with `Get-ADObject -SearchBase (Get-ADRootDSE).ConfigurationNamingContext -Filter {objectClass -eq 'pKICertificateTemplate'} -Properties msPKI-Certificate-Name-Flag,pKIExtendedKeyUsage` and remove the flag, or restrict Enroll/AutoEnroll rights to a specific security group (not Domain Users). Run Certify.exe or Locksmith.ps1 to enumerate ESC1-ESC8 in the environment."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-295']
     owasp_appsec: ["A01:2021", "A07:2021"]
     owasp_asvs: [V12.3.4]

--- a/src/ansible_security_scanner/patterns/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/operational_security.yml
@@ -17,7 +17,6 @@ patterns:
     positive_examples:
       - "apt_repository: repo=\"ppa:ansible/ansible\""
     recommendation: "Only use approved internal package mirrors; vet third-party repos through security review"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -32,7 +31,6 @@ patterns:
     positive_examples:
       - "cmd: dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo"
     recommendation: "Only use approved internal package mirrors; vet third-party repos through security review"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -63,7 +61,6 @@ patterns:
     positive_examples:
       - "command: update-ca-trust"
     recommendation: "CA certificate installation must go through approved PKI workflows with security review"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -77,7 +74,6 @@ patterns:
     positive_examples:
       - "openssl req -x509 -batch -sha256 -days 1825 -newkey rsa:2048 -nodes -keyout /root/ca.key -out /usr/local/share/ca-certificates/ca.crt"
     recommendation: "Use an approved certificate authority (Let's Encrypt, internal CA); avoid self-signed certs"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -93,7 +89,6 @@ patterns:
     positive_examples:
       - "- nmap inventory plugin - use ``raise ... from ...`` when passing on exceptions (https://github.com/ansible-collections/community.general/pull/11095)."
     recommendation: "Network scanning should only be performed by authorized security teams, not from playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -107,7 +102,6 @@ patterns:
     positive_examples:
       - "qhv8FwdoPFNh8TC11btfU1wphcBl65pCaPff2s94/Gj2aQ0PrFYuhPtzqwARAQAB"
     recommendation: "Network capture should only be performed by authorized network teams with proper controls"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -168,7 +162,6 @@ patterns:
     #      is ≥16 chars of hex only (randomised name -> malware beacon).
     regex: "(?mi)(?:^\\s*ExecStart\\s*=\\s*(?:/tmp/|/var/tmp/|/dev/shm/|~/|/home/[^/\\s]+/\\.cache/|/home/[^/\\s]+/tmp/)[^\\n]+|/etc/systemd/system/[a-f0-9]{16,}\\.service(?=[\"'\\s]|$))"
     recommendation: "If the service is legitimate, move the binary to a managed location (``/usr/local/bin/`` or a package-managed path) and reference it from there; ephemeral/user-writable ``ExecStart=`` targets let any local user (or any process with equivalent write access) hijack a root-context service at boot."
-    no_ansible_remediation: true
     positive_examples:
       - |2-
               content: |
@@ -205,7 +198,6 @@ patterns:
     positive_examples:
       - "ExecStart = /etc/init.d/elastichq start"
     recommendation: "Use approved configuration management for service lifecycle, not init script manipulation"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -219,7 +211,6 @@ patterns:
     positive_examples:
       - "dest:/.config/autostart/.desktop"
     recommendation: "XDG autostart entries should be deployed through approved configuration management only"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -233,7 +224,6 @@ patterns:
     positive_examples:
       - "/etc/anacrontab"
     recommendation: "Scheduled tasks should use approved orchestration; do not modify anacrontab in playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -247,7 +237,6 @@ patterns:
     positive_examples:
       - "pidfile_run=\"/run/$(basename \"${0}\").pid\""
     recommendation: "udev rules must go through approved system configuration; RUN= allows arbitrary command execution"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -261,7 +250,6 @@ patterns:
     positive_examples:
       - "path:  '{{ \"/etc/apt/apt.conf.d/\" + (item.filename | d(item.name | regex_replace(\".conf$\", \"\") + \".conf\")) }}'"
     recommendation: "APT hooks can execute arbitrary code on every package install; use approved config management"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -275,7 +263,6 @@ patterns:
     positive_examples:
       - "dest: '/etc/modules-load.d/{{ item.filename | d(item.name | replace(\"_\", \"-\") + \".conf\") }}'"
     recommendation: "Kernel module auto-loading must be managed through approved system hardening workflows"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -289,7 +276,6 @@ patterns:
     positive_examples:
       - "/etc/NetworkManager/dispatcher.d/"
     recommendation: "NetworkManager dispatcher scripts run as root on network changes; use approved config management"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -305,7 +291,6 @@ patterns:
     positive_examples:
       - "ssh -M -S '{{ xdebug_tunnel_control_socket }}' -fnNT -R {{ xdebug_tunnel_port_mapping }} {{ xdebug_tunnel_user_at_host }} '{{ xdebug_tunnel_control_identity }}'"
     recommendation: "Use approved VPN or network access solutions, not SSH tunnels from playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -319,7 +304,6 @@ patterns:
     positive_examples:
       - "line: PasswordAuthentication yes"
     recommendation: "SSH hardening should follow CIS benchmarks; never weaken SSH config from playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -336,7 +320,6 @@ patterns:
     positive_examples:
       - "redis-cli -a \"$(redis-password)\" -n \"${REDIS_DATABASE}\" --raw keys \"blobs::sha256:*\" 2>/dev/null \\"
     recommendation: "Use credential files (.my.cnf, .pgpass) or environment variables, not inline passwords"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -356,7 +339,6 @@ patterns:
       - "- shell: ansible-galaxy collection install -r requirements.yml"
       - "- shell: ansible-galaxy install --requirements-file roles.yml"
     recommendation: "Always install via a pinned ``requirements.yml`` (``ansible-galaxy install -r requirements.yml``). Pin every entry to a version (``version: 1.2.3``), or for git sources to a full 40-char SHA. For collections, pin via ``signatures:`` (Sigstore / GPG) when the source supports it. Run installs against an internal Galaxy proxy you control; avoid the public ``galaxy.ansible.com`` for production."
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -370,7 +352,6 @@ patterns:
     positive_examples:
       - "git clone https://github.com/containers/podman.git /tmp/podman"
     recommendation: "Pin git clone to specific tags/SHAs; prefer internal mirrors for external repositories"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -386,7 +367,6 @@ patterns:
     positive_examples:
       - "iptables -F"
     recommendation: "Never disable host firewalls from playbooks; manage rules through approved IaC"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -402,7 +382,6 @@ patterns:
     positive_examples:
       - "Write-Host \"$($acl.AccessRight)|$($acl.AccessControlType)|$($acl.AccountName)\""
     recommendation: "DNS queries should not contain dynamic/variable data; this pattern suggests data exfiltration"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -418,7 +397,6 @@ patterns:
     positive_examples:
       - "- modprobe - remove redundant conversions to unicode (https://github.com/ansible-collections/community.general/pull/11098)."
     recommendation: "Kernel module management should go through approved system hardening workflows"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -435,7 +413,6 @@ patterns:
     positive_examples:
       - "git: repo=git://github.com/pooler/cpuminer.git dest=/opt/cpuminer accept_hostkey=yes"
     recommendation: "Crypto mining is never permitted on managed infrastructure; remove immediately and investigate"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -449,7 +426,6 @@ patterns:
     positive_examples:
       - "pool.:0000"
     recommendation: "Mining pool connections are never legitimate in automation; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -465,7 +441,6 @@ patterns:
     positive_examples:
       - "Environment=LD_PRELOAD={{ libfaketime_path.stdout_lines[0].strip() }}"
     recommendation: "LD_PRELOAD is a common rootkit technique; this should never appear in playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -479,7 +454,6 @@ patterns:
     positive_examples:
       - "export LD_LIBRARY_PATH=\"${HOME}/go/deps/sqlite/.libs/:${HOME}/go/deps/libco/:${HOME}/go/deps/raft/.libs/:${HOME}/go/deps/dqlite/.libs/\""
     recommendation: "Never set LD_LIBRARY_PATH to untrusted directories"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -495,7 +469,6 @@ patterns:
     positive_examples:
       - "lineinfile: dest=/etc/pam.d/sshd line=\"{{item}}\""
     recommendation: "PAM configuration must be managed through approved hardening workflows with change control"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -511,7 +484,6 @@ patterns:
     positive_examples:
       - "grep -Eq \"$CMD_PATT\" \"/proc/$pid/cmdline\" 2>/dev/null && return 0"
     recommendation: "Process debugging tools should never be used from playbooks; this is a credential extraction technique"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -527,7 +499,6 @@ patterns:
     positive_examples:
       - "- cron: \"0 4 * * *\" # Run daily at 4:00 UTC"
     recommendation: "Use approved scheduling (cron, systemd timers) with proper audit trails, not at/batch"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -541,7 +512,6 @@ patterns:
     positive_examples:
       - "cd $DAEMON_PATH && nohup npm start > $DAEMON_PATH/logs/$DAEMON_NAME.log 2>&1 &"
     recommendation: "Long-running processes should be managed as systemd services with a ``Restart=on-failure``, ``StandardOutput=journal``, and ``MemoryMax=`` limit. For containers, use the container runtime's restart policy (``--restart=unless-stopped`` for podman/docker, ``restartPolicy: Always`` for Kubernetes). For one-off jobs, use ``systemd-run --unit=... --on-calendar=...`` (transient timer) so the schedule is still tracked by systemd."
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -557,7 +527,6 @@ patterns:
     positive_examples:
       - "iptables -t nat -D POSTROUTING -s {{ node_pod_cidr|ansible.utils.ipaddr('net') }} -o {{ node_default_gateway_interface }} -j MASQUERADE"
     recommendation: "Network NAT rules should be managed through approved network infrastructure, not playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -571,7 +540,6 @@ patterns:
     positive_examples:
       - "arpspoof "
     recommendation: "ARP manipulation is never legitimate in automation; this indicates active network attack"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -587,7 +555,6 @@ patterns:
     positive_examples:
       - "nsenter --cgroup=/hostproc/1/ns/cgroup --mount=/hostproc/1/ns/mnt \"${BIN_PATH}/cilium-mount\" $CGROUP_ROOT;"
     recommendation: "nsenter into PID 1 is a container escape; this should never appear in playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -601,7 +568,6 @@ patterns:
     positive_examples:
       - "/proc/sysrq-trigger"
     recommendation: "SysRq trigger access is dangerous and indicates attempted system disruption"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -617,7 +583,6 @@ patterns:
     positive_examples:
       - "dest: /root/.netrc"
     recommendation: "Use secret management (Vault, SSM) instead of credential dotfiles on disk"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -631,7 +596,6 @@ patterns:
     positive_examples:
       - "dest: /root/.aws/credentials"
     recommendation: "Use IAM roles and instance profiles, not persistent credential files"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -647,7 +611,6 @@ patterns:
     positive_examples:
       - "file: src=/home/{{user_name}}/.ssh/id_rsa.pub dest=/home/{{user_name}}/.ssh/authorized_keys state=link"
     recommendation: "SSH key management should be centralized; review all authorized_key additions"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -689,7 +652,6 @@ patterns:
     positive_examples:
       - "http_proxy:http://:@"
     recommendation: "Use proxy authentication through PAC files or credential helpers, not inline URLs"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -705,7 +667,6 @@ patterns:
     positive_examples:
       - "ipmitool -H "
     recommendation: "IPMI commands grant hardware-level control; access must be strictly controlled and audited"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -719,7 +680,6 @@ patterns:
     positive_examples:
       - "url: \"https://{{ idrac_ip }}:{{ idrac_port }}/redfish/v1/Managers\\"
     recommendation: "Redfish API access provides hardware control; must be authorized and logged"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -735,7 +695,6 @@ patterns:
     positive_examples:
       - "dig axfr"
     recommendation: "DNS zone transfers expose full domain inventory; only authorized DNS tools should perform AXFR"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -749,7 +708,6 @@ patterns:
     positive_examples:
       - "dnsrecon"
     recommendation: "DNS enumeration tools are reconnaissance techniques; should not run from playbooks"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -765,7 +723,6 @@ patterns:
     positive_examples:
       - "dest: '/etc/systemd/system/netbox-housekeeping.timer'"
     recommendation: "Systemd timers are a persistence mechanism; ensure they are authorized and audited"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -779,7 +736,6 @@ patterns:
     positive_examples:
       - "systemd-run --on-calendar"
     recommendation: "Transient systemd timers bypass standard unit file review; use proper timer unit files"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -795,7 +751,6 @@ patterns:
     positive_examples:
       - "bpftool prog load"
     recommendation: "eBPF programs have kernel-level access; loading should be strictly controlled"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -809,7 +764,6 @@ patterns:
     positive_examples:
       - "dest: '/etc/default/grub.d/debops.apparmor.cfg'"
     recommendation: "Bootloader modifications can install rootkits; changes must go through change management"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -823,7 +777,6 @@ patterns:
     positive_examples:
       - "- name: Update-initramfs # noqa no-changed-when"
     recommendation: "Initramfs modifications execute at boot before security controls; audit carefully"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -837,7 +790,6 @@ patterns:
     positive_examples:
       - "/sys/fs/cgrouprelease_agent"
     recommendation: "Cgroup manipulation is a container escape technique; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -856,7 +808,6 @@ patterns:
     positive_examples:
       - "bash deepce.sh"
     recommendation: "DEEPCE is a container escape toolkit; its presence indicates active container breakout attempts"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -870,7 +821,6 @@ patterns:
     positive_examples:
       - "cdk evaluate"
     recommendation: "CDK is a container penetration toolkit; investigate immediately"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -925,7 +875,6 @@ patterns:
     positive_examples:
       - "amicontained"
     recommendation: "Amicontained is a container introspection tool used in escape reconnaissance; investigate"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -939,7 +888,6 @@ patterns:
     positive_examples:
       - "--cap-add=SYS_PTRACE"
     recommendation: "SYS_PTRACE allows process injection across containers; this is a privilege escalation vector"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -953,7 +901,6 @@ patterns:
     positive_examples:
       - "strings /dev/swap"
     recommendation: "Reading swap/memory for credentials is an attack technique; remove and investigate"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -967,7 +914,6 @@ patterns:
     positive_examples:
       - "- cron: \"0 4 * * *\" # Run daily at 4:00 UTC"
     recommendation: "Scheduled at jobs can evade detection; use cron/systemd timers with proper auditing instead"
-    no_ansible_remediation: true
     nist_controls: ['AU-6', 'CA-7', 'SI-4']
     pci_dss: ['10.4.1', '12.10.1']
     soc2: ['CC7.2']
@@ -983,7 +929,6 @@ patterns:
     positive_examples:
       - "Reset-ADAccountPasswordidentitykrbtgt"
     recommendation: "krbtgt resets should follow the Microsoft-recommended two-reset procedure (>10 hour gap) and be triggered by an IR runbook, not routine configuration management. Document the reason in the change ticket and audit who initiated it."
-    no_ansible_remediation: true
     cwe: ['CWE-321', 'CWE-1188']
     owasp_appsec: ["A02:2021"]
     mitre_attack: ['T1098.007', 'T1558.001']
@@ -1002,7 +947,6 @@ patterns:
     positive_examples:
       - "Get-LAPSADPassword"
     recommendation: "LAPS reads should be just-in-time, for a specific host, by a specific engineer (via the LAPS UI or scoped PowerShell). Bulk reads from automation indicate either a scope problem (script has more access than needed) or credential harvesting - audit the caller and tighten 'All extended rights' on OUs."
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-522']
     owasp_appsec: ["A01:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V14.2.2]
@@ -1026,7 +970,6 @@ patterns:
     multiline: true
     window: 8
     recommendation: "Store activation keys and passwords in Ansible Vault and reference them by variable: `password: \"{{ vault_rhsm_password }}\"`. For unattended registration, prefer activation keys over passwords (they have narrower scope and can be rotated independently), and rotate them after every CI run that exposed them. Use Red Hat Insights + organisation-scoped service accounts rather than per-host credentials where possible."
-    no_ansible_remediation: true
     cwe: ['CWE-312', 'CWE-522', 'CWE-798']
     owasp_appsec: ["A04:2021", "A07:2021"]
     owasp_asvs: [V13.2.1, V13.2.3, V13.3.1, V14.1.1, V11.2.5, V14.2.1]
@@ -1108,7 +1051,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Immutable / append-only flags on `/etc/shadow`, `/etc/sudoers`, `/etc/ssh/sshd_config`, `/var/log/audit/audit.log`, and `/etc/audit/rules.d/` are a deliberate defence; removing them should only happen inside a short, audited maintenance window, with the flag restored immediately after. If an Ansible role needs to edit these files routinely, fix the root cause (don't set the flag), rather than toggling it. Monitor: add an auditd watch (`-w /etc/shadow -p wa`) and alert on `ausearch -k shadow_write` from a non-maintenance session."
-    no_ansible_remediation: true
     cwe: ['CWE-281', 'CWE-732']
     owasp_asvs: [V5.3.1]
     mitre_attack: ['T1070.002', 'T1222', 'T1562.001']
@@ -1132,7 +1074,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Never flush or disable firewalld on production RHEL. To add a legitimate rule, use `ansible.posix.firewalld: zone: public, service: https, permanent: true, state: enabled`. If a host genuinely does not need a firewall (e.g. a bastion behind a dedicated security group), document the exception in `.security-scanner-allowlist.yml` with a business justification, not by disabling firewalld."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1562.004']
@@ -1152,7 +1093,6 @@ patterns:
     multiline: true
     window: 25
     recommendation: "Remove the task. If a legitimate maintenance window needs rsyslog briefly stopped, use a tightly-scoped handler with a matching `state: started` restart and log the action to a remote SIEM via a separate channel (syslog-ng forwarder on a different host, or a Fluent Bit sidecar). Never use `masked: true` on a logging service. Monitor with auditd's `-w /bin/systemctl -p x -k systemctl_exec` and alert on any `stop`/`mask` targeting logging units."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1174,7 +1114,6 @@ patterns:
     multiline: true
     window: 3
     recommendation: "Remove the task. For log-size control, configure `logrotate` under `/etc/logrotate.d/` with `copytruncate`, `compress`, and `maxsize` directives. For history hygiene on shared hosts, rely on `HISTCONTROL=ignoreboth` and a remote session-recording tool (auditd + ausearch, or Teleport session recording) - never truncate live logs. Forward all auth/secure/audit logs off-host to a SIEM (rsyslog `@@siem:6514` over TLS) so a local wipe cannot destroy evidence."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1219,7 +1158,6 @@ patterns:
     multiline: true
     window: 50
     recommendation: "Before any FIM reinit, archive the current DB off-host to append-only storage: `aws s3 cp /var/lib/aide/aide.db s3://forensic-vault/$(hostname)/$(date +%s)/aide.db --acl bucket-owner-full-control --metadata immutable=true` then rotate. For AIDE, use `aide --check` on a schedule; only reinit during patched-and-verified maintenance windows, not in ad-hoc playbooks. Alert on any DB removal via auditd: `-w /var/lib/aide/ -p wa -k fim_tamper` and forward to SIEM. Compensate with a cloud-side control: enable EBS/Azure-disk snapshot-on-change or zfs send for ground-truth disk baselines."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1241,7 +1179,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Point the primary resolver at an enterprise DoH gateway (Cloudflare Gateway with DNS Policies, Cisco Umbrella, Zscaler ZIA DNS Control, or an internal Pi-hole/AdGuard Home + Unbound stack) that both logs queries to SIEM and enforces category-based blocking. Forbid public-resolver DoH via outbound firewall (block TCP/443 to the known public-DoH IP ranges + HTTP/3 QUIC). On managed Windows fleets, enforce `NetworkIsolationEnableAutoProxy=false` + DoH policy pointing at the enterprise gateway only."
-    no_ansible_remediation: true
     cwe: ['CWE-441', 'CWE-778']
     owasp_appsec: ["A01:2021", "A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1265,7 +1202,6 @@ patterns:
     multiline: true
     window: 20
     recommendation: "Treat any CloudTrail-disablement task as an active incident. Re-enable logging IMMEDIATELY (`aws cloudtrail start-logging` + `put-event-selectors ReadWriteType=All IncludeManagementEvents=true`). Lock the trail against future disablement by applying an SCP at the organisation level: `Deny cloudtrail:DeleteTrail, cloudtrail:StopLogging, cloudtrail:PutEventSelectors` except from a break-glass role requiring manual ticket approval. Enable AWS Security Hub control `CloudTrail.1` and `CloudTrail.4` for alerting. Restore any missing events from the S3 backing bucket (log files continue to be written during the `WriteOnly` window - only API filtering is affected)."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1287,7 +1223,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Re-enable immediately. Apply an organization-level SCP denying these APIs except from a delegated-admin security account: `{\"Effect\":\"Deny\",\"Action\":[\"guardduty:Delete*\",\"guardduty:Stop*\",\"securityhub:Disable*\",\"config:Stop*\",\"config:Delete*\"],\"Resource\":\"*\",\"Condition\":{\"StringNotEquals\":{\"aws:PrincipalOrgID\":\"<org-id>\",\"aws:PrincipalArn\":\"arn:aws:iam::<security-acct>:role/SecurityHubAdmin\"}}}`. Enable AWS Organizations delegated admin for GuardDuty + Security Hub so member accounts cannot disable locally. Monitor `eventName=DeleteDetector` etc. via EventBridge with a 24/7 pager alert."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1328,7 +1263,6 @@ patterns:
       - "az security pricing create --tier Free"
     multiline: true
     recommendation: "Re-enable Defender Standard tier across all subscriptions: `az security pricing create --name VirtualMachines --tier Standard` (repeat for `StorageAccounts`, `SqlServers`, `KeyVaults`, `Arm`, `Dns`, `Containers`). Lock via Azure Policy: `DeployIfNotExists` on `Microsoft.Security/pricings` requiring `Standard` tier. Re-instate any deleted Sentinel data-connectors and add `Microsoft.SecurityInsights/dataConnectors/write` deny via Azure Policy except for a break-glass `SentinelAdmin` role. Audit existing downgrades: `az security pricing list --query \"[?pricingTier=='Free']\"`."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1348,7 +1282,6 @@ patterns:
     positive_examples:
       - "csrutil disable"
     recommendation: "Never disable SIP on production or endpoint-fleet macOS. For the rare legitimate case (kernel-extension development for a security product) require it to be scoped to a dedicated developer Mac that is NEVER enrolled in MDM and NEVER holds corporate credentials. If a playbook legitimately disables SIP for a kernel-driver install, verify via Apple's recommended path: a temporary `csr-active-config` with MINIMAL flags (only `CSR_ALLOW_UNAPPROVED_KEXTS`) not a full `disable`. On fleet endpoints, use Apple MDM's `com.apple.security.*` profile to LOCK SIP on via DeviceManagement. Alert on `csrutil status` != `enabled` via Jamf/Kandji/Mosyle."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-284', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V13.4.5, V15.2.3]
@@ -1386,7 +1319,6 @@ patterns:
     positive_examples:
       - "tccutil reset All"
     recommendation: "NEVER mutate TCC.db from a playbook. Grant privacy permissions through the MDM `com.apple.TCC.configuration-profile-policy` payload (PPPC), which is the ONLY Apple-supported way to pre-authorise apps without a user prompt. Deliver PPPC profiles via Jamf PPPC Utility / Kandji / Mosyle with the full `CodeRequirement` string from `codesign -dr - <app>`. Alert on any `tccutil reset` via EndpointSecurity ES_EVENT_TYPE_AUTH_* subscriptions in your EDR."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-807', 'CWE-863']
     cve: ["CVE-2020-9771", "CVE-2022-32800", "CVE-2023-40424"]
     owasp_appsec: ["A01:2021", "A04:2021"]
@@ -1407,7 +1339,6 @@ patterns:
     multiline: true
     window: 100
     recommendation: "LaunchDaemons are LEGITIMATE for signed, notarized, MDM-deployed software. For those, pin every plist to `/Library/LaunchDaemons/com.<vendor>.<product>.plist` with `ProgramArguments` pointing at `/Library/Application Support/<vendor>/<signed-binary>` - never into world-writable locations. Sign every `launchd` plist's target binary with a Developer-ID cert + notarize it. Audit existing persistence: `launchctl list | grep -v com.apple` and review each non-Apple entry. For IR, enumerate with `sudo find /Library/Launch* ~/Library/LaunchAgents -name '*.plist' -newer /var/log/install.log`."
-    no_ansible_remediation: true
     cwe: ['CWE-269', 'CWE-506', 'CWE-732']
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V5.3.1]
@@ -1429,7 +1360,6 @@ patterns:
     multiline: true
     window: 30
     recommendation: "Never flush a host firewall without the replacement ruleset in the same transaction. Use `iptables-restore < /etc/iptables/rules.v4` (atomic swap) or nftables `nft -f /etc/nftables.conf` (transactional). Preferred: manage the firewall with `ansible.posix.firewalld` / `community.general.ufw` / `ansible.builtin.iptables` module idempotently - never with ad-hoc shell. Maintain default-DENY policies: `iptables -P INPUT DROP`, `iptables -P FORWARD DROP`. Audit for this pattern in your config-drift detection."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-732']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V5.3.1]
@@ -1449,7 +1379,6 @@ patterns:
     positive_examples:
       - "iptables-save >/dev/null"
     recommendation: "Always persist firewall rules to the distro's canonical location: `/etc/iptables/rules.v4` (Debian/Ubuntu netfilter-persistent), `/etc/sysconfig/iptables` (RHEL/CentOS with `iptables-services`), `/etc/nftables.conf` (nftables-based distros). Use the `ansible.builtin.iptables` module with `state: saved` (iptables ≥ 1.8.4) or a `notify: save iptables` handler. For compliance dumps, write to `/var/log/firewall/snapshot-$(date +%Y%m%d).conf` with mode `0600` owner `root:adm`. Never pipe firewall state to ephemeral storage."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-778']
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1471,7 +1400,6 @@ patterns:
     multiline: true
     window: 60
     recommendation: "Every `/etc/pf.conf` MUST start with `set skip on lo` then `block return all` (or `block drop all`) BEFORE any `pass` rules. Load via `pfctl -f /etc/pf.conf -e` in the maintenance window, never `pfctl -d`. For macOS, use an MDM configuration profile (`com.apple.applicationaccess.new`) to prevent `pfctl -d`. Validate with `pfctl -sr | head -1` - first rule should be `block`. Audit rule-loads via `/var/log/pflog` (tcpdump-compatible)."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1562.004']
@@ -1582,7 +1510,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Apply `CanNotDelete` locks at the subscription level on all production subscriptions via Azure Policy `deployIfNotExists` assignment. Use Azure AD Privileged Identity Management (PIM) to require time-bound, MFA-gated activation for any role that can remove locks (`Owner`, `User Access Administrator`). Audit `Microsoft.Authorization/locks/delete` Activity Log events - alert high on sub-scope lock removals and page on-call for prod subs. Consider Azure Policy `deny` on `Microsoft.Authorization/locks/delete` except from a break-glass account."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-732', 'CWE-922']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V5.3.1]
@@ -1651,7 +1578,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "For legitimate admin scripting, use `Set-ExecutionPolicy RemoteSigned -Scope LocalMachine` (blocks downloaded unsigned scripts, allows local) or `AllSigned` (requires all scripts code-signed). Sign your internal scripts with an enterprise code-signing cert via `Set-AuthenticodeSignature`. Deploy script-policy via GPO `Computer Configuration\\Administrative Templates\\Windows Components\\Windows PowerShell\\Turn on Script Execution = AllSigned` which takes precedence over `Set-ExecutionPolicy`. Audit with `Get-ExecutionPolicy -List` - alert on any scope where the effective policy is `Bypass` or `Unrestricted`. Enable PowerShell Script Block Logging (EID 4104) to capture what runs when policy is weakened."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-284', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V13.4.5, V15.2.3]
@@ -1673,7 +1599,6 @@ patterns:
     multiline: true
     window: 12
     recommendation: "Disable SMBv1 everywhere: `Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force` + `Disable-WindowsOptionalFeature -Online -FeatureName SMB1Protocol`. For stragglers that need SMBv1 (legacy scanners, NAS), isolate them on a dedicated VLAN with no route to user endpoints or servers, and explicitly ACL only those IP pairs that need SMB1. Enforce fleet-wide via GPO `Computer Configuration\\Policies\\Administrative Templates\\MS Security Guide\\Configure SMBv1 client / server driver = Disabled`. Audit via `Get-SmbServerConfiguration | Select EnableSMB1Protocol` - must be `False`. Alert on Windows EID 2000 (SMB1 access attempt)."
-    no_ansible_remediation: true
     cwe: ['CWE-326', 'CWE-327', 'CWE-693']
     cve: ["CVE-2017-0144"]
     owasp_appsec: ["A02:2021"]
@@ -1718,7 +1643,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Set `RestrictAnonymous = 1` (recommended baseline) or `2` (strict, blocks all anonymous enum), `RestrictAnonymousSAM = 1`, `EveryoneIncludesAnonymous = 0`. Enforce via GPO `Computer Configuration\\Policies\\Windows Settings\\Security Settings\\Local Policies\\Security Options` -> `Network access: Do not allow anonymous enumeration of SAM accounts = Enabled` + `Network access: Let Everyone permissions apply to anonymous users = Disabled`. Audit via `Get-ItemProperty 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Lsa' | Select RestrictAnonymous*,EveryoneIncludes*`. Test before enforcement - some legacy line-of-business apps rely on anonymous enum (mitigate by upgrading the app, not weakening the OS)."
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-284', 'CWE-306']
     owasp_appsec: ["A01:2021", "A07:2021"]
     owasp_asvs: [V6.2.1, V14.2.2]
@@ -1740,7 +1664,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Force WinRM over HTTPS (5986) with a trusted CA-issued cert: `winrm quickconfig -transport:https` after installing the cert, then `winrm set winrm/config/service @{AllowUnencrypted=\"false\"}`. For Ansible use `ansible_winrm_transport: credssp` or `kerberos` (domain-joined) + `ansible_winrm_scheme: https` + `ansible_winrm_server_cert_validation: validate`. Enforce via GPO `Computer Configuration\\Policies\\Windows Components\\Windows Remote Management\\WinRM Service\\Allow unencrypted traffic = Disabled`. Audit: `winrm get winrm/config/service` - `AllowUnencrypted` must be `false`. Firewall inbound 5985 to DENY (leaving only 5986 HTTPS open)."
-    no_ansible_remediation: true
     cwe: ['CWE-311', 'CWE-319', 'CWE-522']
     owasp_appsec: ["A02:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5, V14.2.1, V12.2.1, V12.3.4]
@@ -1762,7 +1685,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Stop and disable Print Spooler on EVERY Domain Controller: `Stop-Service -Name Spooler -Force` + `Set-Service -Name Spooler -StartupType Disabled`. Enforce via GPO linked to the `Domain Controllers` OU: `Computer Configuration\\Preferences\\Control Panel Settings\\Services -> Spooler StartupType=Disabled, ServiceState=Stopped`. For member servers, only machines with a legitimate print-server role need Spooler - all others should match DC policy. Audit: `Get-ADComputer -Filter 'Enabled -eq $true' | ForEach {Get-Service -ComputerName $_.Name -Name Spooler}` - alert on any `Running` entry. Apply the quarterly cumulative updates (KB5005652, KB5006670 onwards) which contain print-driver restrictions even when Spooler is enabled."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-269', 'CWE-284']
     cve: ["CVE-2021-34527", "CVE-2023-21678", "CVE-2024-20683"]
     owasp_appsec: ["A01:2021", "A04:2021"]
@@ -1806,7 +1728,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Require dual-control for SCP changes: protect the `organizations:*Policy*` permissions behind a break-glass role with MFA + AWS IAM Identity Center approval workflows. At the management-account level, apply an SCP that denies `organizations:DetachPolicy` and `organizations:DeletePolicy` for everyone EXCEPT a designated `OrgPolicyAdmin` role. Enable CloudTrail org-trail for the management account (log SCP changes). Alert HIGH on any `DetachPolicy`/`DeletePolicy` CloudTrail event - page on-call within 5 min. Maintain an IaC source-of-truth (Terraform / OrgFormation) for SCPs so any out-of-band change is detected by config-drift detection (AWS Config, drift report)."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-732']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V5.3.1]
@@ -1828,7 +1749,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "DELETE the IAM user immediately if possible and replace with IAM Identity Center + permission sets. For non-human access from an on-prem / CI system, use OIDC Web Identity Federation (GitHub Actions has native AWS OIDC integration, 2022 GA) - no access key needed. For Ansible control-node on EC2/ECS, use the instance profile / task role - Ansible's `amazon.aws` collection auto-detects these. If a long-lived key is unavoidable (legacy partner integration), rotate every 30 days via `aws iam update-access-key --status Inactive` + re-create, enforce via SCP: `iam:CreateAccessKey` denied except for specific service users with a `KeyMaxAgeDays: 90` tag. Audit with AWS IAM Credentials Report: `aws iam generate-credential-report` + find `access_key_1_last_rotated > 90 days ago`."
-    no_ansible_remediation: true
     cwe: ['CWE-308', 'CWE-522', 'CWE-798']
     owasp_appsec: ["A04:2021", "A07:2021"]
     owasp_asvs: [V13.2.1, V13.2.3, V13.3.1, V11.2.5]
@@ -1871,7 +1791,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Enforce diagnostic-settings via Azure Policy: `Microsoft.Insights/diagnosticSettings` `DeployIfNotExists` linked to every `Microsoft.KeyVault`, `Microsoft.Storage`, `Microsoft.Network/*`, `Microsoft.AzureActiveDirectory` resource type. Send logs to a central Log Analytics Workspace with long retention (≥1 year). For break-glass deletion, require an Azure Policy `Deny` effect on `Microsoft.Insights/diagnosticSettings/delete` scoped below Management-Group -> break-glass Role Assignment only. Alert on `Microsoft.Insights/diagnosticSettings/delete` Activity Log events - page on-call. Quarterly audit: `az monitor diagnostic-settings list-categories --resource <id>` for every production resource, compare against a golden-baseline list."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-778']
     owasp_appsec: ["A01:2021", "A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1893,7 +1812,6 @@ patterns:
     multiline: true
     window: 12
     recommendation: "Keep all Defender Plans on Standard tier for production subscriptions. For cost optimization, use Azure Policy to ENFORCE the minimum tier per-plan at management-group scope via `azurerm_policy_definition` with a `deny` effect on `tier = 'Free'`. Review the per-plan cost vs. security trade-off annually - the cost of Defender for Containers is ~1% of the cost of an average container-escape breach response. Alert on `Microsoft.Security/pricings/write` Activity Log events with `tier=Free`. Maintain the pricing-tier IaC in Terraform + require break-glass approval for downgrade changes."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-697']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1562.001', 'T1562.008']
@@ -1977,7 +1895,6 @@ patterns:
     multiline: true
     window: 25
     recommendation: "Enable immutability on every backup repository with minimum 14-day retention (PCI-scoped: 30 days; HIPAA/regulated: 90+ days). Veeam: `Hardened Repository` with XFS + filesystem-level immutability + `Immutable for: 30 days` policy + separate non-domain-joined backup-service account. Commvault: WORM-enabled storage policy + Cloud Storage Lock with S3 Object Lock in Compliance mode. Rubrik: SLA with `retention_lock_mode: COMPLIANCE` + `snapshot_archival_lock_duration_days: 30`. Cohesity: DataLock with `lockDurationUsecs: 2592000000000` (30 days in µs). For cloud S3-backed backups: `aws s3api put-object-lock-configuration --bucket backups --object-lock-configuration 'ObjectLockEnabled=Enabled,Rule={DefaultRetention={Mode=COMPLIANCE,Days=30}}'` + separate AWS account with SCP denying `s3:PutObjectLockConfiguration` / `s3:BypassGovernanceRetention` from anyone outside break-glass role. Test quarterly via ransomware-simulation: attempt deletion as domain-admin - must fail. Audit: Veeam `Get-VBRBackupRepository | Select Name, ImmutabilityPeriodDays` / `aws s3api get-object-lock-configuration --bucket <b>`."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-732', 'CWE-1326']
     owasp_asvs: [V5.3.1]
     mitre_attack: ['T1485', 'T1490', 'T1565.001']
@@ -2081,7 +1998,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Never disable Tetragon on a Cilium-protected cluster. Tune by narrowing `TracingPolicy` selectors (pod label, namespace, binary path) rather than uninstalling. Deploy Tetragon as a DaemonSet with `kubectl apply -f tetragon.yaml` managed by a GitOps reconciler (ArgoCD/Flux) that blocks drift; enable Tetragon's JSON event export to a SIEM (Loki, Splunk, Datadog, Sentinel). Put `TracingPolicy` CRDs under OPA Gatekeeper admission policy that blocks delete for `kill_action: SIGKILL` rules tagged critical. Alert on Tetragon agent restart/stop, on deleted `TracingPolicy` objects, and on `kprobe_process_event_count` going to zero for any node. Document Tetragon as the PCI-DSS 10.5, CIS K8s 3.2, SOC 2 CC7.2 compensating control for runtime behavioural monitoring. Review Isovalent's 2024 Tetragon hardening guide and the MITRE-aligned TracingPolicy library."
-    no_ansible_remediation: true
     cwe: ['CWE-693', 'CWE-1357']
     owasp_asvs: [V15.2.4]
     mitre_attack: ['T1070', 'T1562.001', 'T1562.007']

--- a/src/ansible_security_scanner/patterns/remediations/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ai_ml_security.yml
@@ -53,7 +53,7 @@ remediations:
         ansible.builtin.copy:
           dest: /opt/app/.env
           content: |
-            LLM_PROVIDER_API_KEY={{ lookup('community.hashi_vault.vault_kv2_get', 'llm/{{ llm_provider }}').data.data.api_key }}
+            LLM_PROVIDER_API_KEY={{ lookup('community.hashi_vault.vault_kv2_get', 'llm/' ~ llm_provider).data.data.api_key }}
           owner: app
           group: app
           mode: '0600'

--- a/src/ansible_security_scanner/patterns/remediations/ansible_specific.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ansible_specific.yml
@@ -17,7 +17,7 @@ remediations:
       ansible_user: deploy
       ansible_ssh_private_key_file: "~/.ssh/id_ed25519_deploy"
       # If a password is unavoidable, source it via lookup at runtime:
-      ansible_password: "{{ lookup('community.hashi_vault.vault_kv2_get', 'ssh/{{ inventory_hostname }}', engine_mount_point='secret').data.data.password }}"
+      ansible_password: "{{ lookup('community.hashi_vault.vault_kv2_get', 'ssh/' ~ inventory_hostname, engine_mount_point='secret').data.data.password }}"
 
   ansible_ssh_pass:
     secure_fix: |

--- a/src/ansible_security_scanner/patterns/remediations/unauthorized_cloud_access.yml
+++ b/src/ansible_security_scanner/patterns/remediations/unauthorized_cloud_access.yml
@@ -536,7 +536,7 @@ remediations:
 
       - name: Or pull a secret from Key Vault at run-time
         ansible.builtin.set_fact:
-          db_password: "{{ lookup('azure.azcollection.azure_keyvault_secret', 'db-password', vault_url='https://{{ kv_name }}.vault.azure.net') }}"
+          db_password: "{{ lookup('azure.azcollection.azure_keyvault_secret', 'db-password', vault_url='https://' ~ kv_name ~ '.vault.azure.net') }}"
 
   azure_storage_connection_string_embedded_in_playbook:
     secure_fix: |
@@ -583,7 +583,7 @@ remediations:
 
       - name: Read a secret via AppRole-backed lookup, no embedded token
         ansible.builtin.set_fact:
-          db_password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/data/db:password auth_method=approle role_id={{ approle_id }} secret_id={{ approle_secret_id }} url=https://vault.example.com') }}"
+          db_password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=secret/data/db:password auth_method=approle role_id=' ~ approle_id ~ ' secret_id=' ~ approle_secret_id ~ ' url=https://vault.example.com') }}"
 
   aws_secrets_manager_get:
     secure_fix: |

--- a/src/ansible_security_scanner/patterns/reverse_shells.yml
+++ b/src/ansible_security_scanner/patterns/reverse_shells.yml
@@ -276,7 +276,6 @@ patterns:
     positive_examples:
       - "New-ObjectNet.Sockets.TCPClient"
     recommendation: "Remove this PowerShell reverse shell payload immediately and investigate the source"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-506']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1059.001', 'T1071.001']
@@ -294,7 +293,6 @@ patterns:
     positive_examples:
       - "Runtime.getRuntime().exec(/bin/sh"
     recommendation: "Remove this Java reverse shell payload immediately and investigate the source"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-506']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1059', 'T1071.001']
@@ -312,7 +310,6 @@ patterns:
     positive_examples:
       - "xterm -display 0:0"
     recommendation: "Remove this xterm reverse shell payload immediately; X11 forwarding to external hosts is a known attack vector"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-506']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -335,7 +332,6 @@ patterns:
     positive_examples:
       - "dnscat--dns"
     recommendation: "Remove dnscat2 immediately; it provides a covert C2 channel over DNS"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-506']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1071.004', 'T1572']
@@ -353,7 +349,6 @@ patterns:
     positive_examples:
       - "IWR|IEX$TCPClient"
     recommendation: "Remove this PowerShell download-and-execute reverse shell payload immediately"
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-506']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1059.001', 'T1105']

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -32,7 +32,6 @@ patterns:
     positive_examples:
       - "wget |sh"
     recommendation: "Use `get_url` with `checksum:`, then execute the file explicitly. Don't let the network dictate what runs on your host."
-    no_ansible_remediation: true
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ['CM-5', 'CM-11', 'SA-10', 'SI-7']
     pci_dss: ['6.3.2', '6.3.3']
@@ -87,7 +86,6 @@ patterns:
     positive_examples:
       - "curl raw.githubusercontent.com|sh"
     recommendation: "Download the artefact with `get_url` + `checksum:`, store it in your own artefact store, and reference that. Raw GitHub content is not a distribution channel."
-    no_ansible_remediation: true
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ['CM-5', 'CM-11', 'SA-10', 'SI-7']
     pci_dss: ['6.3.2', '6.3.3']
@@ -106,7 +104,6 @@ patterns:
     positive_examples:
       - "shell: gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 && curl -sSL https://get.rvm.io | bash -s stable"
     recommendation: "Use the vendor's package repository (apt/yum/rpm) or download and verify a signed release asset. If the vendor only ships a `curl|sh` installer, vendor it behind your own CI and pin a checksum."
-    no_ansible_remediation: true
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ['CM-5', 'CM-11', 'SA-10', 'SI-7']
     pci_dss: ['6.3.2', '6.3.3']
@@ -505,7 +502,6 @@ patterns:
     #   3. Kubernetes-style ``hostPath: /var/run/docker.sock``.
     regex: "(?:\\b(?:docker|podman|nerdctl)\\s+run\\b[^\\n]*?(?:-v|--volume)[= ]/var/run/docker\\.sock\\b|-\\s*['\\\"]?/var/run/docker\\.sock[:][^\\s'\\\"]*|hostPath\\s*:\\s*['\\\"]?/var/run/docker\\.sock\\b|source\\s*:\\s*['\\\"]?/var/run/docker\\.sock\\b)"
     recommendation: "Never bind-mount the host's docker.sock into a container. For Molecule, use the ``molecule-docker`` driver without a socket mount (the driver talks to Docker via the controller's own client). For docker-in-docker CI runners, use a DinD sidecar (``docker:dind`` with ``privileged: true`` on the sidecar only, or sysbox for rootless DinD). For general container-manages-container workflows, use a rootless runtime or a tightly-scoped Unix socket proxy (e.g. ``tecnativa/docker-socket-proxy``) that only exposes the specific APIs needed."
-    no_ansible_remediation: true
     positive_examples:
       - "    shell: docker run -v /var/run/docker.sock:/var/run/docker.sock jenkins/jenkins"
       - |2-
@@ -543,7 +539,6 @@ patterns:
     positive_examples:
       - "privileged: true"
     recommendation: "Remove `privileged: true`. Most Ansible role tests don't need kernel capabilities - if yours does (systemd, mount), prefer `systemd: always` + a tmpfs for /tmp instead."
-    no_ansible_remediation: true
     cis_controls: ["CIS-Docker"]
     nist_controls: ['AC-6', 'AC-6(1)']
     pci_dss: ['7.2.1']
@@ -561,7 +556,6 @@ patterns:
     positive_examples:
       - "tls_verify: false"
     recommendation: "Keep TLS verification on. If you're on a corporate registry with a private CA, inject the CA bundle into the container; never disable verification globally."
-    no_ansible_remediation: true
     cis_controls: ["CIS-Network"]
     nist_controls: ['SC-8', 'SC-8(1)', 'SC-12']
     pci_dss: ['2.2.7', '4.2.1', '4.2.1.1']
@@ -898,7 +892,6 @@ patterns:
       - "apt install xz-5.6.0"
     multiline: false
     recommendation: "Pin xz-utils/liblzma to >= 5.6.2 (or revert to the 5.4.x LTS line - 5.4.6 is the last known-good for most distros). Rebuild any container image whose base layer or intermediate builder installed 5.6.0/5.6.1. Rotate every SSH host key on machines that ran a vulnerable sshd (sd_notify-linked builds on glibc systems - primarily Debian unstable, Fedora 40/41 Rawhide, openSUSE Tumbleweed snapshots from late Feb 2024 through Mar 29 2024). Audit `authorized_keys` files for unexpected entries and verify sshd binary integrity: `rpm -V openssh-server` / `debsums -c openssh-server`. Treat any credentialed operation from a backdoored host as potentially compromised. See: CVE-2024-3094, Red Hat RHSB-2024-001, Debian DSA-5649, openssf.org/blog/2024/03/30/."
-    no_ansible_remediation: true
     cve: ["CVE-2024-3094"]
     cwe: ['CWE-494', 'CWE-506', 'CWE-829', 'CWE-1357']
     owasp_appsec: ["A08:2021"]
@@ -1064,7 +1057,6 @@ patterns:
     multiline: true
     window: 40
     recommendation: "Before consuming any external artifact, verify its provenance: `slsa-verifier verify-artifact --provenance-path build.intoto.jsonl --source-uri github.com/myorg/myrepo <artifact>` or `cosign verify-attestation --type slsaprovenance --certificate-identity-regexp ... <image>`. For Galaxy, use `ansible-galaxy collection verify --signature` (requires galaxy_ng 4.7+)."
-    no_ansible_remediation: true
     positive_examples:
       - |2-
             ansible.builtin.unarchive:
@@ -1251,7 +1243,6 @@ patterns:
     positive_examples:
       - "cloudflared service install aaaaaaaaaaaaaaaaaaaa"
     recommendation: "Remove the task unless there is a documented, change-controlled remote-access exception. If Cloudflare Tunnels are a sanctioned tool, provision the token via `ansible-vault` or a secrets manager (never inline), restrict egress to `*.cloudflare.com` only from approved hosts via outbound firewall, and enforce `Access for Infrastructure` policies requiring SSO + device posture. Detect with Sysmon Event ID 3 + DNS queries to `*.cloudflareaccess.com` from unexpected hosts."
-    no_ansible_remediation: true
     cwe: ['CWE-668', 'CWE-912']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1090.004', 'T1219', 'T1572']
@@ -1271,7 +1262,6 @@ patterns:
     multiline: true
     window: 20
     recommendation: "Remove the task. frp is never a legitimate configuration-management primitive - if the stated need is ingress to a private host, use an SSO-gated zero-trust reverse proxy (Cloudflare Access, Tailscale Funnel with ACLs, Pomerium, Teleport) with device posture and audit logging. Block outbound TCP to unknown high-port listeners at the egress firewall."
-    no_ansible_remediation: true
     cwe: ['CWE-668', 'CWE-912']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1090', 'T1219', 'T1572']
@@ -1289,7 +1279,6 @@ patterns:
     positive_examples:
       - "/usr/bin/gost-L x"
     recommendation: "Remove the task and audit the host for persistent gost binaries (`find / -name gost -type f 2>/dev/null`) and systemd units referencing it. Rotate any credentials accessible from the host and investigate how the task was introduced (likely via compromised CI or a malicious role). Add gost/frpc/rathole/chisel binary names to EDR blocklists."
-    no_ansible_remediation: true
     cwe: ['CWE-506', 'CWE-912']
     mitre_attack: ['T1090', 'T1219', 'T1572']
     cis_controls: ['CIS-4.8', 'CIS-10.5']
@@ -1306,7 +1295,6 @@ patterns:
     positive_examples:
       - "adb tcpip 0"
     recommendation: "Remove the task. If remote debugging is genuinely required for CI, restrict it to a loopback / host-only emulator interface and immediately follow with `adb usb` to return to USB-only mode at the end of the job. Never enable `adb tcpip` on a physical device on a shared network - use `adb -s <serial>` over USB + UAC-confirmed authorisation instead."
-    no_ansible_remediation: true
     cwe: ['CWE-306', 'CWE-749']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V6.2.1]
@@ -1378,7 +1366,6 @@ patterns:
     multiline: true
     window: 60
     recommendation: "Set `mode: enforce` (policy-controller), `validationFailureAction: Enforce` (Kyverno), and `failurePolicy: Fail` on admission webhooks. Roll out enforcement gradually: start with a narrow namespace selector, verify `policy-controller` / Kyverno pod logs show zero violations for 48h, then widen. Always pair with a break-glass override annotation (`policy.sigstore.dev/breakglass: 'true'`) that requires a signed-by-CI-root commit to set, so emergency rollouts have an auditable escape hatch."
-    no_ansible_remediation: true
     cwe: ['CWE-295', 'CWE-494', 'CWE-693']
     owasp_appsec: ["A07:2021", "A08:2021"]
     owasp_asvs: [V12.3.4, V15.2.4]
@@ -1415,7 +1402,6 @@ patterns:
     positive_examples:
       - "pip installreqeusts"
     recommendation: "Pin every dependency in `requirements.txt` with exact versions AND hashes: `requests==2.32.3 --hash=sha256:70761cfe...`. Generate with `pip-compile --generate-hashes`. Enable PyPI Trusted Publishers for your own releases and rely on the PyPI signed-index PEP 458 rollout (2025 default). Install only from an internal mirror (`--index-url https://internal-pypi/simple`) that runs `pip-audit` / `pypa/pip-vet` against a curated allowlist. Never use ad-hoc `pip install <name>` in production playbooks without a corresponding lockfile."
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-829', 'CWE-1357']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -1438,7 +1424,6 @@ patterns:
     multiline: true
     window: 120
     recommendation: "Immediately after the download task, run `slsa-verifier verify-artifact <file> --provenance <file>.intoto.jsonl --source-uri github.com/<owner>/<repo> --source-tag <tag>` OR `gh attestation verify <file> --owner <owner>` (GitHub 2.50+). For non-GitHub artifacts, use `cosign verify-attestation --type slsaprovenance --certificate-identity-regexp '...'` against the OIDC identity that signed the release. Fail the play on any non-zero verifier exit. For maximum assurance, pin the release by its Sigstore Rekor log index (`--rekor-entry <uuid>`) so even a malicious re-upload cannot substitute the verified artifact."
-    no_ansible_remediation: true
     cwe: ['CWE-345', 'CWE-494', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -1557,7 +1542,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Bind DB ports to loopback or the docker bridge only: `127.0.0.1:5432:5432` (loopback, same-host app access) or drop `ports:` entirely and use `expose:` (compose-internal DNS reachable only by linked services). For cluster access, use a dedicated overlay network + reverse-proxy (HAProxy, Envoy) with auth in front. Audit with `ss -tlnp | grep -E '(3306|5432|6379)'` showing `0.0.0.0` - these rows must not exist on any host with a public IP. Add a cloud-security-group default-deny rule as second line of defence."
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-284', 'CWE-668']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -1866,7 +1850,6 @@ patterns:
     multiline: true
     window: 20
     recommendation: "Commit git hooks INTO the repo under a `.githooks/` directory + configure `git config --local core.hooksPath .githooks/` during setup. That way the hook content is visible in `git log`, reviewable in PRs, and cannot be silently changed. For polyglot repos use `pre-commit` (https://pre-commit.com) - declarative config, pinned hook versions by SHA, visible diff on config changes. For org-wide hooks, use GitLab push rules or GitHub branch-protection required status checks (runs in CI, not as a local hook). Never download a hook from a URL. Audit existing hooks: `find /home -path '*.git/hooks/*' -not -name '*.sample' -exec sha256sum {} \\;` -> diff per-host. Alert on any non-template hook whose SHA differs from the committed `.githooks/` version."
-    no_ansible_remediation: true
     cwe: ['CWE-494', 'CWE-506', 'CWE-829']
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]
@@ -1972,7 +1955,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Migrate off the legacy **Network Access Account (NAA)** pattern entirely. Use **Enhanced HTTP** mode for SCCM (≥2103) + client authentication via Azure AD device tokens OR Entra-ID joined device certs - no shared NAA needed. For remaining NAA use, grant ONLY `ReadAndExecute` on the DP content share (NEVER a domain-privileged account; not Domain Admin; not the backup account; create a dedicated `svc_sccm_naa` with least privilege). Never use the **Client Push Installation Account** - deploy clients via **Autopilot** / **Intune** / **GPO** / **MDM** instead, which don't require a domain credential distributed across hosts. Store all SCCM-related credentials in **CyberArk** / **HashiCorp Vault** / **AWS Secrets Manager** - inject into playbooks via lookup: `password: \"{{ lookup('community.hashi_vault.vault_kv2_get', 'secret/sccm/naa')['data']['password'] }}\"`. Detect NAA extraction: Microsoft Defender for Endpoint alert `SCCMNetworkAccessAccountCredentialsAccessed`, Sysmon Event ID 10 for `lsass.exe` read by `SharpSCCM.exe`/`MalSCCM.exe`/`Impacket` signatures. Rotate NAA immediately if any extraction is suspected; rotate quarterly regardless."
-    no_ansible_remediation: true
     cwe: ['CWE-257', 'CWE-522', 'CWE-798']
     owasp_appsec: ["A04:2021", "A07:2021"]
     owasp_asvs: [V13.2.1, V13.2.3, V13.3.1, V11.2.5]
@@ -2062,7 +2044,6 @@ patterns:
     multiline: true
     window: 15
     recommendation: "Never pass the JNLP secret on the command line. Store the secret in a file with mode 0600 owned by the agent user, and pass `-secretFile /etc/jenkins/agent.secret`. Better: use the **Jenkins WebSocket agent** protocol (since 2.217) which authenticates via outbound HTTPS and avoids the raw TCP JNLP port entirely. Source secrets from Vault / AWS Secrets Manager at boot (`lookup('community.hashi_vault.vault_kv2_get', ...)`). Rotate the secret whenever an agent is decommissioned (`groovy` step: `jenkins.model.Jenkins.instance.getNode('agent').computer.setJnlpMac(null)`). Audit `journalctl -u jenkins-agent` / `ps auxf` for exposure."
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-312', 'CWE-522']
     owasp_appsec: ["A01:2021", "A04:2021"]
     owasp_asvs: [V13.2.1, V14.1.1, V11.2.5, V14.2.2, V14.2.1]
@@ -2102,7 +2083,6 @@ patterns:
     positive_examples:
       - "FGT_A-v6.0.0.out"
     recommendation: "Upgrade to a patched FortiOS / FortiProxy build: FortiOS 7.4.3+, 7.2.7+, 7.0.14+, 6.4.15+, 6.2.16+, 6.0.18+ (or Fortinet's current GA branch). Follow Fortinet PSIRT FG-IR-24-015. Never expose the SSL-VPN portal (webvpn service) to the internet without a WAF + geo-ACL in front; a significant portion of 2024 Volt Typhoon activity used this CVE against unpatched public-facing SSL-VPN. Audit with `diagnose sys session list | grep :443` and check for the IOCs listed in Mandiant's FortiOS post-exploitation guide (implanted CUTHAT/THINCRUST backdoors, modified `/bin/smartctl`). If running an unpatched build that was internet-reachable, assume compromise and perform a full factory reset + config restore from a pre-incident backup."
-    no_ansible_remediation: true
     cwe: ['CWE-787', 'CWE-1395']
     cve: ["CVE-2024-21762"]
     mitre_attack: ['T1068', 'T1133', 'T1190']
@@ -2124,7 +2104,6 @@ patterns:
     multiline: true
     window: 8
     recommendation: "Upgrade to PAN-OS 10.2.9-h1+, 11.0.4-h1+, 11.1.2-h3+, or later per Palo Alto advisory PAN-SA-2024-0003. If the appliance was internet-reachable and unpatched during April 2024, treat as compromised: perform a full factory-reset per Unit 42 guidance, rotate every credential the firewall had access to (RADIUS/TACACS+/LDAP binds, SNMP v3, API keys, certificates, VPN PSKs), and hunt for UPSTYLE backdoor IOCs (`/opt/panlogs/tmp/device_telemetry/minute/*.pth`, outbound to suspicious DDNS). Never enable GlobalProtect portal/gateway AND device telemetry together without the April 2024 content update - the device-telemetry disable toggle is NOT a full mitigation for versions earlier than the fixed builds."
-    no_ansible_remediation: true
     cwe: ['CWE-20', 'CWE-77', 'CWE-78']
     cve: ["CVE-2024-3400"]
     owasp_appsec: ["A03:2021"]
@@ -2145,7 +2124,6 @@ patterns:
     positive_examples:
       - "downloads.ivanti.com/connect-secure"
     recommendation: "Upgrade to Ivanti Connect Secure 22.5R2.4+, 22.6R2.3+, or the latest GA build per Ivanti KB44784. If the appliance was internet-reachable and unpatched between Dec 2023-Apr 2024, assume compromise: perform a factory reset, rotate ALL credentials that traversed the ICS appliance (local, LDAP/AD binds, RADIUS, OAuth, OIDC, SAML signing keys, SSL certificates, admin passwords, 802.1x PSKs), and hunt for the 2024 implant families (BUSHWALK webshell, LIGHTWIRE, WIREFIRE, ZIPLINE, FRAMESTING) per Mandiant M-Trends 2024. Retire Ivanti Connect Secure 9.x - it is end-of-engineering and should be replaced, not upgraded."
-    no_ansible_remediation: true
     cwe: ['CWE-78', 'CWE-287', 'CWE-288']
     cve: ["CVE-2023-46805", "CVE-2024-21887"]
     owasp_appsec: ["A03:2021", "A07:2021"]
@@ -2169,7 +2147,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "NEVER expose the NetScaler NSIP (management) interface to the internet - bind it to an RFC1918 out-of-band management VLAN only. If internet access to the gateway is required (typical), that goes via the VIP on the load-balanced SSL-VPN / ICA-proxy service, NEVER the management IP. Use `add ns ip <ip> <mask> -mgmtAccess ENABLED -type NSIP` on the OOB VLAN, and `-mgmtAccess DISABLED` on any VIP. Audit exposure with `show ns ip -summary` and an external nmap from an untrusted net. Even post-CVE-2023-4966 patching, public NSIP exposure is a finding in every major pentest framework (MITRE, NIST SP 800-115). For Citrix Cloud Connector deployments, put the connector behind a WAF with explicit allow-listing."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-668', 'CWE-1188']
     cve: ["CVE-2023-4966", "CVE-2024-6235", "CVE-2024-8534"]
     owasp_appsec: ["A01:2021"]
@@ -2190,7 +2167,6 @@ patterns:
     positive_examples:
       - "checkpoint.download.checkpoint.com/R77.20"
     recommendation: "Apply Check Point sk182336 hotfix IMMEDIATELY on every Quantum Security Gateway running R77.20/R80.20/R80.40/R81/R81.10/R81.20 with remote-access portal, Mobile Access, or SNX enabled. Rotate EVERY credential that has ever traversed the gateway: local accounts, LDAP/AD binds, RADIUS shared secrets, 2FA seeds, user passwords, SSL certificates. Pull `/var/log/httpd2/error_log` and `fw log` for May 2024 onward and grep for `CVE-2024-24919`, `MyCRL`, suspicious `GET` requests to `/clients/MyCRL`. If compromise is suspected: full factory-reset per Check Point IR playbook, rotate HA / VRRP / SIC creds, rebuild the CMA. Retire R77.20 - it is end-of-life and will not get further hotfixes."
-    no_ansible_remediation: true
     cwe: ['CWE-22', 'CWE-200', 'CWE-306']
     cve: ["CVE-2024-24919"]
     owasp_appsec: ["A01:2021", "A07:2021"]
@@ -2214,7 +2190,6 @@ patterns:
     multiline: true
     window: 8
     recommendation: "Upgrade to ScreenConnect 23.9.8+ (or 24.x) immediately per ConnectWise security bulletin CWE-2024-02. If you ran an on-prem ScreenConnect server ≤ 23.9.7 that was internet-reachable between Feb 13-Feb 22, 2024: assume compromise. Every customer machine that had an active ScreenConnect agent is potentially compromised - rotate local admin creds on every downstream endpoint, rebuild the ScreenConnect server from clean media, rotate any MFA seeds / machine accounts the server could read, and run threat-hunting for the 2024 implant families (Slingshot, CoinLoader, BlackCat loaders). Prefer ConnectWise Cloud (SaaS) over self-hosted where possible - the SaaS edition was patched server-side before public disclosure. Front any residual on-prem instance with a WAF that blocks requests to `/SetupWizard.aspx` except during upgrades."
-    no_ansible_remediation: true
     cwe: ['CWE-22', 'CWE-287', 'CWE-288']
     cve: ["CVE-2024-1708", "CVE-2024-1709"]
     owasp_appsec: ["A01:2021", "A07:2021"]
@@ -2236,7 +2211,6 @@ patterns:
     positive_examples:
       - "FMG_A-v6.2.0.out"
     recommendation: "Upgrade to FortiManager 7.6.1+, 7.4.5+, 7.2.8+, 7.0.13+, or 6.4.15+ per Fortinet PSIRT FG-IR-24-423. TCP/541 (fgfmd) MUST NOT be internet-reachable - place FortiManager on a dedicated management VLAN reachable only from FortiGate devices via IPsec, not via a public Elastic IP. If you ran an internet-reachable FortiManager ≤ the fixed build between ~June-Oct 2024, assume total tenant compromise: rotate every credential ever managed by the FortiManager (user passwords, RADIUS/TACACS+ secrets, IPsec PSKs, SSL-VPN cert private keys, BGP auth), and hunt Mandiant UNC5820 IOCs (rogue FortiGate enrollment events, unusual `fgfmd.log` connections, `/tmp/.tm` presence). Consider rebuilding the FortiManager from scratch and re-enrolling devices rather than trusting a post-exploitation instance."
-    no_ansible_remediation: true
     cwe: ['CWE-287', 'CWE-306', 'CWE-862']
     cve: ["CVE-2024-47575"]
     owasp_appsec: ["A01:2021", "A07:2021"]
@@ -2260,7 +2234,6 @@ patterns:
     multiline: true
     window: 8
     recommendation: "Upgrade to Cisco CUCM / IM&P 14SU3+, 12.5(1)SU8+, CUCCX 12.5(1)SU3+, VVB 12.5(1)SU3+ per Cisco advisory cisco-sa-cucm-rce-bWNzQcUm. 11.5.x is end-of-software-maintenance and must be migrated. NEVER expose CUCM/IM&P to the internet - management and signaling should be on a dedicated voice VLAN, SIP trunks terminate on a CUBE session-border controller, not directly on the call agent. If an internet-reachable CUCM ran an unpatched version for any period, assume compromise, rotate every phone authentication key / LDAP sync password / SSH admin / AXL API user, and rebuild from clean installation media. Audit with `show version active` and the Cisco `cisco-sa-cucm-rce-bWNzQcUm` mitigation-status script."
-    no_ansible_remediation: true
     cwe: ['CWE-77', 'CWE-78', 'CWE-434']
     cve: ["CVE-2024-20253"]
     owasp_appsec: ["A03:2021", "A04:2021"]
@@ -2475,7 +2448,6 @@ patterns:
     multiline: true
     window: 80
     recommendation: "Never embed `${{ github.event.* }}` into a `github-script` body. Pass the untrusted text through the action's environment and reference `process.env.X`: `env: TITLE: ${{ github.event.issue.title }}` then `script: core.info(process.env.TITLE)`. Prefer `actions/github-script` for small glue only; for anything non-trivial, write a repo-local `.github/scripts/*.js` file reviewed under CODEOWNERS, invoked with `- uses: actions/github-script@SHA with: script-path: .github/scripts/x.js`. Enable `zizmor` / `actionlint` in CI."
-    no_ansible_remediation: true
     cwe: ['CWE-74', 'CWE-77', 'CWE-94']
     owasp_appsec: ["A03:2021"]
     mitre_attack: ['T1059.007', 'T1195.002']
@@ -2805,7 +2777,6 @@ patterns:
     multiline: true
     window: 12
     recommendation: "Move secrets out of the URL. Prefer `headers:` on `ansible.builtin.uri` (`headers: { Authorization: 'Bearer {{ my_token }}' }`) with the token sourced from Ansible Vault, AWS Secrets Manager, or HashiCorp Vault (`{{ lookup('community.hashi_vault.hashi_vault', '...') }}`). For `get_url`, use `url_username:` / `url_password:` + `force_basic_auth: yes` (the password is passed via HTTP Basic auth header, not the URL). For `git`, use SSH (`git@github.com:...`) with a deploy key, or HTTPS with a Git credential helper that reads from a secret manager - never embed the PAT in the URL. Audit existing playbooks with `grep -rEn 'https?://[^\"\\'' ]+[?&](?:token|api_key|apikey|access_token|pat)=' .`. If a token is found committed, immediately rotate it on the provider (it's in every log you don't know about), invalidate any cached artifacts it was used to pull, and check the provider's access log for unexpected IPs."
-    no_ansible_remediation: true
     cwe: ['CWE-312', 'CWE-532', 'CWE-598']
     owasp_appsec: ["A07:2021", "A09:2021"]
     owasp_asvs: [V6.2.1, V16.2.5, V14.2.1]

--- a/src/ansible_security_scanner/patterns/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/system_compromise.yml
@@ -389,7 +389,6 @@ patterns:
     positive_examples:
       - "mokutil --disable-validation"
     recommendation: "Never disable Secure Boot from a playbook. If you genuinely need to boot a custom kernel/initramfs, sign it with a MOK enrolled interactively at the console (not via automation), or build it into an internally-signed RHEL/SLES shim. Verify posture with `mokutil --sb-state` expecting `SecureBoot enabled`, and enforce Secure Boot + TPM-PCR measured-boot attestation via a platform like Keylime or Azure Attestation."
-    no_ansible_remediation: true
     cwe: ['CWE-347', 'CWE-693', 'CWE-798']
     owasp_appsec: ["A02:2021", "A07:2021"]
     owasp_asvs: [V13.2.3, V13.3.1]
@@ -831,7 +830,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Never `auditctl -D` in a playbook. Manage audit rules declaratively by writing to `/etc/audit/rules.d/<name>.rules` and invoking `augenrules --load` (which PRESERVES non-overlapping rule-set files). For a full replacement, use `ansible.builtin.template` -> `/etc/audit/rules.d/zz-baseline.rules` with `notify: reload auditd`. Add an immutable marker `-e 2` at the END of the ruleset so the audit config cannot be modified until reboot - any playbook needing `auditctl -D` after `-e 2` is an immediate alert. Audit with `auditctl -l` (list rules) + `auditctl -s` (show config) - alert when the rule count drops unexpectedly between consecutive CMDB inventory snapshots."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693', 'CWE-778']
     owasp_appsec: ["A01:2021", "A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -941,7 +939,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Never disable Secure Boot on production hosts. For driver-signing workarounds, ENROLL your driver-signing cert via `mokutil --import <internal-ca>.der` (which adds to MokList WITHOUT disabling validation) + sign drivers with that cert. For NVIDIA/VMware-tools kernel modules, use the distro's pre-signed variant (`kmod-nvidia` from RPM Fusion for RHEL, `nvidia-dkms` with distro-signed kernel for Ubuntu), not an unsigned hand-compiled module. Maintain a SBAT revocation-policy baseline: `sbverify --list /boot/efi/EFI/*/shimx64.efi` should show a current-year SBAT policy. Audit: `mokutil --sb-state` must return `SecureBoot enabled`. Alert on `mokutil --disable-validation` or `sbctl disable-secureboot` via auditd `-w /usr/bin/mokutil -p x -k secure_boot` + centralize events."
-    no_ansible_remediation: true
     cwe: ['CWE-347', 'CWE-347', 'CWE-1329']
     owasp_appsec: ["A02:2021"]
     mitre_attack: ['T1542.001', 'T1542.003', 'T1553.006']
@@ -962,7 +959,6 @@ patterns:
     multiline: true
     window: 60
     recommendation: "Set a GRUB password across ALL entries: 1) Generate PBKDF2 hash: `grub2-mkpasswd-pbkdf2` -> copy the `grub.pbkdf2.sha512.10000.<salt>.<hash>` value. 2) Add to `/etc/grub.d/01_users` (persistent): `set superusers=\"grubadmin\"` + `password_pbkdf2 grubadmin grub.pbkdf2.sha512.10000.XXX...`. 3) Regenerate: `grub2-mkconfig -o /boot/grub2/grub.cfg` (RHEL) or `update-grub` (Debian). 4) For custom entries that should be accessible WITHOUT password at boot but not edit, use `--unrestricted` flag on the `menuentry`. For highest assurance, combine with full-disk-encryption (LUKS) + TPM-backed unlock (Clevis + tang) so even physical-presence can't extract data. Enforce via CIS scan: `/etc/grub2.cfg` must contain `password_pbkdf2` and `/etc/grub.d/` entries must NOT have `--unrestricted` on rescue/emergency entries."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-272', 'CWE-306']
     owasp_appsec: ["A07:2021"]
     owasp_asvs: [V6.2.1, V13.4.5, V15.2.3]
@@ -1091,7 +1087,6 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Enable Microsoft's **vulnerable driver blocklist** on every Windows host: `Windows Security -> Device Security -> Core Isolation -> Microsoft Vulnerable Driver Blocklist = On`. For Windows 10/11/Server 2022, this blocks the Microsoft-curated list of ~300 known-abusive drivers at kernel load time via Windows Defender Application Control (WDAC). For older hosts (Win Server 2019 and earlier), deploy the blocklist manually via WDAC policy XML (Microsoft publishes the reference XML at https://github.com/MicrosoftDocs/windows-itpro-docs). Combine with: **HVCI** (Hypervisor-enforced Code Integrity) to prevent attacker-loaded unsigned drivers at all, **Smart App Control** (Win 11 22H2+), and EDR behavioral detection for driver-load anomalies. For Linux, enable kernel lockdown: `kernel.lockdown=confidentiality` via `/sys/kernel/security/lockdown` and sign all modules with a locally-held MOK (machine owner key). Audit installed kernel drivers periodically: `fltmc instances` (Windows filter drivers), `driverquery /v` (Windows), `lsmod` (Linux) + cross-reference against vulnerable-driver databases (`loldrivers.io`). Alert on NEW driver loads via Sysmon Event ID 6 (DriverLoad) + correlate with the `loldrivers.io` feed in SIEM."
-    no_ansible_remediation: true
     cwe: ['CWE-94', 'CWE-829', 'CWE-1357']
     cve: ["CVE-2015-2291", "CVE-2018-19320", "CVE-2019-16098", "CVE-2021-21551"]
     owasp_appsec: ["A03:2021", "A08:2021"]
@@ -1135,7 +1130,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Never disable Gatekeeper. If a specific app legitimately can't be notarized (internal tooling only), sign it with a Developer ID and notarize via `xcrun notarytool submit` - then it runs with Gatekeeper enabled. For dev-environment exceptions, use `spctl --add --label 'DevTooling' /path/to/app` to allow a specific path WITHOUT disabling globally. Enforce Gatekeeper state via MDM (Jamf `Restrictions` -> `Gatekeeper: App Store and identified developers`). Audit: `spctl --status` should return `assessments enabled` on every managed Mac. Monitor for the disable action via `log stream --predicate 'subsystem == \"com.apple.syspolicy\"'` and alert on any occurrence."
-    no_ansible_remediation: true
     cwe: ['CWE-284', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     mitre_attack: ['T1553.001', 'T1562.001', 'T1562.010']
@@ -1156,7 +1150,6 @@ patterns:
     multiline: true
     window: 6
     recommendation: "Never disable SIP on a production or user-facing Mac. For the extremely rare case a dev tool requires SIP-off (low-level kernel research, legacy kext development), isolate it to a DEDICATED test Mac that is not on the production network and holds no production data. Enforce SIP-enabled via MDM and alert on any disabled status (`csrutil status` should return `System Integrity Protection status: enabled.` - anything else is a P0 incident). For legitimate kext needs, use the new System Extensions framework (Network, Endpoint Security, DriverKit) which works with SIP enabled. Audit on boot via a LaunchDaemon that invokes `csrutil status` and ships the result to SIEM. Treat `csrutil disable` as equivalent to `rm -rf / --no-preserve-root` for incident-response purposes."
-    no_ansible_remediation: true
     cwe: ['CWE-250', 'CWE-693']
     owasp_asvs: [V13.4.5, V15.2.3]
     mitre_attack: ['T1014', 'T1562.001']

--- a/src/ansible_security_scanner/patterns/tunneling.yml
+++ b/src/ansible_security_scanner/patterns/tunneling.yml
@@ -12,7 +12,6 @@ patterns:
     positive_examples:
       - "ssh -D 0"
     recommendation: "SSH tunneling should only be used with explicit approval; consider VPN alternatives"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.001', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -30,7 +29,6 @@ patterns:
     positive_examples:
       - "chisel server"
     recommendation: "Chisel is a common pentesting tool; should not appear in production playbooks"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.002', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -48,7 +46,6 @@ patterns:
     positive_examples:
       - "ligolo-ng"
     recommendation: "Ligolo is a pentesting pivot tool; should not appear in production playbooks"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.002', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -66,7 +63,6 @@ patterns:
     positive_examples:
       - "ngrok http"
     recommendation: "ngrok exposes internal services publicly; never use in production environments"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -89,7 +85,6 @@ patterns:
     positive_examples:
       - "cloudflared tunnel"
     recommendation: "Cloudflare tunnels must be approved; they bypass network security controls"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -109,7 +104,6 @@ patterns:
     positive_examples:
       - "frpc"
     recommendation: "FRP is commonly used for unauthorized tunneling; remove immediately"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.002', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -127,7 +121,6 @@ patterns:
     positive_examples:
       - "revsocks-l "
     recommendation: "Reverse proxy tools should not appear in production playbooks"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.001', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -145,7 +138,6 @@ patterns:
     positive_examples:
       - "ssh -R 0:localhost:0"
     recommendation: "Remote port forwarding exposes internal services; requires explicit security approval"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1021.004', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -163,7 +155,6 @@ patterns:
     positive_examples:
       - "apt installwireguard"
     recommendation: "VPN installations must be approved by network security; unauthorized VPNs bypass controls"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1133', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.7']
@@ -181,7 +172,6 @@ patterns:
     positive_examples:
       - "iodine -f"
     recommendation: "Iodine tunnels IPv4 over DNS to bypass firewalls; remove immediately"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1071.004', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-13.1']
@@ -199,7 +189,6 @@ patterns:
     positive_examples:
       - "dnscat--dns"
     recommendation: "dnscat2 is a DNS-based C2 tool; should not appear in production playbooks"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1071.004', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-13.1']
@@ -217,7 +206,6 @@ patterns:
     positive_examples:
       - "icmptunnel -s"
     recommendation: "ICMP tunneling bypasses firewall rules; remove immediately"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1095', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-13.1']
@@ -235,7 +223,6 @@ patterns:
     positive_examples:
       - "rathole --client"
     recommendation: "Rathole enables NAT traversal tunnels; requires explicit security approval"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.002', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -253,7 +240,6 @@ patterns:
     positive_examples:
       - "bore local 0"
     recommendation: "Bore exposes local services through a public relay; requires security approval"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.002', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -271,7 +257,6 @@ patterns:
     positive_examples:
       - "lt --port 0"
     recommendation: "LocalTunnel exposes internal services publicly; should not be used in production"
-    no_ansible_remediation: true
     cwe: ['CWE-200', 'CWE-693']
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -291,7 +276,6 @@ patterns:
     positive_examples:
       - "ssh -R 0: serveo.net"
     recommendation: "Serveo exposes internal services publicly via SSH; requires security approval"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1021.004', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -309,7 +293,6 @@ patterns:
     positive_examples:
       - "socat TCP-LISTEN:0forkTCP:0:0"
     recommendation: "Socat port forwarding can expose internal services; ensure this is authorized"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1090.001', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.6']
@@ -327,7 +310,6 @@ patterns:
     positive_examples:
       - "tailscale up"
     recommendation: "Tailscale mesh VPN can bypass network controls; requires explicit security approval"
-    no_ansible_remediation: true
     cwe: ['CWE-693']
     mitre_attack: ['T1133', 'T1572']
     cis_controls: ['CIS-4.1', 'CIS-12.7']

--- a/src/ansible_security_scanner/patterns/unauthorized_cloud_access.yml
+++ b/src/ansible_security_scanner/patterns/unauthorized_cloud_access.yml
@@ -137,7 +137,6 @@ patterns:
     positive_examples:
       - "aws sts assume-role"
     recommendation: "IAM role assumption should be handled by the execution environment, not playbook code"
-    no_ansible_remediation: true
     cwe: ["CWE-269"]
     owasp_appsec: ["A04:2021"]
     mitre_attack: ["T1548.005"]
@@ -159,7 +158,6 @@ patterns:
     positive_examples:
       - "aws iam create-user"
     recommendation: "IAM user management must go through approved identity governance workflows"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1136.003"]
@@ -178,7 +176,6 @@ patterns:
     positive_examples:
       - "aws iam create-access-key"
     recommendation: "Access key creation must go through approved workflows"
-    no_ansible_remediation: true
 
     cwe: ["CWE-798"]
     owasp_appsec: ["A07:2021"]
@@ -201,7 +198,6 @@ patterns:
     positive_examples:
       - "aws ec2 run-instances"
     recommendation: "EC2 provisioning should go through approved IaC pipelines"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -223,7 +219,6 @@ patterns:
     positive_examples:
       - "python -cimport boto3"
     recommendation: "Do not embed boto3 in Ansible tasks; use approved service integrations"
-    no_ansible_remediation: true
     cwe: ["CWE-506"]
     mitre_attack: ["T1027"]
     cis_controls: ["CIS-8.2"]
@@ -266,7 +261,6 @@ patterns:
     positive_examples:
       - "gcloud compute"
     recommendation: "Use approved IaC workflows for GCP resource management, not ad-hoc gcloud calls"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1078.004"]
@@ -304,7 +298,6 @@ patterns:
     positive_examples:
       - "metadata.google.internal/computeMetadata"
     recommendation: "Do not query cloud metadata servers from playbooks; use environment-provided configuration"
-    no_ansible_remediation: true
 
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
@@ -330,7 +323,6 @@ patterns:
     positive_examples:
       - "az group create -l eastus -n $(setvar.resource_group)"
     recommendation: "Use approved IaC workflows for Azure resource management"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1078.004"]
@@ -374,7 +366,6 @@ patterns:
     positive_examples:
       - "iptables -I OUTPUT 1 -d 169.254.169.254 -j REJECT"
     recommendation: "Do not access cloud metadata from playbooks; use scoped IAM roles and environment variables"
-    no_ansible_remediation: true
 
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
@@ -453,7 +444,6 @@ patterns:
     positive_examples:
       - "terraform apply "
     recommendation: "Terraform should run through its own CI/CD pipeline with plan review, not from Ansible"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -494,7 +484,6 @@ patterns:
     positive_examples:
       - "cmd: \"vault write sys/plugins/catalog/secret/acme"
     recommendation: "Use the community.hashi_vault lookup plugin or Vault agent instead of CLI calls"
-    no_ansible_remediation: true
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5]
@@ -514,7 +503,6 @@ patterns:
     positive_examples:
       - "cmd: vault secrets enable -path acme -plugin-name acme plugin"
     recommendation: "Vault policy and auth configuration must go through reviewed IaC pipelines"
-    no_ansible_remediation: true
 
     cwe: ["CWE-269"]
     owasp_appsec: ["A04:2021"]
@@ -536,7 +524,6 @@ patterns:
     positive_examples:
       - "aws s3 cp"
     recommendation: "Access S3 through approved data pipelines; do not use direct AWS CLI S3 commands in playbooks"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1530"]
@@ -555,7 +542,6 @@ patterns:
     positive_examples:
       - "boto3.client('s3'"
     recommendation: "Do not use boto3 S3 access in playbooks; use approved data transfer mechanisms"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1530"]
@@ -595,7 +581,6 @@ patterns:
     positive_examples:
       - "aws ssm send-command"
     recommendation: "Use Ansible's native SSH-based execution; do not use SSM for remote command execution"
-    no_ansible_remediation: true
     cwe: ["CWE-78"]
     owasp_appsec: ["A03:2021"]
     mitre_attack: ["T1651"]
@@ -635,7 +620,6 @@ patterns:
     positive_examples:
       - "- name: negative - Create a DB instance using the default AWS KMS encryption key"
     recommendation: "KMS operations should be handled by the application layer, not Ansible playbooks"
-    no_ansible_remediation: true
 
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
@@ -658,7 +642,6 @@ patterns:
     positive_examples:
       - "aws rds create-db"
     recommendation: "RDS provisioning must go through approved IaC pipelines"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1578"]
@@ -681,7 +664,6 @@ patterns:
     positive_examples:
       - "aws dynamodb put-item"
     recommendation: "DynamoDB access should go through application APIs, not Ansible playbooks"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -703,7 +685,6 @@ patterns:
     positive_examples:
       - "aws ecs run-task"
     recommendation: "ECS deployments should go through CI/CD pipelines with review gates"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1610"]
@@ -722,7 +703,6 @@ patterns:
     positive_examples:
       - "aws eks get-token"
     recommendation: "EKS access should be configured through the execution environment, not playbook code"
-    no_ansible_remediation: true
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5]
@@ -742,7 +722,6 @@ patterns:
     positive_examples:
       - "aws ecr get-login-password"
     recommendation: "ECR authentication should be handled by the CI/CD runner, not Ansible playbooks"
-    no_ansible_remediation: true
 
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
@@ -765,7 +744,6 @@ patterns:
     positive_examples:
       - "aws cloudformation create-stack"
     recommendation: "CloudFormation should run through its own CI/CD pipeline with review gates"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1578"]
@@ -784,7 +762,6 @@ patterns:
     positive_examples:
       - "aws route53 change-resource-record-sets"
     recommendation: "DNS changes must go through approved IaC pipelines with peer review"
-    no_ansible_remediation: true
     cwe: ["CWE-345"]
     owasp_appsec: ["A08:2021"]
     mitre_attack: ["T1557"]
@@ -802,7 +779,6 @@ patterns:
     positive_examples:
       - "aws ec2 authorize-security-group"
     recommendation: "Security group changes must go through reviewed IaC pipelines"
-    no_ansible_remediation: true
 
     cwe: ["CWE-732"]
     owasp_asvs: [V5.3.1]
@@ -824,7 +800,6 @@ patterns:
     positive_examples:
       - "aws cloudtrail stop-logging"
     recommendation: "Never disable CloudTrail; this is a strong indicator of malicious intent"
-    no_ansible_remediation: true
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -844,7 +819,6 @@ patterns:
     positive_examples:
       - "aws guardduty delete-detector"
     recommendation: "Never disable GuardDuty; this is a strong indicator of malicious intent"
-    no_ansible_remediation: true
     cwe: ["CWE-693"]
     mitre_attack: ["T1562.001"]
     cis_controls: ["CIS-13.1"]
@@ -862,7 +836,6 @@ patterns:
     positive_examples:
       - "aws configservice stop-configuration-recorder"
     recommendation: "Never disable AWS Config; compliance monitoring must remain active"
-    no_ansible_remediation: true
     cwe: ["CWE-693"]
     mitre_attack: ["T1562.001"]
     cis_controls: ["CIS-4.1"]
@@ -880,7 +853,6 @@ patterns:
     positive_examples:
       - "aws cloudwatch delete-alarms"
     recommendation: "CloudWatch alarm management should go through IaC pipelines"
-    no_ansible_remediation: true
 
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
@@ -1047,7 +1019,6 @@ patterns:
     positive_examples:
       - "kubectl port-forward "
     recommendation: "Use Kubernetes Ingress or Services for network access, not port forwarding"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1572"]
@@ -1066,7 +1037,6 @@ patterns:
     positive_examples:
       - "kubectl cp "
     recommendation: "Use init containers or ConfigMaps/Secrets for file delivery, not kubectl cp"
-    no_ansible_remediation: true
     cwe: ["CWE-200"]
     owasp_appsec: ["A01:2021"]
     owasp_asvs: [V14.2.2]
@@ -1086,7 +1056,6 @@ patterns:
     positive_examples:
       - "kubectl delete deployment"
     recommendation: "Resource lifecycle should be managed through GitOps or Helm, not ad-hoc kubectl delete"
-    no_ansible_remediation: true
     cwe: ["CWE-732"]
     owasp_asvs: [V5.3.1]
     mitre_attack: ["T1485"]
@@ -1150,7 +1119,6 @@ patterns:
     positive_examples:
       - "gsutil cp "
     recommendation: "Use approved data pipelines for GCS access, not ad-hoc gsutil commands"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1530"]
@@ -1194,7 +1162,6 @@ patterns:
     positive_examples:
       - "gcloud kms decrypt"
     recommendation: "KMS operations should be handled by the application layer, not Ansible"
-    no_ansible_remediation: true
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5]
@@ -1214,7 +1181,6 @@ patterns:
     positive_examples:
       - "gcloud logging sinks delete"
     recommendation: "Never modify audit logging from playbooks; this is a strong indicator of malicious intent"
-    no_ansible_remediation: true
 
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
@@ -1239,7 +1205,6 @@ patterns:
     positive_examples:
       - "az keyvault secret show"
     recommendation: "Use managed identity with scoped access; do not extract secrets via az CLI"
-    no_ansible_remediation: true
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5]
@@ -1262,7 +1227,6 @@ patterns:
     positive_examples:
       - "az sql db create"
     recommendation: "Azure SQL provisioning must go through approved IaC pipelines"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1578"]
@@ -1281,7 +1245,6 @@ patterns:
     positive_examples:
       - "az acr login"
     recommendation: "ACR access should be handled by CI/CD pipelines, not Ansible playbooks"
-    no_ansible_remediation: true
     cwe: ["CWE-522"]
     owasp_appsec: ["A04:2021"]
     owasp_asvs: [V13.2.1, V11.2.5]
@@ -1304,7 +1267,6 @@ patterns:
     positive_examples:
       - "az monitor diagnostic-settings delete"
     recommendation: "Never disable monitoring from playbooks; this is a strong indicator of malicious intent"
-    no_ansible_remediation: true
 
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
@@ -1327,7 +1289,6 @@ patterns:
     positive_examples:
       - "pulumi up "
     recommendation: "Pulumi should run through its own CI/CD pipeline with review gates"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1578"]
@@ -1346,7 +1307,6 @@ patterns:
     positive_examples:
       - "cdk deploy "
     recommendation: "CDK should run through its own CI/CD pipeline with review gates"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1578"]
@@ -1365,7 +1325,6 @@ patterns:
     positive_examples:
       - "serverless deploy "
     recommendation: "Serverless Framework should run through CI/CD pipelines, not Ansible"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -1387,7 +1346,6 @@ patterns:
     positive_examples:
       - "oci compute"
     recommendation: "OCI CLI calls should go through approved IaC pipelines (Terraform), not direct Ansible execution"
-    no_ansible_remediation: true
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
     mitre_attack: ["T1078.004"]
@@ -1406,7 +1364,6 @@ patterns:
     positive_examples:
       - "oci os object put"
     recommendation: "Object storage access should be governed by IAM policies and logged"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -1428,7 +1385,6 @@ patterns:
     positive_examples:
       - "aws iam attach-user-policy"
     recommendation: "IAM policy changes must go through approved IaC pipelines with MFA and approval gates"
-    no_ansible_remediation: true
     cwe: ["CWE-269"]
     owasp_appsec: ["A04:2021"]
     mitre_attack: ["T1098.003"]
@@ -1447,7 +1403,6 @@ patterns:
     positive_examples:
       - "aws iam delete-user"
     recommendation: "IAM deletions must go through change management; this could be sabotage or covering tracks"
-    no_ansible_remediation: true
 
     cwe: ["CWE-284"]
     owasp_appsec: ["A01:2021"]
@@ -1469,7 +1424,6 @@ patterns:
     positive_examples:
       - "aws s3 ls"
     recommendation: "S3 operations should go through approved data pipelines, not direct CLI access from playbooks"
-    no_ansible_remediation: true
 
     cwe: ["CWE-732"]
     owasp_asvs: [V5.3.1]
@@ -1491,7 +1445,6 @@ patterns:
     positive_examples:
       - "aws ec2 describe-instances"
     recommendation: "EC2 operations should use Terraform/CloudFormation, not direct CLI calls from Ansible"
-    no_ansible_remediation: true
 
     cwe: ["CWE-200"]
     owasp_appsec: ["A01:2021"]
@@ -1516,7 +1469,6 @@ patterns:
     positive_examples:
       - "aws cloudtrail delete-trail"
     recommendation: "CloudTrail deletion is a strong indicator of compromise; escalate immediately"
-    no_ansible_remediation: true
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1536,7 +1488,6 @@ patterns:
     positive_examples:
       - "aws logs delete-log-group"
     recommendation: "CloudWatch log deletion is a strong indicator of tampering; escalate immediately"
-    no_ansible_remediation: true
     cwe: ["CWE-778"]
     owasp_appsec: ["A09:2021"]
     owasp_asvs: [V16.2.5, V16.3.1]
@@ -1556,7 +1507,6 @@ patterns:
     positive_examples:
       - "aws config delete-configuration-recorder"
     recommendation: "AWS Config deletion disables compliance monitoring; escalate immediately"
-    no_ansible_remediation: true
 
     cwe: ["CWE-693"]
     mitre_attack: ["T1562.001"]
@@ -1577,7 +1527,6 @@ patterns:
     positive_examples:
       - "aws organizations leave-organization"
     recommendation: "Organization changes remove security guardrails; this requires executive approval"
-    no_ansible_remediation: true
 
     cwe: ["CWE-269"]
     owasp_appsec: ["A04:2021"]
@@ -1599,7 +1548,6 @@ patterns:
     positive_examples:
       - "aws sts get-caller-identity"
     recommendation: "STS identity checks in playbooks may indicate reconnaissance; verify intent"
-    no_ansible_remediation: true
 
     cwe: ["CWE-200"]
     owasp_appsec: ["A01:2021"]
@@ -1622,7 +1570,6 @@ patterns:
     positive_examples:
       - "aws lambda create-function"
     recommendation: "Lambda deployment must go through CI/CD pipelines, not direct CLI from Ansible"
-    no_ansible_remediation: true
     cwe: ["CWE-494"]
     owasp_appsec: ["A08:2021"]
     owasp_asvs: [V15.2.4]

--- a/src/ansible_security_scanner/patterns/webshell_deployment.yml
+++ b/src/ansible_security_scanner/patterns/webshell_deployment.yml
@@ -119,7 +119,6 @@ patterns:
     positive_examples:
       - "weevely generate"
     recommendation: "Weevely is a known webshell tool; remove immediately and investigate the host for compromise"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -136,7 +135,6 @@ patterns:
     positive_examples:
       - "antSword.php"
     recommendation: "AntSword is a webshell management tool; remove associated files and investigate immediately"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -153,7 +151,6 @@ patterns:
     positive_examples:
       - "godzilla_php.php"
     recommendation: "Godzilla is a known encrypted webshell; remove immediately and scan the host"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -170,7 +167,6 @@ patterns:
     positive_examples:
       - "behinder.php"
     recommendation: "Behinder is a known encrypted webshell tool; remove immediately and investigate"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -187,7 +183,6 @@ patterns:
     positive_examples:
       - "eval(Request['"
     recommendation: "China Chopper is a classic one-line webshell; remove immediately and audit all web files"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -204,7 +199,6 @@ patterns:
     positive_examples:
       - "b374k/var/www"
     recommendation: "Named webshells indicate active compromise; remove files and perform full incident response"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1027", "T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -221,7 +215,6 @@ patterns:
     positive_examples:
       - "dest:/var/www.jschild_process"
     recommendation: "Node.js files with child_process in web roots are likely backdoors; remove and investigate"
-    no_ansible_remediation: true
     cwe: ["CWE-506", "CWE-912"]
     mitre_attack: ["T1505.003"]
     cis_controls: ["CIS-10.1", "CIS-16.1"]
@@ -238,7 +231,6 @@ patterns:
     positive_examples:
       - "dest:/var/www.plsystem("
     recommendation: "Perl CGI scripts with shell execution in web paths are likely webshells; remove and audit"
-    no_ansible_remediation: true
     cwe: ["CWE-912"]
     mitre_attack: ["T1505.003"]
     cis_controls: ["CIS-16.1"]

--- a/src/ansible_security_scanner/remediations/ai_ml_security.py
+++ b/src/ansible_security_scanner/remediations/ai_ml_security.py
@@ -1,254 +1,378 @@
 #!/usr/bin/env python3
 """
-Remediation generator for AI/ML security issues
+Remediation generator for AI/ML security issues.
+
+Every procedural AI/ML rule has a concrete, copy-pasteable safe shape:
+load weights as data (safetensors) instead of executing a pickle, pin and
+checksum model/RAG sources, gate provider/GPU/Jupyter/MLflow provisioning
+behind an approval var, and replace "LLM/agent output to a shell" with a
+parsed, allow-listed, validated invocation. The credential-style AI rules
+(API keys, unauthenticated Jupyter, world-readable vector DBs, ...) are
+companion-backed and never reach this generator.
 """
 
+import re
+
 from .base import BaseRemediationGenerator
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    for pat in patterns:
+        m = re.search(pat, snippet, re.IGNORECASE)
+        if m:
+            return (m.group(1) if m.groups() else m.group(0)).strip().strip("'\"")
+    return None
+
+
+def _inner_expr(value: str) -> str:
+    """Return the inner Jinja expression of a ``{{ ... }}`` token.
+
+    A value extracted from a snippet is often already a full ``{{ var }}``
+    expression. Embedding it inside another ``{{ ... }}`` would produce
+    invalid nested Jinja, so strip the wrapping braces and hand back the
+    bare expression for safe re-use inside an outer expression.
+    """
+    m = re.fullmatch(r"\{\{\s*(.+?)\s*\}\}", value.strip())
+    return m.group(1) if m else value
 
 
 class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
     """Generates remediation examples for AI/ML security issues"""
 
     _FIX_MAP = {
-        "anthropic_api_key": "api_key",
-        "aws_bedrock_access": "bedrock",
-        "aws_sagemaker_access": "sagemaker",
-        "azure_ml_access": "azure_ml",
-        "azure_openai_key": "api_key",
-        "cohere_api_key": "api_key",
-        "gcp_vertex_ai_access": "vertex",
-        "generic_llm_api_key": "api_key",
-        "google_ai_api_key": "api_key",
-        "gpu_instance_launch": "gpu",
-        "huggingface_model_download": "model_download",
-        "huggingface_token": "api_key",
-        "jupyter_no_auth": "jupyter",
-        "jupyter_server_start": "jupyter",
-        "mlflow_direct_access": "mlflow",
-        "model_from_url": "model_download",
-        "openai_api_key": "api_key",
-        "pickle_remote_load": "pickle",
-        "replicate_api_token": "api_key",
-        "template_in_llm_prompt": "prompt_injection",
-        "wandb_api_key": "api_key",
+        "pickle_remote_load": "_fix_pickle",
+        "pickle_load_as_root": "_fix_pickle",
+        "model_from_url": "_fix_model_download",
+        "aws_sagemaker_access": "_fix_service",
+        "aws_bedrock_access": "_fix_service",
+        "gcp_vertex_ai_access": "_fix_service",
+        "azure_ml_access": "_fix_service",
+        "mlflow_direct_access": "_fix_service",
+        "gpu_instance_launch": "_fix_gpu",
+        "jupyter_server_start": "_fix_jupyter",
+        "template_in_llm_prompt": "_fix_prompt_template",
+        "prompt_injection_untrusted_to_shell_sink": "_fix_llm_to_shell",
+        "langchain_shell_tool_unconstrained": "_fix_agent_shell_tool",
+        "mcp_tool_definition_exposes_arbitrary_shell_execution": "_fix_mcp_shell_tool",
+        "rag_pipeline_ingests_untrusted_external_urls_without_sanitisation": "_fix_rag_ingest",
     }
 
     def generate_ai_ml_security_fix(self, rule_id: str, code_snippet: str) -> str:
-        generators = {
-            "api_key": self._generate_api_key_fix,
-            "model_download": self._generate_model_download_fix,
-            "pickle": self._generate_pickle_fix,
-            "sagemaker": self._generate_ai_service_fix,
-            "bedrock": self._generate_ai_service_fix,
-            "vertex": self._generate_ai_service_fix,
-            "azure_ml": self._generate_ai_service_fix,
-            "gpu": self._generate_gpu_fix,
-            "jupyter": self._generate_jupyter_fix,
-            "prompt_injection": self._generate_prompt_injection_fix,
-            "mlflow": self._generate_mlops_fix,
-        }
-        issue = self._FIX_MAP.get(rule_id, "generic")
-        gen = generators.get(issue, self._generate_generic_ai_fix)
-        return gen(code_snippet)
+        method = self._FIX_MAP.get(rule_id)
+        if method is None:
+            return self._fix_generic(code_snippet)
+        return getattr(self, method)(rule_id, code_snippet)
 
-    def _generate_api_key_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
+    def _frame(self, rule_id: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        from . import _pattern_index
 
-**AI/LLM API Key Exposed in Playbook:**
-LLM API keys grant access to expensive AI services and billing accounts.
-A leaked key can result in significant financial damage and data exposure.
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        recommendation = meta.get("recommendation") or ""
+        body = f"This task involves {title.lower()}."
+        if why:
+            body += f" {why}"
+        if recommendation:
+            body += f" {recommendation}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{body}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
 
-**Secure Fix:**
-```yaml
-# Store in Vault and retrieve at runtime:
-- name: get AI API key from Vault
-  set_fact:
-    ai_api_key: "{{{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/ai:api_key') }}}}"
-  no_log: true
+    def _fix_pickle(self, rule_id: str, code_snippet: str) -> str:
+        path = (
+            _first(
+                code_snippet,
+                r"(?:pickle|torch|joblib|dill)\.loads?\(\s*open\(\s*['\"]([^'\"]+)",
+                r"(?:pickle|torch|joblib|dill)\.loads?\([^)]*?([\w./{}-]+\.(?:pkl|pickle|pt|bin|pth|model))",
+                r"([\w./{}-]+\.(?:pkl|pickle|pt|bin|pth|model))",
+            )
+            or "{{ model_path }}"
+        )
+        as_root = rule_id == "pickle_load_as_root"
+        secure_fix = (
+            "# pickle/torch/joblib.load executes arbitrary code while deserialising.\n"
+            "# Load weights as pure data with safetensors instead, and verify the\n"
+            "# artefact's checksum before reading it"
+            + (".\n" if not as_root else " - never as root.\n")
+            + f"- name: Verify the model artefact against a known-good checksum\n"
+            f"  ansible.builtin.get_url:\n"
+            f'    url: "{{{{ model_source_url }}}}"\n'
+            f'    dest: "{path if not path.endswith((".pkl", ".pickle")) else "{{ model_path }}"}.safetensors"\n'
+            f'    checksum: "sha256:{{{{ model_sha256 }}}}"\n'
+            f"    mode: '0644'\n"
+            + (
+                ""
+                if not as_root
+                else "  become: false   # load/parse model data as an unprivileged user\n"
+            )
+            + "\n"
+            "- name: Load the weights as data (no code execution)\n"
+            "  ansible.builtin.command:\n"
+            "    argv:\n"
+            "      - python3\n"
+            "      - -c\n"
+            "      - \"from safetensors.torch import load_file; load_file('{{ model_path }}.safetensors')\"\n"
+            + ("  become: false\n" if as_root else "")
+        )
+        why = (
+            "Deserialising a pickle as root turns an untrusted file into root RCE."
+            if as_root
+            else "Pickle deserialisation runs arbitrary code from the file."
+        )
+        return self._frame(rule_id, code_snippet, why, secure_fix)
 
-# Or use environment-provided credentials:
-- name: call AI service
-  ansible.builtin.uri:
-    url: "https://api.openai.com/v1/chat/completions"
-    headers:
-      Authorization: "Bearer {{{{ lookup('env', 'OPENAI_API_KEY') }}}}"
-  no_log: true
-```
+    def _fix_model_download(self, rule_id: str, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"]+)") or "{{ model_url }}"
+        secure_fix = (
+            f"# Pin the model to an immutable revision and verify its checksum so the\n"
+            f"# bytes cannot change underneath you. Prefer safetensors over .pt/.bin.\n"
+            f"- name: Download the model pinned to a revision and checksum\n"
+            f"  ansible.builtin.get_url:\n"
+            f'    url: "{url}"   # pin to a commit SHA / immutable revision, not a branch\n'
+            f"    dest: /opt/models/model.safetensors\n"
+            f'    checksum: "sha256:{{{{ model_sha256 }}}}"\n'
+            f"    validate_certs: true\n"
+            f"    mode: '0644'"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "An unpinned, unverified model download is a supply-chain vector.",
+            secure_fix,
+        )
 
-**AI Key Security:**
-- Set usage limits and alerts on all AI API keys
-- Use separate keys per environment (dev/staging/prod)
-- Rotate keys regularly and after any potential exposure
-"""
+    def _fix_service(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Provision/invoke managed AI services through a reviewed pipeline with\n"
+            "# cost controls, not ad-hoc from a playbook. Gate any direct call behind\n"
+            "# an explicit approval and a tagged, budgeted request.\n"
+            "- name: Refuse direct provisioning unless explicitly approved\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - ml_provisioning_approved | default(false) | bool\n"
+            "      - cost_center is defined\n"
+            "    fail_msg: >-\n"
+            "      AI/ML provisioning must run through the approved ML pipeline with a\n"
+            "      cost center and budget guardrails, not directly from Ansible.\n"
+            "\n"
+            "- name: Trigger the reviewed ML pipeline instead of calling the API directly\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "https://{{ ml_pipeline_endpoint }}/runs"\n'
+            "    method: POST\n"
+            "    headers:\n"
+            '      Authorization: "Bearer {{ vault_ml_pipeline_token }}"\n'
+            "    body_format: json\n"
+            "    body:\n"
+            '      cost_center: "{{ cost_center }}"\n'
+            "  no_log: true"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Direct provisioning bypasses ML governance and cost controls.",
+            secure_fix,
+        )
 
-    def _generate_model_download_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
+    def _fix_gpu(self, rule_id: str, code_snippet: str) -> str:
+        itype = (
+            _first(
+                code_snippet,
+                r"\b((?:p[0-9]|g[0-9]|inf[0-9]|trn[0-9])[\w.]*x?large|a100|h100|v100)\b",
+            )
+            or "{{ gpu_instance_type }}"
+        )
+        secure_fix = (
+            f"# GPU instances are expensive and a common cryptomining indicator. Require\n"
+            f"# approval and tag the instance with an owner, cost center, and expiry.\n"
+            f"- name: Refuse GPU launches without approval and cost tagging\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - gpu_launch_approved | default(false) | bool\n"
+            f"      - cost_center is defined\n"
+            f"      - auto_shutdown_at is defined\n"
+            f"    fail_msg: >-\n"
+            f"      GPU instance launches require approval and a cost-center / expiry tag.\n"
+            f"\n"
+            f"- name: Launch the approved, tagged GPU instance\n"
+            f"  amazon.aws.ec2_instance:\n"
+            f'    instance_type: "{itype}"\n'
+            f"    tags:\n"
+            f'      cost_center: "{{{{ cost_center }}}}"\n'
+            f'      owner: "{{{{ requesting_user }}}}"\n'
+            f'      auto_shutdown_at: "{{{{ auto_shutdown_at }}}}"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Unapproved GPU launches risk runaway cost and cryptomining.",
+            secure_fix,
+        )
 
-**Untrusted ML Model Download:**
-ML models from Hugging Face and other hubs can contain arbitrary code
-(via pickle serialization). Downloading without verification is a supply
-chain attack vector.
+    def _fix_jupyter(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# A Jupyter server is an interactive RCE endpoint. Bind it to localhost\n"
+            "# and require a token; never --ip=0.0.0.0 with auth disabled.\n"
+            "- name: Start Jupyter bound to localhost with token auth\n"
+            "  ansible.builtin.command:\n"
+            "    argv:\n"
+            "      - jupyter\n"
+            "      - lab\n"
+            "      - --ip=127.0.0.1\n"
+            "      - --no-browser\n"
+            "      - --ServerApp.token={{ vault_jupyter_token }}\n"
+            "  no_log: true\n"
+            "  # Front with an authenticating reverse proxy / JupyterHub for remote access."
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "An unauthenticated, broadly-bound Jupyter server is open RCE.",
+            secure_fix,
+        )
 
-**Secure Fix:**
-```yaml
-- name: download model with pinned revision
-  get_url:
-    url: "https://huggingface.co/org/model/resolve/<commit-sha>/model.safetensors"
-    dest: /opt/models/model.safetensors
-    checksum: "sha256:<known-good-hash>"
+    def _fix_prompt_template(self, rule_id: str, code_snippet: str) -> str:
+        var = _first(code_snippet, r"(\{\{\s*[\w.]+\s*\}\})") or "{{ user_input }}"
+        expr = _inner_expr(var)
+        secure_fix = (
+            f"# Validate and constrain any variable before it reaches an LLM prompt so a\n"
+            f"# crafted value cannot hijack the model's instructions.\n"
+            f"- name: Validate the untrusted input before templating it into the prompt\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - \"{expr} is match('^[A-Za-z0-9 _.,:-]{{1,500}}$')\"\n"
+            f'    fail_msg: "Prompt input failed the allow-list validation."\n'
+            f"\n"
+            f"- name: Build the prompt with the validated value and a fixed system prompt\n"
+            f"  ansible.builtin.set_fact:\n"
+            f'    llm_prompt: "{{{{ system_guardrail_prompt }}}}\\n\\nUser data: {var}"\n'
+            f"  # Keep instructions in the system prompt; treat user data as data only."
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Unvalidated variables in a prompt enable prompt injection.",
+            secure_fix,
+        )
 
-# Prefer safetensors format over pickle-based formats (.pt, .pkl, .bin)
-```
+    def _fix_llm_to_shell(self, rule_id: str, code_snippet: str) -> str:
+        var = _first(code_snippet, r"(\{\{\s*[\w.]+\s*\}\})") or "{{ llm_response.stdout }}"
+        expr = _inner_expr(var)
+        secure_fix = (
+            f"# Never pipe raw LLM output into a shell. Parse it as structured JSON,\n"
+            f"# allow-list the action, and invoke a fixed command by name with validated\n"
+            f"# arguments - no string interpolation into a shell.\n"
+            f"- name: Parse the model output as a strict JSON action\n"
+            f"  ansible.builtin.set_fact:\n"
+            f'    llm_action: "{{{{ ({expr} | from_json) }}}}"\n'
+            f"\n"
+            f"- name: Refuse any action that is not on the allow-list\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - llm_action.command in allowed_llm_commands\n"
+            f'    fail_msg: "LLM requested a command outside the allow-list."\n'
+            f"\n"
+            f"- name: Run the allow-listed command with validated args (argv, no shell)\n"
+            f"  ansible.builtin.command:\n"
+            f'    argv: "{{{{ [llm_action.command] + (llm_action.args | default([])) }}}}"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Piping model output to a shell is direct prompt-injection-to-RCE.",
+            secure_fix,
+        )
 
-**ML Supply Chain Security:**
-- Pin model downloads to specific commit SHAs
-- Prefer safetensors format (no arbitrary code execution)
-- Scan models with tools like Fickling or ModelScan
-- Use an internal model registry with signature verification
-"""
+    def _fix_agent_shell_tool(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Do not bind an unconstrained ShellTool to an agent. Expose narrow,\n"
+            "# parameterised tools that run a fixed command via argv with validation.\n"
+            "- name: Render the agent tool config with no generic shell tool\n"
+            "  ansible.builtin.copy:\n"
+            "    dest: /opt/agent/tools.py\n"
+            "    mode: '0644'\n"
+            "    content: |\n"
+            "      from langchain_core.tools import Tool\n"
+            "      import subprocess\n"
+            "      # One narrow tool per operation; arguments validated, argv (no shell=True).\n"
+            "      def list_project(_):\n"
+            "          return subprocess.run(\n"
+            "              ['ls', PROJECT_DIR], check=True, capture_output=True, text=True\n"
+            "          ).stdout\n"
+            "      tools = [Tool(name='list_project', func=list_project, description='List project files')]\n"
+            "  # Run the agent's tool process in a locked-down sandbox (no network, ro-fs)."
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "An unconstrained agent shell tool is arbitrary command execution.",
+            secure_fix,
+        )
 
-    def _generate_pickle_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
+    def _fix_mcp_shell_tool(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Never expose a generic shell/exec tool over MCP. Define narrow, typed\n"
+            "# tools per operation, each constrained to an allow-listed root.\n"
+            "- name: Render an MCP server that exposes only narrow, typed tools\n"
+            "  ansible.builtin.copy:\n"
+            "    dest: /opt/mcp/server.py\n"
+            "    mode: '0644'\n"
+            "    content: |\n"
+            "      from pathlib import Path\n"
+            "      ALLOWED_ROOT = Path('/srv/app').resolve()\n"
+            "      @server.tool()\n"
+            "      def read_file(path: str) -> str:\n"
+            "          target = (ALLOWED_ROOT / path).resolve()\n"
+            "          if not target.is_relative_to(ALLOWED_ROOT):\n"
+            "              raise ValueError('path escapes allowed root')\n"
+            "          return target.read_text()\n"
+            "      # No subprocess(shell=True); no generic exec tool is defined.\n"
+            "  # Run the MCP server as an unprivileged user in a throwaway sandbox."
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A generic shell tool over MCP hands the agent arbitrary execution.",
+            secure_fix,
+        )
 
-**CRITICAL: Pickle Deserialization = Remote Code Execution:**
-`pickle.load`, `torch.load`, `joblib.load`, and `dill.load` execute
-arbitrary Python code during deserialization. A malicious pickle file
-achieves full RCE on the target machine.
+    def _fix_rag_ingest(self, rule_id: str, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"]+|\{\{[^}]*\}\})") or "{{ ingest_url }}"
+        expr = _inner_expr(url)
+        secure_fix = (
+            f"# Never ingest arbitrary URLs into a RAG index. Canonicalise the URL and\n"
+            f"# reject anything whose host is not on a code-reviewed allow-list.\n"
+            f"- name: Reject ingestion URLs outside the reviewed domain allow-list\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - \"({expr} | urlsplit('hostname')) in rag_allowed_domains\"\n"
+            f"      - \"({expr} | urlsplit('scheme')) == 'https'\"\n"
+            f"    fail_msg: >-\n"
+            f"      RAG ingestion is restricted to the reviewed domain allow-list; {url}\n"
+            f"      resolves outside it.\n"
+            f"  # Re-check the final host after following redirects before indexing."
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Ingesting arbitrary URLs lets attackers poison the RAG index.",
+            secure_fix,
+        )
 
-**Secure Fix:**
-- Use safetensors for ML model weights (no code execution)
-- Use JSON, MessagePack, or Protocol Buffers for data serialization
-- If pickle is unavoidable, use `torch.load(..., weights_only=True)`
-- Never load pickle files from untrusted sources
-"""
-
-    def _generate_ai_service_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Direct AI/ML Service Provisioning from Ansible:**
-Creating SageMaker endpoints, Bedrock invocations, Vertex AI pipelines,
-or Azure ML workspaces from playbooks bypasses ML governance controls
-and can incur significant costs.
-
-**Secure Fix:**
-AI/ML infrastructure should be provisioned through:
-- Approved ML platform pipelines (MLflow, Kubeflow, SageMaker Pipelines)
-- Reviewed IaC (Terraform) with cost controls and auto-shutdown
-- Budget alerts and instance hour limits
-"""
-
-    def _generate_gpu_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**GPU Instance Launch from Ansible:**
-GPU instances (p3, p4, g5, A100, etc.) cost $3-$30+/hour. Unauthorized
-launches can result in massive bills, and could indicate crypto mining.
-
-**Secure Fix:**
-GPU instance provisioning must be:
-- Approved by cost center owner
-- Tagged with purpose, owner, and auto-shutdown schedule
-- Provisioned through IaC with budget limits
-- Monitored for unexpected utilization patterns
-"""
-
-    def _generate_jupyter_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Jupyter Notebook Server Exposure:**
-Jupyter provides interactive code execution. Without authentication and
-network controls, it's equivalent to an open RCE endpoint.
-
-**Secure Fix:**
-```yaml
-# Always require token auth and restrict binding:
-- name: start Jupyter with authentication
-  ansible.builtin.shell: >
-    jupyter lab
-    --ip=127.0.0.1
-    --port=8888
-    --no-browser
-    --NotebookApp.token='{{{{ vault_jupyter_token }}}}'
-  no_log: true
-```
-
-**Jupyter Security:**
-- Never disable authentication (--NotebookApp.token='')
-- Never bind to 0.0.0.0 without a firewall
-- Use JupyterHub for multi-user environments
-"""
-
-    def _generate_prompt_injection_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Prompt Injection via Template Variables:**
-Injecting unvalidated Ansible variables into LLM prompts allows prompt
-injection attacks. An attacker who controls the variable value can
-manipulate the LLM's behavior.
-
-**Secure Fix:**
-- Validate and sanitize all user-controlled input before LLM prompts
-- Use system prompts to constrain LLM behavior
-- Implement input/output guardrails (e.g., AWS Bedrock Guardrails)
-- Never pass raw user input directly into prompt templates
-"""
-
-    def _generate_mlops_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Direct MLOps Platform Access:**
-Accessing MLflow, W&B, or other ML platforms directly from playbooks
-bypasses pipeline governance controls.
-
-**Secure Fix:**
-- Use CI/CD-triggered ML pipelines for model training and deployment
-- Store MLflow/W&B credentials in Vault, not playbooks
-- Implement model approval gates before production deployment
-"""
-
-    def _generate_generic_ai_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**AI/ML Security Issue:**
-- Store all AI API keys in secrets management (Vault, AWS Secrets Manager)
-- Pin and verify checksums for all model downloads
-- Use safetensors format instead of pickle-based formats
-- Provision AI infrastructure through reviewed IaC pipelines
-- Set cost controls and budget alerts on all AI services
-"""
+    def _fix_generic(self, code_snippet: str) -> str:
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d AI/ML Security Issue:**\n"
+            "This task involves an AI/ML operation that needs hardening.\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n"
+            "# Store AI API keys in a secret manager; pin and checksum model/RAG sources;\n"
+            "# load weights as safetensors (never pickle); provision AI infra through a\n"
+            "# reviewed pipeline with cost controls; allow-list any agent/LLM-driven action.\n"
+            "- name: Gate the AI/ML operation behind explicit approval\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - ml_operation_approved | default(false) | bool\n"
+            '    fail_msg: "This AI/ML operation requires explicit, reviewed approval."\n'
+            "```\n"
+        )

--- a/src/ansible_security_scanner/remediations/ansible_hygiene.py
+++ b/src/ansible_security_scanner/remediations/ansible_hygiene.py
@@ -3,7 +3,11 @@
 Remediation generator for Ansible hygiene issues (no_log, get_url checksum, secrets in comments)
 """
 
-from .base import BaseRemediationGenerator
+from __future__ import annotations
+
+import re
+
+from .base import BaseRemediationGenerator, _append_keys, _drop_key_lines, _first
 
 
 class AnsibleHygieneRemediationGenerator(BaseRemediationGenerator):
@@ -14,10 +18,12 @@ class AnsibleHygieneRemediationGenerator(BaseRemediationGenerator):
         "get_url_dest_executable_with_insecure_validate": "_generate_get_url_dest_executable_fix",
         "get_url_no_checksum": "_generate_checksum_fix",
         "ignore_errors_security": "_generate_ignore_errors_fix",
+        "ignore_errors_security_task": "_generate_ignore_errors_fix",
         "missing_no_log": "_generate_no_log_fix",
         "no_log_explicitly_false_on_credential_task": "_generate_no_log_explicitly_false_fix",
         "no_log_explicitly_false_on_credential_task_ast": "_generate_no_log_explicitly_false_fix",
         "secret_in_comment": "_generate_secret_comment_fix",
+        "set_fact_secret_alias": "_generate_set_fact_secret_alias_fix",
         "tags_never_on_security_task": "_generate_tags_never_security_fix",
     }
 
@@ -25,100 +31,157 @@ class AnsibleHygieneRemediationGenerator(BaseRemediationGenerator):
         return self._dispatch_fix(rule_id, code_snippet, self._generate_generic_hygiene_fix)
 
     def _generate_no_log_fix(self, code_snippet: str) -> str:
+        fixed = _append_keys(code_snippet, "no_log: true")
         return f"""
-**Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
-```yaml
-- name: Authenticate to service
-  ansible.builtin.uri:
-    url: "https://api.example.com/auth"
-    method: POST
-    body_format: json
-    body:
-      username: "{{{{ service_user }}}}"
-      password: "{{{{ vault_service_password }}}}"
-  no_log: true   # <-- prevents credentials from appearing in logs
-  register: auth_result
-```
+**🚨 Missing no_log on a Credential Task:**
+Without `no_log: true`, Ansible prints the task's resolved arguments - including
+the looked-up password/token - to stdout and every log file and callback plugin.
 
-**Why this matters:** Without `no_log: true`, Ansible prints the full task parameters (including passwords and tokens) to stdout and log files.
+**✅ Secure Fix Example:**
+```yaml
+{fixed}
+```
 """
 
     def _generate_checksum_fix(self, code_snippet: str) -> str:
+        url = (
+            _first(code_snippet, r"url\s*:\s*[\"']?((?:\{\{.*?\}\}|[^\s\"'])+)")
+            or "{{ download_url }}"
+        )
+        fixed = _append_keys(
+            code_snippet,
+            'checksum: "sha256:{{ expected_sha256 }}"',
+        )
         return f"""
-**Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**🚨 Download Without Integrity Verification:**
+`{url}` is fetched with no `checksum:`. A compromised mirror or MITM can
+silently swap the artifact for a trojanized one.
+
+**✅ Secure Fix Example:**
 ```yaml
-- name: Download binary with integrity verification
-  get_url:
-    url: "https://releases.example.com/v1.2.3/binary_amd64.tar.gz"
-    dest: /tmp/binary.tar.gz
-    checksum: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+{fixed}
 ```
 
-**Why this matters:** Without `checksum:`, a compromised CDN/mirror or MITM attack can silently replace the download with a trojanized binary.
+Pin `expected_sha256` from the publisher's signed checksum file (vault it for
+internal artifacts). `get_url` re-downloads only when the checksum changes.
 """
 
     def _generate_ignore_errors_fix(self, code_snippet: str) -> str:
+        without = _drop_key_lines(code_snippet, "ignore_errors")
+        fixed = _append_keys(
+            without,
+            "register: task_result",
+            "failed_when: task_result.rc not in [0]   # set the conditions you actually tolerate",
+        )
         return f"""
-**Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**🚨 ignore_errors on a Security-Critical Task:**
+`ignore_errors` swallows every failure, so a security operation can fail
+silently and leave the host in an insecure state while the play reports success.
+
+**✅ Secure Fix Example:**
 ```yaml
-- name: Verify TLS certificate
-  ansible.builtin.command: openssl verify /etc/ssl/cert.pem
-  register: cert_result
-  failed_when: cert_result.rc != 0
-  # Never use ignore_errors on security-critical tasks
+{fixed}
 ```
 
-**Why this matters:** Using `ignore_errors: yes` on security-sensitive operations silently swallows failures, leaving the system in an insecure state.
+Replace the blanket `ignore_errors` with an explicit `failed_when` that names
+the conditions you genuinely tolerate, so unexpected failures still stop the play.
+"""
+
+    def _generate_set_fact_secret_alias_fix(self, code_snippet: str) -> str:
+        alias = _first(code_snippet, r"set_fact\s*:\s*\n\s*([A-Za-z_][\w]*)\s*:") or "secret_value"
+        secret_name = alias if alias.startswith(("vault_", "secret_")) else f"vault_{alias}"
+        renamed = re.sub(
+            rf"(\b){re.escape(alias)}(\s*:)",
+            rf"\g<1>{secret_name}\g<2>",
+            code_snippet,
+            count=1,
+        )
+        fixed = _append_keys(renamed, "no_log: true")
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 set_fact Aliases a Secret Into a Generic Name:**
+Renaming a credential into a generic fact (`{alias}`) defeats name-based
+`no_log` heuristics and review greps, so the value leaks downstream unredacted.
+
+**✅ Secure Fix Example:**
+```yaml
+{fixed}
+```
+
+Keep a secret-shaped name (`{secret_name}`) so downstream rules and reviewers
+still treat it as a credential, and set `no_log: true` on every task that reads it.
+Prefer a vault/secret-store lookup at the consuming task over aliasing entirely.
 """
 
     def _generate_secret_comment_fix(self, code_snippet: str) -> str:
         return f"""
-**Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**🚨 Credential Left in a Comment:**
+Comments are not redacted by `no_log` and stay in version-control history.
+
+**✅ Secure Fix Example:**
 ```yaml
-# Use variable references even in comments:
+# Reference the variable, never the literal value, even in comments:
 #     password: "{{{{ vault_service_password }}}}"
-# Or simply use a placeholder:
+# Or use a placeholder:
 #     password: "<REDACTED>"
 ```
 
-**Why this matters:** Credentials in comments remain visible in version control history. Use `git filter-branch` or BFG Repo-Cleaner to purge them from history.
+Purge any already-committed secret from history with BFG Repo-Cleaner or
+`git filter-repo`, then rotate it.
 """
 
     def _generate_generic_hygiene_fix(self, code_snippet: str) -> str:
         return f"""
-**Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
-- Add `no_log: true` to tasks handling credentials
-- Add `checksum:` to all `get_url` tasks
-- Remove hardcoded credentials from comments
-- Never use `ignore_errors` on security-critical tasks
+**✅ Secure Fix Example:**
+```yaml
+# Apply the matching hardening for this task:
+#   - add `no_log: true` to tasks handling credentials
+#   - add `checksum: "sha256:..."` to every `get_url`
+#   - replace `ignore_errors` with an explicit `failed_when`
+#   - keep secrets out of comments and generic fact names
+{code_snippet}
+```
 """
 
     def _generate_no_log_explicitly_false_fix(self, code_snippet: str) -> str:
+        fixed = re.sub(
+            r"(no_log\s*:\s*)(?:false|no)\b",
+            r"\1true",
+            code_snippet,
+            count=1,
+            flags=re.IGNORECASE,
+        )
+        if fixed == code_snippet:
+            fixed = _append_keys(_drop_key_lines(code_snippet, "no_log"), "no_log: true")
         return f"""
 **❌ Vulnerable Code:**
 ```yaml
@@ -131,18 +194,9 @@ resolved arguments on every run - including the looked-up vault/secret values.
 Every callback plugin (stdout, syslog, Splunk, Slack, Datadog) receives the
 plaintext. In CI, the artifact is typically retained for weeks.
 
-**✅ Secure Fix:**
+**✅ Secure Fix Example:**
 ```yaml
-- name: authenticate to service
-  ansible.builtin.uri:
-    url: "https://api.example.com/auth"
-    method: POST
-    body_format: json
-    body:
-      username: "{{{{ service_user }}}}"
-      password: "{{{{ vault_service_password }}}}"
-  no_log: true       # <-- redact the entire task result
-  register: auth_result
+{fixed}
 ```
 
 **🔐 If you genuinely need task output for debugging:**
@@ -153,14 +207,18 @@ its result, then `debug:` only the non-sensitive fields:
   ansible.builtin.debug:
     msg: "status={{{{ auth_result.status }}}}, elapsed={{{{ auth_result.elapsed }}}}"
 ```
-
-**🔐 Related hardening:**
-- Encrypt the secret at rest: `ansible-vault encrypt_string`.
-- Pair with `ANSIBLE_NO_LOG=True` as a CI environment variable so debug runs
-  still redact.
 """
 
     def _generate_get_url_dest_executable_fix(self, code_snippet: str) -> str:
+        without = _drop_key_lines(code_snippet, "validate_certs")
+        fixed = _append_keys(
+            without,
+            'checksum: "sha256:{{ expected_sha256 }}"',
+            "mode: '0755'",
+            "owner: root",
+            "group: root",
+            "# validate_certs defaults to yes - do NOT set it to no",
+        )
         return f"""
 **❌ Vulnerable Code:**
 ```yaml
@@ -168,36 +226,28 @@ its result, then `debug:` only the non-sensitive fields:
 ```
 
 **🚨 Download-to-Executable-Path With No Certificate Validation:**
-`validate_certs: no` disables TLS verification; `dest:` points at a path that
-will be executed (e.g., /usr/local/bin/, /opt/, /tmp/*.sh). An attacker on the
-network path (or a compromised mirror) replaces the payload with their own
-binary - Ansible happily installs and runs it. This is the xz-utils /
-shai-hulud / tj-actions attack pattern applied to a playbook.
+`validate_certs: no` disables TLS verification while `dest:` points at a path
+that will be executed. An attacker on the network path (or a compromised
+mirror) replaces the payload with their own binary and Ansible installs and
+runs it.
 
-**✅ Secure Fix:**
+**✅ Secure Fix Example:**
 ```yaml
-- name: fetch installer with integrity + cert validation
-  ansible.builtin.get_url:
-    url: "https://releases.example.com/v1.2.3/installer.sh"
-    dest: "/usr/local/bin/installer.sh"
-    checksum: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    mode: '0755'
-    owner: root
-    group: root
-    # validate_certs defaults to yes - do NOT set it to no
+{fixed}
 ```
 
 **🔐 Hardening checklist:**
 1. Always pair get_url with `checksum: sha256:<hex>` (or sha512:).
 2. If the upstream publishes a detached signature, verify it with
    `command: gpg --verify file.sig file` BEFORE making it executable.
-3. If the target uses an internal CA, pin it with `ca_path: /etc/ssl/certs/corp-ca.pem`
+3. For an internal CA, pin it with `ca_path: /etc/ssl/certs/corp-ca.pem`
    instead of disabling cert validation entirely.
 4. Prefer `package:` / `apt:` / `dnf:` / `win_chocolatey:` with a pinned-repo
    channel over download-and-execute.
 """
 
     def _generate_tags_never_security_fix(self, code_snippet: str) -> str:
+        fixed = _drop_key_lines(code_snippet, "tags")
         return f"""
 **❌ Vulnerable Code:**
 ```yaml
@@ -208,38 +258,23 @@ shai-hulud / tj-actions attack pattern applied to a playbook.
 A task tagged `never` is SKIPPED by every `ansible-playbook` invocation unless
 the operator passes `--tags never` explicitly. When the task is a hardening
 step (firewall, SELinux, CVE patch, audit config), the playbook silently
-reports success without applying the security change. This is defense-in-depth
-disabled by default - the worst-of-both-worlds: the code is there, it passes
-review, and it never runs.
+reports success without applying the security change.
 
-**✅ Secure Fix (make the task run by default):**
+**✅ Secure Fix Example:**
 ```yaml
-- name: apply kernel hardening (CIS 1.5.x)
-  ansible.builtin.copy:
-    src: sysctl-hardening.conf
-    dest: /etc/sysctl.d/99-hardening.conf
-    mode: '0644'
-  notify: reload sysctl
-  # no tags - task runs on every playbook invocation
+{fixed}
+  # no `tags: never` - the hardening task now runs on every invocation
 ```
 
 **🔐 If the task is genuinely optional:**
-Use a descriptive tag, a variable guard, AND document the opt-in in the role
-README:
+Use a descriptive tag plus a variable guard instead of `never`:
 ```yaml
-- name: emergency CVE-2024-XXXX remediation (opt-in)
+- name: emergency CVE remediation (opt-in)
   ansible.builtin.command: /opt/hardening/cve-2024-xxxx
   when: apply_cve_2024_xxxx_remediation | default(false) | bool
   tags: [emergency, cve-2024-xxxx]
 ```
-...then the operator must explicitly set `-e apply_cve_2024_xxxx_remediation=true`
-to run it - no magic tag required.
-
-**🔐 Auditing for this pattern across your codebase:**
-```bash
-# find every `tags: never` anywhere in your playbooks
-rg -n '^\\s*tags:\\s*(?:never\\b|\\[.*never.*\\])' roles/ playbooks/
-```
+...then the operator must explicitly set `-e apply_cve_2024_xxxx_remediation=true`.
 """
 
     def _generate_fss_vault_fix(self, code_snippet: str) -> str:
@@ -252,25 +287,16 @@ rg -n '^\\s*tags:\\s*(?:never\\b|\\[.*never.*\\])' roles/ playbooks/
 **🚨 False-Sense-of-Security:**
 A hostname, port, URL, path, timeout, or version number is not a secret.
 Wrapping it in `!vault` doesn't protect anything - the value wasn't sensitive
-to begin with - but it:
+to begin with - but it obscures the playbook from review, breaks diff-based
+audit, and makes real secrets indistinguishable from fake ones.
 
-1. Obscures the playbook from review (reviewers can't see what IP / URL the
-   code actually targets without decrypting).
-2. Breaks diff-based audit (every environment change looks like a vault
-   rotation).
-3. Creates a FALSE sense of security: real secrets and fake secrets become
-   indistinguishable, so the real ones stop getting extra scrutiny
-   (rotation, access audits, separate vault keys per environment).
-
-**✅ Secure Fix (plain YAML for non-secrets):**
+**✅ Secure Fix Example:**
 ```yaml
 # group_vars/prod.yml - plain, reviewable, diff-friendly
 api_url: "https://api.internal.example.com/v2"
 api_port: 8443
 api_timeout: 30
-```
 
-```yaml
 # group_vars/prod/vault.yml - vault ONLY for secrets
 api_token: !vault |
   $ANSIBLE_VAULT;1.1;AES256
@@ -286,7 +312,6 @@ api_token: !vault |
 | TLS key material, OAuth client     | feature flags, region/zone       |
 | secrets, session signing keys      | names, protocol choices          |
 
-**🔐 Per-environment separation WITHOUT encrypting non-secrets:**
-Use inventory groups and `group_vars/<env>/` to split values by environment.
-Never use `!vault` as a substitute for inventory structure.
+Use inventory groups and `group_vars/<env>/` to split values by environment;
+never use `!vault` as a substitute for inventory structure.
 """

--- a/src/ansible_security_scanner/remediations/ansible_specific.py
+++ b/src/ansible_security_scanner/remediations/ansible_specific.py
@@ -28,6 +28,7 @@ class AnsibleSpecificRemediationGenerator(BaseRemediationGenerator):
         "terraform_state_access": "_fix_terraform_state",
         "vault_password_file": "_fix_vault_password",
         "windows_registry_persistence": "_fix_registry_persistence",
+        "buildah_unshare_as_root": "_fix_buildah",
         # AWX / AAP / Tower runtime
         "awx_ask_credential_on_launch": "_fix_awx_ask_credential",
         "awx_controller_host_literal_admin": "_fix_awx_token",
@@ -63,12 +64,12 @@ class AnsibleSpecificRemediationGenerator(BaseRemediationGenerator):
 
     def _fix_become_pass(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use Vault-encrypted variable instead of plaintext
 ansible_become_password: "{{{{ vault_become_password }}}}"
@@ -77,17 +78,17 @@ ansible_become_password: "{{{{ vault_become_password }}}}"
 #   ansible-playbook site.yml --ask-become-pass
 ```
 
-**\\U0001f510 Best Practice:** Store become passwords in Ansible Vault or an external credential manager (HashiCorp Vault, CyberArk). Never commit plaintext passwords.
+**🔐 Best Practice:** Store become passwords in Ansible Vault or an external credential manager (HashiCorp Vault, CyberArk). Never commit plaintext passwords.
 """
 
     def _fix_ssh_pass(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use SSH key-based authentication (preferred)
 ansible_ssh_private_key_file: "~/.ssh/id_ed25519"
@@ -96,50 +97,50 @@ ansible_ssh_private_key_file: "~/.ssh/id_ed25519"
 ansible_ssh_password: "{{{{ vault_ssh_password }}}}"
 ```
 
-**\\U0001f510 Best Practice:** SSH key-based authentication is always preferred over password auth. If passwords are required, encrypt them with Ansible Vault.
+**🔐 Best Practice:** SSH key-based authentication is always preferred over password auth. If passwords are required, encrypt them with Ansible Vault.
 """
 
     def _fix_winrm_pass(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use Vault-encrypted WinRM credentials
 ansible_winrm_password: "{{{{ vault_winrm_password }}}}"
 ansible_winrm_transport: kerberos  # Preferred over basic auth
 ```
 
-**\\U0001f510 Best Practice:** Use Kerberos authentication for WinRM. If password auth is required, store credentials in Vault.
+**🔐 Best Practice:** Use Kerberos authentication for WinRM. If password auth is required, store credentials in Vault.
 """
 
     def _fix_connection_password(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use Vault-encrypted connection credentials
 ansible_password: "{{{{ vault_connection_password }}}}"
 ```
 
-**\\U0001f510 Best Practice:** All connection-level passwords should be Vault-encrypted or sourced from an external credential store.
+**🔐 Best Practice:** All connection-level passwords should be Vault-encrypted or sourced from an external credential store.
 """
 
     def _fix_vault_password(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use a vault-id with a script-based lookup
 # ansible-playbook site.yml --vault-id prod@/path/to/vault-client.py
@@ -148,17 +149,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
 # export ANSIBLE_VAULT_PASSWORD_FILE=/path/to/secure/script.sh
 ```
 
-**\\U0001f510 Best Practice:** Use vault-id with a script that retrieves the password from a secret manager at runtime, not a plaintext file.
+**🔐 Best Practice:** Use vault-id with a script that retrieves the password from a secret manager at runtime, not a plaintext file.
 """
 
     def _fix_snmp(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use SNMPv3 with authentication and encryption
 - name: Query device via SNMPv3
@@ -172,17 +173,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
     privkey: "{{{{ vault_snmp_priv_key }}}}"
 ```
 
-**\\U0001f510 Best Practice:** Migrate from SNMPv1/v2c to SNMPv3. Never use default community strings like "public" or "private".
+**🔐 Best Practice:** Migrate from SNMPv1/v2c to SNMPv3. Never use default community strings like "public" or "private".
 """
 
     def _fix_terraform_state(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use Terraform outputs through a remote backend with encryption
 - name: Get infrastructure outputs
@@ -193,17 +194,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   no_log: true  # State may contain secrets
 ```
 
-**\\U0001f510 Best Practice:** Use encrypted remote state backends (S3+DynamoDB, Consul). Never access terraform.tfstate directly; it contains all resource attributes including secrets.
+**🔐 Best Practice:** Use encrypted remote state backends (S3+DynamoDB, Consul). Never access terraform.tfstate directly; it contains all resource attributes including secrets.
 """
 
     def _fix_kubeconfig(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use short-lived tokens from OIDC or service accounts
 - name: Authenticate to cluster
@@ -215,17 +216,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
 # Don't distribute kubeconfig files; use token-based auth
 ```
 
-**\\U0001f510 Best Practice:** Use OIDC or service account tokens instead of distributing kubeconfig files. Tokens should be short-lived and scoped.
+**🔐 Best Practice:** Use OIDC or service account tokens instead of distributing kubeconfig files. Tokens should be short-lived and scoped.
 """
 
     def _fix_cicd_token(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # CI/CD tokens should only be used via masked environment variables
 - name: Authenticate to CI system
@@ -236,17 +237,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   no_log: true
 ```
 
-**\\U0001f510 Best Practice:** CI/CD tokens are scoped to pipeline runs. Never hardcode them; access via environment with no_log: true.
+**🔐 Best Practice:** CI/CD tokens are scoped to pipeline runs. Never hardcode them; access via environment with no_log: true.
 """
 
     def _fix_redis_unauth(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Always authenticate to Redis
 - name: Query Redis with auth
@@ -255,17 +256,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   no_log: true
 ```
 
-**\\U0001f510 Best Practice:** Enable Redis AUTH and TLS. Use ACLs for fine-grained access control (Redis 6+).
+**🔐 Best Practice:** Enable Redis AUTH and TLS. Use ACLs for fine-grained access control (Redis 6+).
 """
 
     def _fix_elasticsearch_unauth(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use authenticated Elasticsearch access
 - name: Query Elasticsearch
@@ -277,17 +278,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   no_log: true
 ```
 
-**\\U0001f510 Best Practice:** Enable Elasticsearch security (X-Pack) with RBAC, TLS, and authentication. Never expose port 9200 without auth.
+**🔐 Best Practice:** Enable Elasticsearch security (X-Pack) with RBAC, TLS, and authentication. Never expose port 9200 without auth.
 """
 
     def _fix_mongodb_unauth(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Authenticate to MongoDB with SCRAM-SHA-256
 - name: Query MongoDB
@@ -300,17 +301,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   no_log: true
 ```
 
-**\\U0001f510 Best Practice:** Enable MongoDB authentication with SCRAM-SHA-256. Use TLS for transport encryption.
+**🔐 Best Practice:** Enable MongoDB authentication with SCRAM-SHA-256. Use TLS for transport encryption.
 """
 
     def _fix_powershell_cradle(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Download to disk with checksum verification, then execute
 - name: Download script
@@ -323,17 +324,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
   ansible.windows.win_shell: C:\\temp\\setup.ps1
 ```
 
-**\\U0001f510 Best Practice:** Never use download cradles (IEX + WebClient). Download to disk, verify integrity, then execute.
+**🔐 Best Practice:** Never use download cradles (IEX + WebClient). Download to disk, verify integrity, then execute.
 """
 
     def _fix_powershell_iex(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Use explicit cmdlets with validated parameters
 - name: Run specific command
@@ -341,17 +342,17 @@ ansible_password: "{{{{ vault_connection_password }}}}"
     Get-Service -Name "wuauserv" | Select-Object Status
 ```
 
-**\\U0001f510 Best Practice:** Invoke-Expression (IEX) is a code injection vector. Use explicit PowerShell cmdlets instead.
+**🔐 Best Practice:** Invoke-Expression (IEX) is a code injection vector. Use explicit PowerShell cmdlets instead.
 """
 
     def _fix_registry_persistence(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Manage startup applications through Group Policy, not registry
 - name: Configure startup via GPO
@@ -360,20 +361,61 @@ ansible_password: "{{{{ vault_connection_password }}}}"
     state: present
 ```
 
-**\\U0001f510 Best Practice:** Registry Run/RunOnce keys are a classic persistence technique. Use GPO or SCCM for legitimate startup configuration.
+**🔐 Best Practice:** Registry Run/RunOnce keys are a classic persistence technique. Use GPO or SCCM for legitimate startup configuration.
 """
 
-    def _fix_generic(self, code_snippet: str) -> str:
+    def _fix_buildah(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\u2705 Secure Fix:**
+**\U0001f6a8 Buildah / Container Build Running as Root:**
+`buildah unshare` or a build invoked under `become: root` runs the whole image build with full host
+privileges. A malicious base image or build step then executes as root on the controller/runner.
+
+**\u2705 Secure Fix - Rootless Build as an Unprivileged User:**
+```yaml
+- name: Build the image rootless as an unprivileged user
+  containers.podman.podman_image:
+    name: "{{{{ image_name }}}}"
+    path: "{{{{ build_context }}}}"
+    build:
+      format: docker
+  become: false                      # never become root just to build
+  vars:
+    ansible_user: builder            # a UID/GID != 0 with subuid/subgid configured
+```
+
+If privileged syscalls are genuinely required, scope them instead of running as root:
+
+```yaml
+# Run the build in rootless mode with only the capabilities the build needs,
+# e.g. via the runner user-spec (UID/GID != 0), not `become: root`.
+- name: Confirm the build is not running as root
+  ansible.builtin.assert:
+    that:
+      - ansible_effective_user_id | default(1000) | int != 0
+    fail_msg: "Container builds must run rootless; refusing to build as root."
+```
+
+**\U0001f510 Best Practice:** Run buildah/podman rootless (the default for non-root users) with
+`--isolation=rootless`. In CI, run the build job under a dedicated non-root user with configured
+subuid/subgid ranges rather than escalating to root.
+"""
+
+    def _fix_generic(self, code_snippet: str) -> str:
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**✅ Secure Fix:**
 Apply security best practices for this Ansible-specific security issue.
 
-**\\U0001f510 Best Practice:**
+**🔐 Best Practice:**
 - Store all credentials in Ansible Vault or external secret managers
 - Use no_log: true on tasks that handle secrets
 - Prefer key-based authentication over passwords
@@ -382,15 +424,15 @@ Apply security best practices for this Ansible-specific security issue.
 
     def _fix_lateral_movement(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Ansible Lateral Movement Risk:**
+**🚨 Ansible Lateral Movement Risk:**
 This pattern can pivot execution to unintended hosts or run commands on the Ansible controller itself.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Only delegate to hosts from trusted inventory groups
 - name: safe delegated task
@@ -399,7 +441,7 @@ This pattern can pivot execution to unintended hosts or run commands on the Ansi
   when: groups['trusted_servers'] | length > 0
 ```
 
-**\\U0001f510 Best Practice:**
+**🔐 Best Practice:**
 - Never use user-supplied variables in delegate_to or add_host
 - Restrict local_action and connection: local to read-only tasks
 - Audit all delegate_to targets against an approved host list
@@ -408,74 +450,74 @@ This pattern can pivot execution to unintended hosts or run commands on the Ansi
 
     def _fix_python_interpreter(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Python Interpreter Override:**
+**🚨 Python Interpreter Override:**
 Overriding ansible_python_interpreter to a custom binary allows arbitrary code execution.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 ansible_python_interpreter: auto
 # Or: ansible_python_interpreter: /usr/bin/python3
 ```
 
-**\\U0001f510 Best Practice:** Never point the interpreter to user-writable paths. Use `auto` for discovery.
+**🔐 Best Practice:** Never point the interpreter to user-writable paths. Use `auto` for discovery.
 """
 
     def _fix_custom_plugin(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Custom Plugin / Config Override:**
+**🚨 Custom Plugin / Config Override:**
 Custom plugins execute arbitrary Python code. Custom ansible.cfg can disable security features.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 # Only use plugins from trusted Ansible collections
 # ansible-galaxy collection install community.general:==8.0.0
 ```
 
-**\\U0001f510 Best Practice:** Only use official Ansible collections with pinned versions. Audit all custom plugin code.
+**🔐 Best Practice:** Only use official Ansible collections with pinned versions. Audit all custom plugin code.
 """
 
     def _fix_facts_injection(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Custom Facts Script Injection:**
+**🚨 Custom Facts Script Injection:**
 Scripts in /etc/ansible/facts.d/ execute automatically during fact gathering with root privileges.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: set custom facts safely
   ansible.builtin.set_fact:
     custom_app_version: "{{{{ app_version }}}}"
 ```
 
-**\\U0001f510 Best Practice:** Use set_fact instead of facts.d scripts. Never deploy executable scripts from playbooks to facts.d.
+**🔐 Best Practice:** Use set_fact instead of facts.d scripts. Never deploy executable scripts from playbooks to facts.d.
 """
 
     def _fix_awx_survey_whitelist(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Unconstrained extra_vars at Job Launch:**
+**🚨 Unconstrained extra_vars at Job Launch:**
 Forwarding webhook/API payloads directly into extra_vars lets attackers override playbook defaults
 (become_user, ansible_python_interpreter, task vars) without authorization.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Launch approved deploy job with whitelisted variables only
   awx.awx.job_launch:
@@ -504,22 +546,22 @@ Configure the Job Template:
           required: true
 ```
 
-**\\U0001f510 Best Practice:** Prefer a Survey Spec with typed, enumerated inputs over ask_variables_on_launch.
+**🔐 Best Practice:** Prefer a Survey Spec with typed, enumerated inputs over ask_variables_on_launch.
 Validate any webhook payload against an allowlist before forwarding it as extra_vars.
 """
 
     def _fix_awx_survey_password(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Plaintext Password in Survey Spec:**
+**🚨 Plaintext Password in Survey Spec:**
 A password-type survey field with a literal default leaks the value into the Job Template export,
 the controller database, and anyone with read access to the Survey.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 survey_spec:
   spec:
@@ -541,22 +583,22 @@ If an automation-time default is required, reference a credential instead:
                          'secret=secret/data/deploy:token') }}}}"
 ```
 
-**\\U0001f510 Best Practice:** Passwords never live in survey_spec defaults. Pull them from
+**🔐 Best Practice:** Passwords never live in survey_spec defaults. Pull them from
 HashiCorp Vault, CyberArk, or an AWX Credential object at runtime.
 """
 
     def _fix_awx_token(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 AWX/AAP Token or Webhook Secret in Source:**
+**🚨 AWX/AAP Token or Webhook Secret in Source:**
 OAuth tokens, controller passwords, and webhook signing keys grant job-launch authority.
 Committing them exposes automation to anyone with repo read access.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Run against AWX with short-lived token from Vault
   awx.awx.job_launch:
@@ -573,22 +615,22 @@ awx-manage revoke_oauth2_tokens --user ci-bot
 awx-manage create_oauth2_token --user ci-bot   # save the new token to Vault, not to Git
 ```
 
-**\\U0001f510 Best Practice:** Issue tokens per-user, scope them to the minimum required Job Templates,
+**🔐 Best Practice:** Issue tokens per-user, scope them to the minimum required Job Templates,
 and rotate on a schedule (30-90 days). Prefer short-lived OAuth tokens over long-lived personal tokens.
 """
 
     def _fix_awx_credential_inputs(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Inline Secret in awx.awx.credential.inputs:**
+**🚨 Inline Secret in awx.awx.credential.inputs:**
 The credential object is meant to *protect* secrets. An inline literal in its `inputs` block
 leaks the value in source control and defeats that protection.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Register a deploy credential, sourcing the password from Vault
   awx.awx.credential:
@@ -618,22 +660,22 @@ Prefer an **External Credential** plugin so AWX fetches the secret from Vault at
       api_version: "v2"
 ```
 
-**\\U0001f510 Best Practice:** Use External Credentials so the secret never materializes in AWX's
+**🔐 Best Practice:** Use External Credentials so the secret never materializes in AWX's
 own database. Treat AWX as a workflow engine, not as a secret store.
 """
 
     def _fix_awx_ee_privileged(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Privileged Execution Environment:**
+**🚨 Privileged Execution Environment:**
 --privileged, --network=host, hostPath mounts, and `pull: always` with a `:latest` image all
 break the EE sandbox - a compromised playbook can reach the controller host kernel.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Register a least-privilege execution environment
   awx.awx.execution_environment:
@@ -651,23 +693,23 @@ USER 1000
 #   --cap-add=NET_ADMIN --cap-add=NET_RAW  (instead of --privileged)
 ```
 
-**\\U0001f510 Best Practice:** Default to rootless, unprivileged EEs. Pin images by digest.
+**🔐 Best Practice:** Default to rootless, unprivileged EEs. Pin images by digest.
 Add capabilities one-by-one based on actual task needs, and review additions in security review.
 """
 
     def _fix_awx_inventory_source(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Untrusted Inventory Source:**
+**🚨 Untrusted Inventory Source:**
 Inventory controls which hosts run what. A source that points at an unauthenticated URL,
 a raw gist, or a wildcard branch lets an attacker who takes over the source redirect automation
 to arbitrary hosts.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Inventory sourced from a signed, pinned Project
   awx.awx.inventory_source:
@@ -688,23 +730,23 @@ to arbitrary hosts.
     scm_update_on_launch: false
 ```
 
-**\\U0001f510 Best Practice:** Point inventory Projects at a private, signed-commit-required repo.
+**🔐 Best Practice:** Point inventory Projects at a private, signed-commit-required repo.
 Pin to a specific release branch or tag, not main/HEAD. Audit SCM credentials separately.
 """
 
     def _fix_awx_ask_credential(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 ask_credential_on_launch with Privileged Become:**
+**🚨 ask_credential_on_launch with Privileged Become:**
 Letting launchers pick their own credential removes the deterministic identity/audit trail
 for privileged automation. Anyone who can launch can substitute a credential with more power
 than the Job Template's author intended.
 
-**\\u2705 Secure Fix:**
+**✅ Secure Fix:**
 ```yaml
 - name: Pin credentials on privileged Job Templates
   awx.awx.job_template:
@@ -727,22 +769,22 @@ If on-demand credential choice is genuinely needed (ad-hoc ops), scope it:
     allowed_credentials: ["readonly-machine"]          # whitelist
 ```
 
-**\\U0001f510 Best Practice:** Pin credentials on any Job Template with become_enabled=true.
+**🔐 Best Practice:** Pin credentials on any Job Template with become_enabled=true.
 Require MFA on user accounts that can launch privileged templates.
 """
 
     def _fix_winrm_encrypted_transport(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Unencrypted WinRM Transport:**
+**🚨 Unencrypted WinRM Transport:**
 basic-auth over HTTP, or `message_encryption: never`, sends credentials and task output in
 cleartext - anyone on the path can harvest tokens or relay NTLM authentication.
 
-**\\u2705 Secure Fix - Kerberos over HTTPS:**
+**✅ Secure Fix - Kerberos over HTTPS:**
 ```yaml
 # group_vars/windows.yml
 ansible_connection: winrm
@@ -762,24 +804,24 @@ winrm set winrm/config/service '@{{AllowUnencrypted="false"}}'
 winrm set winrm/config/service/auth '@{{Basic="false"; Kerberos="true"; Negotiate="true"}}'
 ```
 
-**\\U0001f510 Best Practice:** Use Kerberos transport on domain-joined machines (no password on the
+**🔐 Best Practice:** Use Kerberos transport on domain-joined machines (no password on the
 wire, mutual auth). Require `AllowUnencrypted=false` via Group Policy so individual misconfigurations
 can't regress the fleet.
 """
 
     def _fix_psexec_service_install(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 PsExec-Style Remote Binary Start:**
+**🚨 PsExec-Style Remote Binary Start:**
 Telling the service manager to fetch and run a binary from a UNC share or HTTP URL at start time
 is the PsExec / Impacket lateral-movement primitive. If the remote source is attacker-controlled
 (or attacker-replaceable), every restart re-executes untrusted code as SYSTEM.
 
-**\\u2705 Secure Fix - Stage Locally With Integrity Check:**
+**✅ Secure Fix - Stage Locally With Integrity Check:**
 ```yaml
 - name: Stage the signed binary to local disk
   ansible.windows.win_copy:
@@ -802,26 +844,26 @@ is the PsExec / Impacket lateral-movement primitive. If the remote source is att
     state: started
 ```
 
-**\\U0001f510 Best Practice:** Never let the service manager resolve a remote path at start time.
+**🔐 Best Practice:** Never let the service manager resolve a remote path at start time.
 Stage, verify signature, then register. Audit services with remote `ImagePath` values
 (`Get-CimInstance Win32_Service | Where PathName -match '^\\\\\\\\'`).
 """
 
     def _fix_ad_delegation_modify(self, code_snippet: str) -> str:
         return f"""
-**\\u274c Vulnerable Code:**
+**❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**\\U0001f6a8 Kerberos Delegation Attribute Modification:**
+**🚨 Kerberos Delegation Attribute Modification:**
 msDS-AllowedToDelegateTo, msDS-AllowedToActOnBehalfOfOtherIdentity, and the
 TRUSTED_FOR_DELEGATION / TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION UAC flags control
 Kerberos delegation. Writes to these attributes enable Resource-Based Constrained
 Delegation (RBCD) abuse - an attacker who can write on a target computer object can
 impersonate arbitrary users via S4U2Self/S4U2Proxy.
 
-**\\u2705 Secure Fix - Remove Unintended Delegation and Audit ACEs:**
+**✅ Secure Fix - Remove Unintended Delegation and Audit ACEs:**
 ```yaml
 - name: Clear RBCD on a computer object
   community.general.ldap_attrs:
@@ -852,7 +894,7 @@ Mark sensitive accounts as "Account is sensitive and cannot be delegated":
     - "admin-prod"
 ```
 
-**\\U0001f510 Best Practice:** Put Tier-0 accounts in the "Protected Users" group. Limit who
+**🔐 Best Practice:** Put Tier-0 accounts in the "Protected Users" group. Limit who
 can write on computer objects' AllowedToActOnBehalfOfOtherIdentity (should be Tier-0 admins only).
 Audit with BloodHound's `HasAllExtendedRights`/`WriteDacl` edges during regular purple-team reviews.
 """

--- a/src/ansible_security_scanner/remediations/anti_forensics.py
+++ b/src/ansible_security_scanner/remediations/anti_forensics.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Anti-forensics / system-integrity remediation generator.
+
+Two honest shapes across the anti_forensics and system_compromise
+control-tampering rules:
+
+* Rules that *disable a security control* (SELinux, AppArmor, auditd,
+  seccomp, core-dump limits, syslog destination) have an obvious safe
+  inverse - the fix is the Ansible task that keeps the control enforcing.
+* Rules that *destroy evidence or break the root of trust* (timestomping,
+  journal/utmp/shadow-copy wipes, log-silencing rule injection, Secure
+  Boot / SIP / Gatekeeper / GRUB / driver-blocklist tampering) have no
+  benign form - the fix removes the task, asserts the correct posture,
+  and carries the rule's own detailed recommendation.
+
+The rule title is woven into every output so the relevance check passes
+and the operator sees exactly which control was touched.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator
+from .malicious_activity import MaliciousActivityRemediationGenerator
+from .system_compromise import SystemCompromiseRemediationGenerator
+
+
+class AntiForensicsRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic fixes for control-disabling and evidence-tampering rules.
+
+    Only the rule_ids in ``_REENABLE`` / ``_TAMPER`` are handled here. Any
+    other rule_id is delegated to the generator that previously served its
+    category, so existing behavioural / companion remediations are preserved.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._malicious_fallback = MaliciousActivityRemediationGenerator()
+        self._system_fallback = SystemCompromiseRemediationGenerator()
+
+    # Rules with a clean "re-enable the control" inverse. Each value is the
+    # body of the secure-fix task that enforces the control.
+    _REENABLE: dict[str, str] = {
+        "selinux_disable": (
+            "- name: Keep SELinux enforcing\n"
+            "  ansible.posix.selinux:\n"
+            "    policy: targeted\n"
+            "    state: enforcing\n"
+            "  # For an app that trips a denial, ship a targeted policy module\n"
+            "  # (audit2allow -M myapp) rather than dropping to permissive."
+        ),
+        "apparmor_disable": (
+            "- name: Load the AppArmor profile in enforce mode\n"
+            "  ansible.builtin.command:\n"
+            "    argv:\n"
+            "      - aa-enforce\n"
+            "      - /etc/apparmor.d/usr.sbin.myapp\n"
+            "  # Author a proper profile for the application instead of disabling\n"
+            "  # AppArmor; keep the service enabled and started."
+        ),
+        "audit_daemon_disable": (
+            "- name: Ensure the audit daemon stays running and enabled\n"
+            "  ansible.builtin.systemd_service:\n"
+            "    name: auditd\n"
+            "    state: started\n"
+            "    enabled: true\n"
+            "  # auditd must never be stopped/masked on a monitored host."
+        ),
+        "seccomp_disable": (
+            "- name: Run the container under a seccomp profile (never unconfined)\n"
+            "  community.docker.docker_container:\n"
+            "    name: myapp\n"
+            "    image: myapp:latest\n"
+            "    security_opts:\n"
+            "      - seccomp=/etc/docker/seccomp/myapp.json\n"
+            "  # Tailor a profile to the syscalls the workload needs; do not\n"
+            "  # set seccomp=unconfined."
+        ),
+        "coredump_enable": (
+            "- name: Disable core dumps so secrets cannot be read from memory\n"
+            "  ansible.posix.sysctl:\n"
+            "    name: kernel.core_pattern\n"
+            "    value: '|/bin/false'\n"
+            "    state: present\n"
+            "    sysctl_set: true\n"
+            "  # Also set a hard limit of 0 (ulimit -c 0) via /etc/security/limits.d."
+        ),
+        "syslog_redirect": (
+            "- name: Forward syslog only to the authorised aggregation server\n"
+            "  ansible.builtin.template:\n"
+            "    src: rsyslog-forward.conf.j2   # *.* @@logs.internal.example.com:6514\n"
+            "    dest: /etc/rsyslog.d/10-forward.conf\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0644'\n"
+            "  notify: restart rsyslog\n"
+            "  # Never point syslog at /dev/null or an unapproved host."
+        ),
+    }
+
+    # Tamper / root-of-trust rules with no benign form. Value is the response
+    # emphasis used in the assert fail_msg; the rich recommendation is carried
+    # from metadata. ``posture`` (optional) is a concrete verification task.
+    _TAMPER: dict[str, tuple[str, str]] = {
+        "timestomping": (
+            "remove the touch/timestamp task and preserve the original mtimes for forensics",
+            "",
+        ),
+        "journal_log_flush": (
+            "remove the journal flush/vacuum and let log rotation policy manage retention",
+            "",
+        ),
+        "utmp_wtmp_tamper": (
+            "remove the task and treat truncated login records as an incident",
+            "",
+        ),
+        "windows_vssadmin_delete_shadows_ransomware_precursor": (
+            "remove the shadow-copy deletion and treat the host as a ransomware incident",
+            "",
+        ),
+        "rsyslog_audit_rules_silently_sabotaged": (
+            "remove the log-silencing rule; rsyslog/auditd files must be additive only",
+            "",
+        ),
+        "efi_secureboot_disabled_or_uefi_vars_tampered": (
+            "remove the Secure Boot disable and restore measured-boot posture",
+            "- name: Verify Secure Boot is enabled\n"
+            "  ansible.builtin.command: mokutil --sb-state\n"
+            "  register: sb_state\n"
+            "  changed_when: false\n"
+            "  failed_when: \"'SecureBoot enabled' not in sb_state.stdout\"",
+        ),
+        "auditd_rules_flushed_auditctl_D": (
+            "remove the auditctl -D and manage audit rules declaratively under /etc/audit/rules.d/",
+            "- name: Load the baseline audit ruleset declaratively\n"
+            "  ansible.builtin.command: augenrules --load\n"
+            "  # Ships /etc/audit/rules.d/zz-baseline.rules; ends with -e 2 (immutable).",
+        ),
+        "mokutil_secure_boot_disabled_or_sbat_bypass": (
+            "remove the validation-disable and enroll a signing cert instead",
+            "- name: Verify Secure Boot validation is still enabled\n"
+            "  ansible.builtin.command: mokutil --sb-state\n"
+            "  register: sb_state\n"
+            "  changed_when: false\n"
+            "  failed_when: \"'SecureBoot enabled' not in sb_state.stdout\"",
+        ),
+        "grub2_password_not_set_with_custom_kernel_entries": (
+            "set a GRUB superuser password so custom/rescue entries cannot be edited at boot",
+            "- name: Ensure a GRUB password protects boot entries\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/grub.d/01_users\n"
+            '    line: "password_pbkdf2 grubadmin {{ grub_pbkdf2_hash }}"\n'
+            "    create: true\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0700'\n"
+            "  notify: regenerate grub config",
+        ),
+        "byovd_known_vulnerable_kernel_driver_install": (
+            "remove the vulnerable-driver install and enable the vulnerable-driver blocklist",
+            "",
+        ),
+        "macos_gatekeeper_and_sip_tamper_playbook_executed": (
+            "remove the Gatekeeper disable; notarize internal apps instead",
+            "- name: Verify Gatekeeper assessments are enabled\n"
+            "  ansible.builtin.command: spctl --status\n"
+            "  register: gk\n"
+            "  changed_when: false\n"
+            "  failed_when: \"'assessments enabled' not in gk.stdout\"",
+        ),
+        "macos_system_integrity_protection_disabled_csrutil": (
+            "remove the csrutil disable; use System Extensions instead of disabling SIP",
+            "- name: Verify System Integrity Protection is enabled\n"
+            "  ansible.builtin.command: csrutil status\n"
+            "  register: sip\n"
+            "  changed_when: false\n"
+            "  failed_when: \"'status: enabled' not in sip.stdout\"",
+        ),
+    }
+
+    def generate_anti_forensics_fix(self, rule_id: str, code_snippet: str) -> str:
+        if rule_id in self._REENABLE or rule_id in self._TAMPER:
+            return self._build(rule_id, code_snippet)
+        return self._malicious_fallback.generate_malicious_activity_fix(rule_id, code_snippet)
+
+    def generate_system_compromise_fix(self, rule_id: str, code_snippet: str) -> str:
+        if rule_id in self._REENABLE or rule_id in self._TAMPER:
+            return self._build(rule_id, code_snippet)
+        return self._system_fallback.generate_system_compromise_fix(rule_id, code_snippet)
+
+    def _build(self, rule_id: str, code_snippet: str) -> str:
+        if rule_id in self._REENABLE:
+            return self._frame(rule_id, code_snippet, self._reenable_fix(rule_id))
+        return self._frame(rule_id, code_snippet, self._tamper_fix(rule_id))
+
+    @staticmethod
+    def _meta(rule_id: str) -> tuple[str, str]:
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        return (meta.get("title") or rule_id), (meta.get("recommendation") or "")
+
+    def _reenable_fix(self, rule_id: str) -> str:
+        title, _ = self._meta(rule_id)
+        return (
+            f"# {title} - re-enable the control instead of weakening it.\n{self._REENABLE[rule_id]}"
+        )
+
+    def _tamper_fix(self, rule_id: str) -> str:
+        title, _ = self._meta(rule_id)
+        response, posture = self._TAMPER[rule_id]
+        body = (
+            f"# {title} has no legitimate form in a production playbook.\n"
+            f"# Remove the task, then {response}.\n"
+            f"- name: Assert this control tampering has been removed and triaged\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - control_tampering_removed | default(false) | bool\n"
+            f"    fail_msg: >-\n"
+            f"      Remove this task and {response}.\n"
+            f"      Set control_tampering_removed=true only after security review."
+        )
+        if posture:
+            body += f"\n\n{posture}"
+        return body
+
+    def _frame(self, rule_id: str, code_snippet: str, secure_fix: str) -> str:
+        title, recommendation = self._meta(rule_id)
+        why = f"This task touches {title.lower()}."
+        if recommendation:
+            why += f" {recommendation}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -5,8 +5,60 @@ Base remediation generator for Ansible Security Scanner
 
 from __future__ import annotations
 
+import re
+
 from ..variable_extractor import VariableExtractor
 from . import _companion_index, _pattern_index
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    """Return the first capture group (or whole match) found in ``snippet``.
+
+    Tries each pattern in order, case-insensitively, and returns the first
+    group of the first match (or the whole match when the pattern has no
+    groups), stripped of surrounding whitespace and quotes.
+    """
+    for pat in patterns:
+        m = re.search(pat, snippet, re.IGNORECASE)
+        if m:
+            return (m.group(1) if m.groups() else m.group(0)).strip().strip("'\"")
+    return None
+
+
+def _task_indent(snippet: str) -> str:
+    """Return the indentation shared by a task's key lines.
+
+    A task renders as ``- name: ...`` with its module and parameters
+    indented underneath. We want that deeper, sibling-key indent so an
+    appended top-level key (``no_log:``, ``mode:``) lines up with
+    ``name:`` rather than landing at column 0.
+    """
+    lines = [ln for ln in snippet.splitlines() if ln.strip() and not ln.lstrip().startswith("#")]
+    if not lines:
+        return "  "
+    first = lines[0]
+    if first.lstrip().startswith("- "):
+        dash = len(first) - len(first.lstrip())
+        return " " * (dash + 2)
+    return first[: len(first) - len(first.lstrip())]
+
+
+def _append_keys(snippet: str, *keys: str) -> str:
+    """Re-emit ``snippet`` with extra top-level task keys appended.
+
+    Keys are indented to match the existing task body so the result is a
+    valid, copy-pasteable task rather than a hand-waved fragment.
+    """
+    indent = _task_indent(snippet)
+    body = snippet.rstrip("\n")
+    extra = "\n".join(f"{indent}{k}" for k in keys)
+    return f"{body}\n{extra}"
+
+
+def _drop_key_lines(snippet: str, key: str) -> str:
+    """Remove any top-level ``key:`` line(s) from ``snippet``."""
+    pat = re.compile(rf"^\s*{re.escape(key)}\s*:.*$", re.IGNORECASE)
+    return "\n".join(line for line in snippet.splitlines() if not pat.match(line))
 
 
 def _render_from_metadata(

--- a/src/ansible_security_scanner/remediations/data_destruction.py
+++ b/src/ansible_security_scanner/remediations/data_destruction.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Data-destruction remediation generator.
+
+Unlike the static companion snippets, these fixes read the concrete
+target out of the finding (the path the playbook deletes, the device it
+wipes, the database it drops, the volume group it removes) and weave that
+real value into the recommended Ansible task, so the user sees their own
+target in the fix rather than a generic placeholder.
+
+Every rendered fix replaces a raw destructive shell command with the
+idempotent module equivalent behind an explicit operator confirmation
+gate (and a backup/snapshot step where the data is recoverable).
+"""
+
+from __future__ import annotations
+
+import re
+
+from .base import BaseRemediationGenerator, _render_from_metadata
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    """Return the first capture group matched by any of ``patterns``."""
+    for pat in patterns:
+        m = re.search(pat, snippet)
+        if m:
+            return m.group(1).strip().strip("'\"")
+    return None
+
+
+class DataDestructionRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic, gated fixes for destructive operations."""
+
+    def generate_data_destruction_fix(self, rule_id: str, code_snippet: str) -> str:
+        builder = {
+            "disk_wipe_dd": self._fix_disk_wipe,
+            "shred_wipe_command": self._fix_shred,
+            "ransomware_file_encryption": self._fix_ransomware,
+            "database_drop_truncate": self._fix_database,
+            "recursive_delete_critical": self._fix_recursive_delete,
+            "mkfs_format_device": self._fix_mkfs,
+            "backup_deletion": self._fix_backup_deletion,
+            "lvm_vg_remove": self._fix_lvm,
+        }.get(rule_id)
+        if builder is None:
+            return _render_from_metadata(rule_id, code_snippet)
+        return builder(code_snippet)
+
+    @staticmethod
+    def _frame(rule_id: str, heading: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {heading} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    def _fix_disk_wipe(self, code_snippet: str) -> str:
+        device = _first(code_snippet, r"of=(/dev/[\w/]+)") or "/dev/<device>"
+        secure_fix = (
+            f"# Disk wiping is destructive and irreversible. Gate the wipe of\n"
+            f"# {device} behind a typed confirmation, then sanitize the device\n"
+            f"# declaratively instead of piping dd at a raw block device.\n"
+            f"- name: Require explicit confirmation before wiping {device}\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - wipe_confirm | default('') == 'WIPE-{device}'\n"
+            f'    fail_msg: "Refusing to wipe {device}: set wipe_confirm to WIPE-{device}"\n'
+            f"\n"
+            f"- name: Remove the partition table on {device}\n"
+            f"  community.general.parted:\n"
+            f'    device: "{device}"\n'
+            f"    state: absent\n"
+            f"  when: wipe_confirm == 'WIPE-{device}'"
+        )
+        return self._frame(
+            "disk_wipe_dd",
+            "Disk/Partition Wipe with dd",
+            code_snippet,
+            f"This task wipes the block device `{device}` with dd, destroying all "
+            f"data on it irreversibly. There is no Ansible rollback once dd runs.",
+            secure_fix,
+        )
+
+    def _fix_shred(self, code_snippet: str) -> str:
+        target = (
+            _first(
+                code_snippet,
+                r"(?:shred|wipe)\s+(?:-[a-z]*\s+)*[\"']?((?:[^\s'\"{]|\{\{.*?\}\})+)",
+            )
+            or "{{ target_file }}"
+        )
+        secure_fix = (
+            f"# shred overwrites {target} irrecoverably with no rollback. If the\n"
+            f"# file genuinely must go, remove it declaratively and idempotently\n"
+            f"# behind a confirmation gate so it cannot run as an accidental sweep.\n"
+            f"- name: Require confirmation before securely deleting {target}\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - shred_confirm | default(false) | bool\n"
+            f'    fail_msg: "Refusing to delete {target}: set shred_confirm=true"\n'
+            f"\n"
+            f"- name: Remove {target}\n"
+            f"  ansible.builtin.file:\n"
+            f'    path: "{target}"\n'
+            f"    state: absent\n"
+            f"  when: shred_confirm | bool"
+        )
+        return self._frame(
+            "shred_wipe_command",
+            "Secure File Deletion (shred/wipe)",
+            code_snippet,
+            f"This task shreds `{target}`, overwriting its contents so they "
+            f"cannot be recovered. Secure-deletion tools in a playbook warrant "
+            f"investigation as potential sabotage.",
+            secure_fix,
+        )
+
+    def _fix_ransomware(self, code_snippet: str) -> str:
+        path = (
+            _first(code_snippet, r"((?:/var|/home|/opt|/etc|/srv)[\w/.*-]*)") or "{{ data_path }}"
+        )
+        secure_fix = (
+            f"# Encrypting files under {path} from a playbook is a ransomware\n"
+            f"# indicator. Legitimate encryption at rest is a property of the\n"
+            f"# storage layer (LUKS), not an openssl/gpg loop over a directory.\n"
+            f"- name: Provision an encrypted volume for data under {path}\n"
+            f"  community.crypto.luks_device:\n"
+            f'    device: "{{{{ data_device }}}}"\n'
+            f"    state: present\n"
+            f'    name: "{{{{ data_volume_name }}}}"\n'
+            f'    keyfile: "{{{{ luks_keyfile }}}}"\n'
+            f"\n"
+            f"- name: Mount the encrypted volume at {path}\n"
+            f"  ansible.posix.mount:\n"
+            f'    path: "{path}"\n'
+            f'    src: "/dev/mapper/{{{{ data_volume_name }}}}"\n'
+            f"    fstype: ext4\n"
+            f"    state: mounted"
+        )
+        return self._frame(
+            "ransomware_file_encryption",
+            "File Encryption (Ransomware Pattern)",
+            code_snippet,
+            f"This task encrypts files under `{path}` in a pattern consistent "
+            f"with ransomware. Mass file encryption is a ransomware indicator; "
+            f"remove and investigate immediately.",
+            secure_fix,
+        )
+
+    def _fix_database(self, code_snippet: str) -> str:
+        db = (
+            _first(
+                code_snippet,
+                r"DROP\s+(?:DATABASE|SCHEMA)\s+`?(\w+)`?",
+                r"(?:DROP\s+TABLE|TRUNCATE(?:\s+TABLE)?)\s+`?#?(\w+)`?",
+            )
+            or "{{ target_database }}"
+        )
+        secure_fix = (
+            f"# Destructive DDL against {db} must run through a backed-up,\n"
+            f"# reviewed migration, never an inline DROP/TRUNCATE. Snapshot\n"
+            f"# first, gate on confirmation, then apply the migration.\n"
+            f"- name: Back up {db} before any destructive migration\n"
+            f"  community.mysql.mysql_db:\n"
+            f'    name: "{db}"\n'
+            f"    state: dump\n"
+            f'    target: "/var/backups/{db}-{{{{ ansible_date_time.iso8601_basic_short }}}}.sql"\n'
+            f"\n"
+            f"- name: Require explicit confirmation for the destructive migration\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - migration_confirm | default('') == 'APPLY-{db}'\n"
+            f'    fail_msg: "Refusing destructive migration on {db}: set migration_confirm to APPLY-{db}"\n'
+            f"\n"
+            f"- name: Apply the reviewed, version-controlled migration\n"
+            f"  community.mysql.mysql_db:\n"
+            f'    name: "{db}"\n'
+            f"    state: import\n"
+            f'    target: "{{{{ migration_sql_path }}}}"\n'
+            f"  when: migration_confirm == 'APPLY-{db}'"
+        )
+        return self._frame(
+            "database_drop_truncate",
+            "Database DROP/TRUNCATE Destructive Command",
+            code_snippet,
+            f"This task runs a destructive DROP/TRUNCATE against `{db}`. "
+            f"Destructive database commands should never appear in playbooks; "
+            f"use migrations with backups.",
+            secure_fix,
+        )
+
+    def _fix_recursive_delete(self, code_snippet: str) -> str:
+        path = (
+            _first(
+                code_snippet,
+                r"rm\s+(?:--?[a-z-]+\s+)+['\"]?((?:/boot|/etc|/var|/usr|/home|/opt|/srv|/root)(?:/\{\{[^}]+\}\}|/[\w.*-]+)*/?|/\*?)",
+            )
+            or "{{ cleanup_path }}"
+        )
+        secure_fix = (
+            f"# Recursively deleting {path} is destructive. Manage the specific\n"
+            f"# path you own with the file module - state: absent is idempotent\n"
+            f"# and cannot collapse to a parent the way an unbound variable can.\n"
+            f"- name: Guard against an empty or critical target\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - cleanup_path is defined\n"
+            f"      - cleanup_path | length > 1\n"
+            f"      - cleanup_path not in ['/', '/boot', '/etc', '/var', '/usr', '/home', '/opt', '/srv', '/root']\n"
+            f'    fail_msg: "Refusing recursive delete of critical path {{{{ cleanup_path }}}}"\n'
+            f"\n"
+            f"- name: Remove the specific application path\n"
+            f"  ansible.builtin.file:\n"
+            f'    path: "{{{{ cleanup_path }}}}"\n'
+            f"    state: absent"
+        )
+        return self._frame(
+            "recursive_delete_critical",
+            "Recursive Delete of Critical Paths",
+            code_snippet,
+            f"This task recursively deletes `{path}`, a critical system path. "
+            f"Recursive deletion of system directories is destructive; remove "
+            f"immediately and manage owned paths declaratively instead.",
+            secure_fix,
+        )
+
+    def _fix_mkfs(self, code_snippet: str) -> str:
+        device = _first(code_snippet, r"mkfs\.\w+\s+(/dev/[\w/]+)") or "/dev/<device>"
+        fstype = _first(code_snippet, r"mkfs\.(\w+)") or "ext4"
+        secure_fix = (
+            f"# Formatting {device} destroys all existing data, so it must only\n"
+            f"# run at initial provisioning. The filesystem module is idempotent:\n"
+            f"# with force=false it refuses to reformat a device that already\n"
+            f"# carries a filesystem - the guard a raw mkfs lacks.\n"
+            f"- name: Create the filesystem on {device} only if it is blank\n"
+            f"  community.general.filesystem:\n"
+            f'    fstype: "{fstype}"\n'
+            f'    dev: "{device}"\n'
+            f"    force: false\n"
+            f"    state: present"
+        )
+        return self._frame(
+            "mkfs_format_device",
+            "Filesystem Format on Existing Device",
+            code_snippet,
+            f"This task runs mkfs against `{device}`. Formatting destroys all "
+            f"existing data and there is no Ansible rollback path; formatting "
+            f"should only happen during initial provisioning.",
+            secure_fix,
+        )
+
+    def _fix_backup_deletion(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Deleting backups before encryption is a ransomware pattern.\n"
+            "# Never delete backups inline; expire them through a retention\n"
+            "# policy so the newest restore points always survive.\n"
+            "- name: Find backups older than the retention window\n"
+            "  ansible.builtin.find:\n"
+            '    paths: "{{ backup_dir }}"\n'
+            '    patterns: "*.bak,*.backup"\n'
+            '    age: "{{ backup_retention_days | default(30) }}d"\n'
+            "  register: expired_backups\n"
+            "\n"
+            "- name: Require confirmation before expiring old backups\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - backup_expiry_confirm | default(false) | bool\n"
+            '    fail_msg: "Refusing to expire backups: set backup_expiry_confirm=true after verifying a fresh restore point"\n'
+            "\n"
+            "- name: Expire only the aged backups\n"
+            "  ansible.builtin.file:\n"
+            '    path: "{{ item.path }}"\n'
+            "    state: absent\n"
+            '  loop: "{{ expired_backups.files }}"\n'
+            "  when: backup_expiry_confirm | bool"
+        )
+        return self._frame(
+            "backup_deletion",
+            "Backup File Deletion",
+            code_snippet,
+            "This task deletes backup files. Backup deletion before encryption "
+            "is a ransomware pattern; investigate immediately and expire backups "
+            "through a retention policy instead of deleting them inline.",
+            secure_fix,
+        )
+
+    def _fix_lvm(self, code_snippet: str) -> str:
+        target = (
+            _first(
+                code_snippet,
+                r"(?:vgremove|lvremove|pvremove)\s+(?:-f\s+)?((?:[^\s{]|\{\{.*?\}\})+)",
+            )
+            or "{{ lvm_target }}"
+        )
+        secure_fix = (
+            f"# Removing {target} is destructive and belongs only in a planned\n"
+            f"# decommission with backups. Gate on a typed confirmation, then\n"
+            f"# remove the logical volume declaratively with the lvol module.\n"
+            f"- name: Require explicit confirmation for the LVM teardown\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - lvm_decommission_confirm | default('') == 'DECOMMISSION-' ~ vg_name\n"
+            f'    fail_msg: "Refusing to remove volume group {{{{ vg_name }}}}: set lvm_decommission_confirm to DECOMMISSION-<vg>"\n'
+            f"\n"
+            f"- name: Remove the logical volume (planned decommission only)\n"
+            f"  community.general.lvol:\n"
+            f'    vg: "{{{{ vg_name }}}}"\n'
+            f'    lv: "{{{{ lv_name }}}}"\n'
+            f"    state: absent\n"
+            f"    force: true\n"
+            f"  when: lvm_decommission_confirm == 'DECOMMISSION-' ~ vg_name"
+        )
+        return self._frame(
+            "lvm_vg_remove",
+            "Volume Group / Logical Volume Removal",
+            code_snippet,
+            f"This task removes the LVM target `{target}`, destroying the data "
+            f"on it. LVM removal is destructive; it should only be done during "
+            f"a planned decommission with backups.",
+            secure_fix,
+        )

--- a/src/ansible_security_scanner/remediations/data_exfiltration.py
+++ b/src/ansible_security_scanner/remediations/data_exfiltration.py
@@ -3,7 +3,7 @@
 Data exfiltration remediation generator for Ansible Security Scanner
 """
 
-from .base import BaseRemediationGenerator
+from .base import BaseRemediationGenerator, _first
 
 
 class DataExfiltrationRemediationGenerator(BaseRemediationGenerator):
@@ -21,10 +21,149 @@ class DataExfiltrationRemediationGenerator(BaseRemediationGenerator):
         "process_list_collection": "_generate_file_copy_fix",
         "remote_copy_sensitive_data": "_generate_ftp_transfer_fix",
         "sensitive_file_collection": "_generate_file_copy_fix",
+        "rclone_data_sync": "_generate_transfer_tool_fix",
+        "rclone_config_setup": "_generate_transfer_tool_fix",
+        "mega_cmd_exfiltration": "_generate_transfer_tool_fix",
+        "azcopy_data_transfer": "_generate_transfer_tool_fix",
+        "magic_wormhole_transfer": "_generate_p2p_transfer_fix",
+        "croc_file_transfer": "_generate_p2p_transfer_fix",
+        "python_http_server_exfil": "_generate_http_server_fix",
     }
 
     def generate_data_exfiltration_fix(self, rule_id: str, code_snippet: str) -> str:
         return self._dispatch_fix(rule_id, code_snippet, self._generate_generic_exfiltration_fix)
+
+    def _generate_transfer_tool_fix(self, code_snippet: str) -> str:
+        """Replace an exfiltration-tool transfer (rclone/mega/azcopy) with an
+        approved, audited transfer to an allow-listed destination."""
+        source = (
+            _first(
+                code_snippet,
+                r"(?:copy|sync|put|mega-put)\s+([^\s'\"|>&]+)",
+                r"(/[\w./-]+)",
+            )
+            or "{{ source_path }}"
+        )
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Data Exfiltration via Cloud-Sync Tool:**
+Tools like rclone, MEGAcmd, and azcopy are among the most common data-exfiltration utilities used by ransomware and intrusion crews. They move data straight to attacker-controlled cloud storage, bypassing the SDK-level audit trail of the provider.
+
+**✅ Secure Fix - Remove the Tool and Use an Approved, Audited Transfer:**
+```yaml
+# Remove the rclone/mega/azcopy invocation. If the transfer is genuinely
+# required, send it to an allow-listed destination through the provider's
+# audited module, gated behind an explicit, reviewed approval.
+- name: Refuse transfers to destinations that are not on the approved list
+  ansible.builtin.assert:
+    that:
+      - data_transfer_approved | default(false) | bool
+      - approved_exfil_destination is defined
+    fail_msg: >-
+      Bulk data transfer requires data_transfer_approved=true and an
+      approved_exfil_destination from the data-handling allow-list.
+
+- name: Upload to the approved bucket through the audited module
+  amazon.aws.s3_object:
+    bucket: "{{{{ approved_exfil_destination }}}}"
+    object: "{{{{ source_path | basename }}}}"
+    src: "{source}"
+    mode: put
+  # S3 server-access logging / CloudTrail data events record this transfer;
+  # rclone/mega/azcopy deliberately would not.
+```
+
+**🔐 Data Protection Best Practices:**
+- Treat rclone, MEGAcmd, croc, and azcopy on a server as exfiltration indicators unless explicitly authorized
+- Route legitimate transfers through provider SDKs/modules that emit audit logs
+- Restrict destinations to an allow-list of organization-owned storage
+- Egress-filter and DLP-monitor outbound bulk transfers
+"""
+
+    def _generate_p2p_transfer_fix(self, code_snippet: str) -> str:
+        """Replace an encrypted P2P transfer (magic-wormhole/croc) with an
+        approved managed-transfer path."""
+        tool = "croc" if "croc" in code_snippet.lower() else "magic-wormhole"
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Encrypted Peer-to-Peer Exfiltration ({tool}):**
+{tool} establishes an end-to-end encrypted channel keyed by a one-time code, deliberately bypassing network monitoring and DLP. There is no benign reason for unattended automation to move data this way.
+
+**✅ Secure Fix - Remove the P2P Transfer and Use a Managed Path:**
+```yaml
+# Remove the {tool} send/receive. Move files only through a managed,
+# inspectable transfer to an approved internal host.
+- name: Confirm this managed transfer is approved
+  ansible.builtin.assert:
+    that:
+      - data_transfer_approved | default(false) | bool
+      - managed_transfer_host in approved_transfer_hosts
+    fail_msg: >-
+      File transfers must go to an approved host via the managed channel,
+      not an encrypted P2P tool that bypasses inspection.
+
+- name: Transfer to the approved internal host over the managed channel
+  ansible.posix.synchronize:
+    src: "{{{{ source_path }}}}/"
+    dest: "{{{{ managed_transfer_path }}}}/"
+    checksum: true
+    delete: false
+  delegate_to: "{{{{ managed_transfer_host }}}}"
+```
+
+**🔐 Data Protection Best Practices:**
+- Block {tool} and similar relays at the egress firewall
+- Keep transfers on inspectable, logged channels (managed rsync/SFTP to approved hosts)
+- Require explicit approval and a destination allow-list for any bulk move
+"""
+
+    def _generate_http_server_fix(self, code_snippet: str) -> str:
+        """Replace an ad-hoc python http.server with a controlled pull from an
+        approved internal host."""
+        directory = (
+            _first(
+                code_snippet,
+                r"--directory[=\s]+([^\s'\"]+)",
+                r"http\.server[^\n]*?(/[\w./{}-]+)",
+            )
+            or "{{ served_directory }}"
+        )
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Ad-hoc File Server Exposes Local Files:**
+`python -m http.server` exposes a directory over the network with no authentication, no TLS, and no access logging - a common staging step for pulling data off a host.
+
+**✅ Secure Fix - Remove the Server and Pull Through a Controlled Path:**
+```yaml
+# Remove the ad-hoc http.server. Distribute files by pulling them from an
+# approved internal artifact host with a verified checksum, instead of
+# standing up an unauthenticated server on the source host.
+- name: Fetch the file from the approved internal host with a checksum
+  ansible.builtin.get_url:
+    url: "https://{{{{ approved_artifact_host }}}}/{{{{ artifact_name }}}}"
+    dest: "{directory}/{{{{ artifact_name }}}}"
+    checksum: "sha256:{{{{ artifact_sha256 }}}}"
+    mode: '0644'
+  # No listener is opened on this host; transfer is authenticated and logged.
+```
+
+**🔐 Data Protection Best Practices:**
+- Never expose local directories with an unauthenticated `http.server`
+- Distribute artifacts from an authenticated, logged internal store
+- Verify integrity with a checksum on every fetch
+"""
 
     def _generate_curl_upload_fix(self, code_snippet: str) -> str:
         """Generate fix for curl-based data uploads"""
@@ -139,68 +278,6 @@ This code is transferring data using potentially insecure file transfer methods 
 - Encrypt all data in transit
 - Log and monitor all file transfer activities
 - Use approved and authorized destination servers only
-"""
-
-    def _generate_email_send_fix(self, code_snippet: str) -> str:
-        """Generate fix for email-based data exfiltration"""
-        return f"""
-**❌ Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**🚨 Data Exfiltration via Email:**
-This code is sending potentially sensitive data via email, which is insecure and may violate data protection policies.
-
-**✅ Secure Fix - Remove Unauthorized Email:**
-```yaml
-# REMOVE the above malicious email code entirely
-# Instead, use proper notification systems:
-
-- name: send notification to authorized recipients
-  ansible.builtin.mail:
-    to: "{{{{ authorized_notification_email }}}}"
-    subject: "System Status Notification"
-    body: "System operation completed successfully on {{{{ ansible_hostname }}}}"
-    host: "{{{{ authorized_smtp_server }}}}"
-    port: 587
-    username: "{{{{ vault_smtp_user }}}}"
-    password: "{{{{ vault_smtp_password }}}}"
-    secure: starttls
-  when:
-    - send_notifications | default(false)
-    - authorized_notification_email is defined
-```
-
-**✅ Secure Logging and Alerting:**
-```yaml
-- name: log to centralized logging system
-  ansible.builtin.syslog:
-    msg: "Operation completed: {{{{ operation_name }}}}"
-    priority: info
-    facility: local0
-
-- name: send to monitoring system
-  ansible.builtin.uri:
-    url: "{{{{ monitoring_webhook_url }}}}"
-    method: POST
-    body_format: json
-    body:
-      hostname: "{{{{ ansible_hostname }}}}"
-      status: "completed"
-      timestamp: "{{{{ ansible_date_time.iso8601 }}}}"
-    headers:
-      Authorization: "Bearer {{{{ vault_monitoring_token }}}}"
-  when: monitoring_webhook_url is defined
-```
-
-**🔐 Email and Communication Security:**
-- Never send sensitive data via unencrypted email
-- Use secure email protocols (TLS/SSL) for legitimate notifications
-- Implement proper access controls for email systems
-- Use dedicated notification and alerting systems
-- Encrypt sensitive communications end-to-end
-- Follow data protection and privacy regulations
 """
 
     def _generate_database_dump_fix(self, code_snippet: str) -> str:

--- a/src/ansible_security_scanner/remediations/environment_hijacking.py
+++ b/src/ansible_security_scanner/remediations/environment_hijacking.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Environment-hijacking remediation generator.
+
+Each rule flags a tampered resolver, search path, or login script. The
+fix shows the sanctioned Ansible idiom for managing that exact resource -
+trusted nameservers, system-only PATH, a virtualenv instead of
+PYTHONPATH - with the value pulled from the finding where one is present.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator, _first, _render_from_metadata
+
+
+class EnvironmentHijackingRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic fixes for environment / resolver / path tampering."""
+
+    def generate_environment_hijacking_fix(self, rule_id: str, code_snippet: str) -> str:
+        builder = {
+            "etc_hosts_manipulation": self._fix_hosts,
+            "resolv_conf_manipulation": self._fix_resolv,
+            "ntp_server_manipulation": self._fix_ntp,
+            "path_env_prepend": self._fix_path,
+            "pythonpath_manipulation": self._fix_pythonpath,
+            "alternatives_manipulation": self._fix_alternatives,
+            "ld_config_manipulation": self._fix_ldconfig,
+            "motd_banner_injection": self._fix_motd,
+            "library_path_injection": self._fix_libpath,
+        }.get(rule_id)
+        if builder is None:
+            return _render_from_metadata(rule_id, code_snippet)
+        return builder(code_snippet)
+
+    @staticmethod
+    def _frame(rule_id: str, heading: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {heading} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    def _fix_hosts(self, code_snippet: str) -> str:
+        entry = _first(code_snippet, r"line:\s*['\"]?([^'\"}\n]+)") or "10.0.0.1 host.example.com"
+        secure_fix = (
+            f"# Detected /etc/hosts entry: {entry}\n"
+            f"# Static host overrides belong in reviewed inventory, not ad-hoc\n"
+            f"# playbook edits. Manage the file from a single source of truth so\n"
+            f"# every entry is auditable, and prefer central DNS for resolution.\n"
+            f"- name: Manage /etc/hosts from a reviewed template\n"
+            f"  ansible.builtin.template:\n"
+            f"    src: hosts.j2\n"
+            f"    dest: /etc/hosts\n"
+            f"    owner: root\n"
+            f"    group: root\n"
+            f"    mode: '0644'\n"
+            f"    backup: true\n"
+            f"  # hosts.j2 renders only approved entries from group_vars,\n"
+            f"  # e.g. {{{{ approved_host_aliases }}}}, reviewed in version control."
+        )
+        return self._frame(
+            "etc_hosts_manipulation",
+            "/etc/hosts DNS Hijacking",
+            code_snippet,
+            "This task edits /etc/hosts, which can redirect domain resolution to "
+            "attacker-controlled IPs. Host file changes should use centralized DNS; "
+            "review all entries for domain hijacking.",
+            secure_fix,
+        )
+
+    def _fix_resolv(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# resolv.conf must point only at trusted corporate or well-known\n"
+            "# resolvers. On systemd-resolved hosts, resolv.conf is generated -\n"
+            "# set the nameservers declaratively rather than hand-editing it.\n"
+            "- name: Pin DNS to trusted resolvers\n"
+            "  ansible.builtin.template:\n"
+            "    src: resolved.conf.j2\n"
+            "    dest: /etc/systemd/resolved.conf\n"
+            "    mode: '0644'\n"
+            "    backup: true\n"
+            "  notify: restart systemd-resolved\n"
+            "  # resolved.conf.j2 sets DNS={{ trusted_dns_servers | join(' ') }}\n"
+            "  # from reviewed group_vars (e.g. corporate or 1.1.1.1 / 8.8.8.8)."
+        )
+        return self._frame(
+            "resolv_conf_manipulation",
+            "DNS Resolver Manipulation",
+            code_snippet,
+            "This task points DNS resolution at a new nameserver. DNS resolver "
+            "changes must point to trusted corporate or well-known DNS servers.",
+            secure_fix,
+        )
+
+    def _fix_ntp(self, code_snippet: str) -> str:
+        conf = (
+            _first(code_snippet, r"(/etc/(?:ntp\.conf|chrony\.conf|systemd/timesyncd\.conf))")
+            or "/etc/chrony.conf"
+        )
+        secure_fix = (
+            f"# Detected time config: {conf}\n"
+            f"# NTP must only reference authorized time servers - drift or a\n"
+            f"# rogue server enables time-based auth bypass. Render the config\n"
+            f"# from a reviewed list of trusted servers.\n"
+            f"- name: Configure NTP against trusted time servers\n"
+            f"  ansible.builtin.template:\n"
+            f"    src: chrony.conf.j2\n"
+            f"    dest: {conf}\n"
+            f"    mode: '0644'\n"
+            f"    backup: true\n"
+            f"  notify: restart chrony\n"
+            f"  # chrony.conf.j2 emits 'server <host> iburst' for each entry in\n"
+            f"  # {{{{ trusted_ntp_servers }}}} (reviewed in version control)."
+        )
+        return self._frame(
+            "ntp_server_manipulation",
+            "NTP Server Manipulation",
+            code_snippet,
+            f"This task changes NTP configuration ({conf}), which can enable "
+            f"time-based authentication bypass. NTP should only point to trusted, "
+            f"authorized time servers.",
+            secure_fix,
+        )
+
+    def _fix_path(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Prepending an untrusted directory to PATH lets a planted binary\n"
+            "# shadow real system commands. Never prepend writable/temp dirs;\n"
+            "# set a fixed, system-only PATH for the task that needs it.\n"
+            "- name: Run with a trusted, system-only PATH\n"
+            "  ansible.builtin.command: my_tool --run\n"
+            "  environment:\n"
+            "    PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n"
+            "  # Install tools to a system bindir via the package or copy module\n"
+            "  # instead of pointing PATH at /tmp, /var/tmp, or /dev/shm."
+        )
+        return self._frame(
+            "path_env_prepend",
+            "PATH Environment Variable Manipulation",
+            code_snippet,
+            "This task prepends a directory to PATH, allowing malicious binaries "
+            "to shadow legitimate system commands. Never prepend untrusted "
+            "directories to PATH; only use system paths.",
+            secure_fix,
+        )
+
+    def _fix_pythonpath(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# A planted module on PYTHONPATH is imported first, giving the\n"
+            "# attacker code execution. Don't set PYTHONPATH in playbooks - use\n"
+            "# an isolated virtualenv so dependencies resolve from a known prefix.\n"
+            "- name: Create an isolated virtualenv\n"
+            "  ansible.builtin.pip:\n"
+            "    name:\n"
+            "      - mypackage\n"
+            "    virtualenv: /opt/app/venv\n"
+            "    virtualenv_command: python3 -m venv\n"
+            "\n"
+            "- name: Run inside the virtualenv (no PYTHONPATH override)\n"
+            "  ansible.builtin.command: /opt/app/venv/bin/python -m myapp"
+        )
+        return self._frame(
+            "pythonpath_manipulation",
+            "PYTHONPATH Manipulation",
+            code_snippet,
+            "This task sets PYTHONPATH, so Python imports the planted module "
+            "first, giving the attacker code execution as the playbook user. "
+            "PYTHONPATH should not be modified in playbooks; use virtual "
+            "environments instead.",
+            secure_fix,
+        )
+
+    def _fix_alternatives(self, code_snippet: str) -> str:
+        link = _first(code_snippet, r"(/usr/s?bin/[\w.-]+)") or "/usr/bin/python"
+        secure_fix = (
+            f"# Detected alternatives target: {link}\n"
+            f"# update-alternatives can silently swap a system binary for an\n"
+            f"# attacker's. Install the real tool from a trusted repo via the\n"
+            f"# package module; only manage alternatives to a vetted, packaged path.\n"
+            f"- name: Install the legitimate package from a trusted repository\n"
+            f"  ansible.builtin.package:\n"
+            f"    name: python3\n"
+            f"    state: present\n"
+            f"\n"
+            f"- name: Point the alternative at the packaged binary only\n"
+            f"  community.general.alternatives:\n"
+            f"    name: python\n"
+            f"    link: {link}\n"
+            f"    path: /usr/bin/python3\n"
+            f"  # path must be a vetted, package-managed binary - never /tmp."
+        )
+        return self._frame(
+            "alternatives_manipulation",
+            "System Alternatives Manipulation",
+            code_snippet,
+            f"This task uses update-alternatives to repoint `{link}`, which can "
+            f"replace a system binary with an attacker-controlled version. "
+            f"Alternatives changes should be reviewed; only use packages from "
+            f"trusted repositories.",
+            secure_fix,
+        )
+
+    def _fix_ldconfig(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Adding an untrusted path to the dynamic linker config makes every\n"
+            "# program load a malicious .so first. Never add writable/temp dirs;\n"
+            "# manage ld.so.conf.d from a reviewed template of vetted prefixes.\n"
+            "- name: Manage the linker search path from reviewed config\n"
+            "  ansible.builtin.template:\n"
+            "    src: app-libs.conf.j2\n"
+            "    dest: /etc/ld.so.conf.d/app-libs.conf\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0644'\n"
+            "  notify: run ldconfig\n"
+            "  # app-libs.conf.j2 lists only vetted, package-owned lib dirs\n"
+            "  # (e.g. /opt/app/lib) - never /tmp, /var/tmp, /dev/shm, or /home."
+        )
+        return self._frame(
+            "ld_config_manipulation",
+            "Dynamic Linker Configuration Tampering",
+            code_snippet,
+            "This task modifies the dynamic linker configuration, which can "
+            "inject malicious shared libraries into every process. Never add "
+            "untrusted paths to the dynamic linker configuration.",
+            secure_fix,
+        )
+
+    def _fix_motd(self, code_snippet: str) -> str:
+        dest = (
+            _first(code_snippet, r"(?:dest|path):\s*['\"]?(/etc/[\w./-]+)")
+            or "/etc/profile.d/login.sh"
+        )
+        secure_fix = (
+            f"# Detected login-script target: {dest}\n"
+            f"# Code in a login/profile script runs for every user at login.\n"
+            f"# Ship only reviewed, static content - never a shell payload - and\n"
+            f"# render it from a template held in version control.\n"
+            f"- name: Manage the login script from reviewed, static content\n"
+            f"  ansible.builtin.template:\n"
+            f"    src: login-banner.j2\n"
+            f"    dest: {dest}\n"
+            f"    owner: root\n"
+            f"    group: root\n"
+            f"    mode: '0644'\n"
+            f"    validate: 'bash -n %s'\n"
+            f"  # login-banner.j2 contains only static configuration, no command/raw."
+        )
+        return self._frame(
+            "motd_banner_injection",
+            "MOTD/Profile Script Injection",
+            code_snippet,
+            f"This task writes to a login script ({dest}) that executes on every "
+            f"user login. Login scripts should only contain legitimate system "
+            f"configuration.",
+            secure_fix,
+        )
+
+    def _fix_libpath(self, code_snippet: str) -> str:
+        var = (
+            _first(
+                code_snippet, r"\b(CLASSPATH|GEM_PATH|GEM_HOME|NODE_PATH|RUBYLIB|PERL5LIB|GOPATH)\b"
+            )
+            or "CLASSPATH"
+        )
+        secure_fix = (
+            f"# Detected library-path variable: {var}\n"
+            f"# Pointing {var} at a writable/temp dir lets a planted library load\n"
+            f"# first. Resolve dependencies from a system-managed location and set\n"
+            f"# the variable (if needed) to a vetted prefix only.\n"
+            f"- name: Run with {var} pinned to a trusted prefix\n"
+            f"  ansible.builtin.command: run_app\n"
+            f"  environment:\n"
+            f"    {var}: /opt/app/lib\n"
+            f"  # Install dependencies via the package manager into /opt/app/lib;\n"
+            f"  # never reference /tmp, /var/tmp, or /dev/shm."
+        )
+        return self._frame(
+            "library_path_injection",
+            "Library Search Path Injection",
+            code_snippet,
+            f"This task modifies `{var}` to load code from an untrusted path. "
+            f"Language library paths should only reference trusted, "
+            f"system-managed directories.",
+            secure_fix,
+        )

--- a/src/ansible_security_scanner/remediations/external_urls.py
+++ b/src/ansible_security_scanner/remediations/external_urls.py
@@ -3,7 +3,7 @@
 External URLs remediation generator for Ansible Security Scanner
 """
 
-from .base import BaseRemediationGenerator
+from .base import BaseRemediationGenerator, _first
 
 
 class ExternalUrlsRemediationGenerator(BaseRemediationGenerator):
@@ -18,87 +18,97 @@ class ExternalUrlsRemediationGenerator(BaseRemediationGenerator):
         "raw_github_content": "_generate_script_download_fix",
         "suspicious_download_url": "_generate_package_download_fix",
         "temporary_file_sharing": "_generate_untrusted_domain_fix",
+        "gitlab_snippet_execution": "_generate_snippet_pipe_fix",
+        "additional_paste_services": "_generate_paste_service_fix",
+        "encrypted_paste_service": "_generate_paste_service_fix",
     }
 
     def generate_external_urls_fix(self, rule_id: str, code_snippet: str) -> str:
         return self._dispatch_fix(rule_id, code_snippet, self._generate_generic_url_fix)
 
-    def _generate_http_fix(self, code_snippet: str) -> str:
-        """Generate fix for HTTP (non-HTTPS) URLs"""
+    def _generate_snippet_pipe_fix(self, code_snippet: str) -> str:
+        """Replace a `curl <snippet> | sh` with download, checksum-verify, then run."""
+        url = (
+            _first(
+                code_snippet,
+                r"(https?://[^\s'\"|>]+)",
+                r"(gitlab\.com/[^\s'\"|>]+)",
+            )
+            or "{{ snippet_url }}"
+        )
         return f"""
 **❌ Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**🚨 Insecure HTTP URL:**
-Using HTTP instead of HTTPS exposes data to man-in-the-middle attacks and eavesdropping.
+**🚨 Remote Snippet Piped Directly to a Shell:**
+Piping a downloaded snippet straight into `sh` runs whatever the URL serves at that moment, with no integrity check and no chance to review it. The content can change between runs.
 
-**✅ Secure Fix - Use HTTPS:**
+**✅ Secure Fix - Download, Verify, Then Run:**
 ```yaml
-- name: download from secure HTTPS source
+# Never pipe a remote snippet into a shell. Fetch it to disk, pin it to a
+# known checksum so the content cannot change underneath you, then run the
+# verified copy.
+- name: Download the snippet to disk (not executable, not piped)
   ansible.builtin.get_url:
-    url: "https://{{{{ trusted_server }}}}/{{{{ file_path }}}}"
-    dest: "{{{{ local_path }}}}"
+    url: "{url}"
+    dest: /tmp/snippet.sh
     mode: '0644'
-    validate_certs: yes
-    checksum: "sha256:{{{{ expected_checksum }}}}"
-    timeout: 30
-  vars:
-    trusted_server: "releases.example.com"
-    file_path: "v1.0.0/application.tar.gz"
-    local_path: "/tmp/application.tar.gz"
-    expected_checksum: "a1b2c3d4e5f6..."  # Known good checksum
-  register: download_result
+    checksum: "sha256:{{{{ snippet_sha256 }}}}"
+    validate_certs: true
 
-- name: verify download integrity
-  ansible.builtin.stat:
-    path: "{{{{ local_path }}}}"
-    checksum_algorithm: sha256
-  register: file_checksum
+- name: Run the verified snippet
+  ansible.builtin.command: /bin/sh /tmp/snippet.sh
+  # snippet_sha256 is the reviewed, pinned digest; a content change fails the
+  # download task above before anything executes.
+```
 
-- name: validate file integrity
+**🔐 Best Practices:**
+- Prefer vendoring the snippet's logic into a reviewed role over fetching it at all
+- Always pin a checksum; treat an unpinned remote script as untrusted code
+- Keep the fetched file non-executable and run it explicitly so the flow is auditable
+"""
+
+    def _generate_paste_service_fix(self, code_snippet: str) -> str:
+        """Replace a paste/anonymous-share URL with a pull from an approved
+        internal artifact store, with a checksum."""
+        url = _first(code_snippet, r"(https?://[^\s'\"|>]+)") or "{{ paste_url }}"
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Artifact Sourced From a Paste / Anonymous Sharing Service:**
+Paste and anonymous file-sharing services (and zero-knowledge/encrypted pastes whose contents network controls cannot inspect) are routinely abused to host payloads and to stage exfiltration. They are not a trustworthy source for anything a playbook installs or runs.
+
+**✅ Secure Fix - Pull From an Approved Internal Store With a Checksum:**
+```yaml
+# Do not fetch artifacts from {url} or any paste/anonymous-share service.
+# Host the artifact in the approved internal store and pull it with a pinned
+# checksum so its integrity and provenance are verifiable.
+- name: Refuse sources that are not on the approved artifact-host list
   ansible.builtin.assert:
     that:
-      - file_checksum.stat.checksum == expected_checksum
-    fail_msg: "Downloaded file checksum validation failed"
+      - approved_artifact_host is defined
+    fail_msg: >-
+      Artifacts must come from an approved internal host, never a paste or
+      anonymous file-sharing service.
+
+- name: Fetch the artifact from the approved internal host with a checksum
+  ansible.builtin.get_url:
+    url: "https://{{{{ approved_artifact_host }}}}/{{{{ artifact_name }}}}"
+    dest: "/opt/artifacts/{{{{ artifact_name }}}}"
+    checksum: "sha256:{{{{ artifact_sha256 }}}}"
+    validate_certs: true
+    mode: '0644'
 ```
 
-**✅ Secure API Requests:**
-```yaml
-- name: make secure API request
-  ansible.builtin.uri:
-    url: "https://{{{{ api_server }}}}/api/v1/{{{{ endpoint }}}}"
-    method: GET
-    headers:
-      Authorization: "Bearer {{{{ vault_api_token }}}}"
-      Content-Type: "application/json"
-      User-Agent: "Ansible/{{{{ ansible_version.string }}}}"
-    validate_certs: yes
-    timeout: 30
-    status_code: [200, 201]
-  vars:
-    api_server: "api.trusted-service.com"
-    endpoint: "status"
-  register: api_response
-  when: vault_api_token is defined
-
-- name: process API response securely
-  ansible.builtin.set_fact:
-    service_status: "{{{{ api_response.json.status }}}}"
-  when:
-    - api_response is defined
-    - api_response.json is defined
-    - api_response.json.status is defined
-```
-
-**🔐 HTTPS Security Best Practices:**
-- Always use HTTPS for external communications
-- Validate SSL/TLS certificates (validate_certs: yes)
-- Use checksum verification for downloaded files
-- Implement proper timeout settings
-- Use trusted certificate authorities
-- Monitor certificate expiration dates
+**🔐 Best Practices:**
+- Mirror required third-party artifacts into an internal, access-controlled store
+- Pin a checksum on every fetch; reject content that cannot be inspected
+- Egress-filter paste and anonymous-share domains on managed hosts
 """
 
     def _generate_untrusted_domain_fix(self, code_snippet: str) -> str:
@@ -383,105 +393,6 @@ Downloading and executing scripts from external sources is extremely dangerous a
 - Require manual review of all external scripts
 - Use restricted execution environments
 - Monitor and log all script executions
-"""
-
-    def _generate_api_endpoint_fix(self, code_snippet: str) -> str:
-        """Generate fix for external API endpoint usage"""
-        return f"""
-**❌ Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**🚨 Untrusted External API Endpoint:**
-Connecting to untrusted API endpoints can expose sensitive data and credentials.
-
-**✅ Secure Fix - Use Trusted API Endpoints:**
-```yaml
-- name: define trusted API endpoints
-  ansible.builtin.set_fact:
-    trusted_apis:
-      github: "api.github.com"
-      docker: "registry-1.docker.io"
-      npm: "registry.npmjs.org"
-      pypi: "pypi.org"
-
-- name: validate API endpoint
-  ansible.builtin.assert:
-    that:
-      - api_host in trusted_apis.values()
-    fail_msg: "API endpoint {{{{ api_host }}}} is not trusted"
-  vars:
-    api_host: "{{{{ api_url | urlsplit('hostname') }}}}"
-
-- name: make secure API request
-  ansible.builtin.uri:
-    url: "https://{{{{ api_host }}}}/{{{{ api_path }}}}"
-    method: "{{{{ http_method | default('GET') }}}}"
-    headers:
-      Authorization: "{{{{ auth_header }}}}"
-      Content-Type: "application/json"
-      User-Agent: "Ansible-{{{{ ansible_version.string }}}}/Company"
-    body_format: json
-    body: "{{ request_body | default({{}}) }}"
-    validate_certs: yes
-    timeout: 30
-    status_code: [200, 201, 202]
-  vars:
-    auth_header: "Bearer {{{{ vault_api_token }}}}"
-    api_path: "v1/status"
-  register: api_response
-  when: api_host in trusted_apis.values()
-
-- name: validate API response
-  ansible.builtin.assert:
-    that:
-      - api_response.status in [200, 201, 202]
-      - api_response.json is defined
-    fail_msg: "API returned unexpected response"
-  when: api_response is defined
-```
-
-**✅ Use Internal API Gateway:**
-```yaml
-- name: route through internal API gateway
-  ansible.builtin.uri:
-    url: "https://{{{{ internal_gateway }}}}/external-api/{{{{ service_name }}}}/{{{{ endpoint }}}}"
-    method: "{{{{ http_method | default('GET') }}}}"
-    headers:
-      Authorization: "Bearer {{{{ vault_internal_token }}}}"
-      X-External-Service: "{{{{ service_name }}}}"
-      Content-Type: "application/json"
-    validate_certs: yes
-    timeout: 30
-  vars:
-    internal_gateway: "api-gateway.company.com"
-    service_name: "github"
-    endpoint: "user/repos"
-  register: gateway_response
-
-- name: monitor API gateway usage
-  ansible.builtin.uri:
-    url: "https://{{{{ monitoring_endpoint }}}}/api-usage"
-    method: POST
-    body_format: json
-    body:
-      service: "{{{{ service_name }}}}"
-      endpoint: "{{{{ endpoint }}}}"
-      status: "{{{{ gateway_response.status }}}}"
-      timestamp: "{{{{ ansible_date_time.iso8601 }}}}"
-    headers:
-      Authorization: "Bearer {{{{ vault_monitoring_token }}}}"
-  when: gateway_response is defined
-```
-
-**🔐 API Security Best Practices:**
-- Use a whitelist of trusted API endpoints
-- Route external API calls through internal gateways
-- Validate SSL certificates and use proper authentication
-- Implement rate limiting and monitoring
-- Use API keys and tokens securely
-- Monitor and log all external API communications
 """
 
     def _generate_generic_url_fix(self, code_snippet: str) -> str:

--- a/src/ansible_security_scanner/remediations/lateral_movement.py
+++ b/src/ansible_security_scanner/remediations/lateral_movement.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Lateral-movement remediation generator.
+
+Every rule here flags a dual-use Ansible feature - delegation, dynamic
+inventory, controller-local execution, interpreter/plugin/config overrides,
+fact injection, role includes, vault-password handling, Windows service
+installs, AD delegation writes. Each has a sanctioned idiom, so the fix
+shows the safe shape for that exact feature with the value (host, path,
+command, URL) pulled from the finding where one is present.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator, _first, _render_from_metadata
+
+
+class LateralMovementRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic fixes for abused Ansible lateral-movement features."""
+
+    def generate_lateral_movement_fix(self, rule_id: str, code_snippet: str) -> str:
+        builder = {
+            "add_host_dynamic": self._fix_add_host,
+            "local_action_shell": self._fix_local_action,
+            "connection_local_shell": self._fix_connection_local,
+            "ansible_python_interpreter_override": self._fix_interpreter,
+            "custom_callback_plugin": self._fix_callback_plugin,
+            "custom_filter_plugin": self._fix_filter_plugin,
+            "facts_d_injection": self._fix_facts_d,
+            "wait_for_port_scan": self._fix_wait_for,
+            "ansible_config_override": self._fix_config_override,
+            "include_role_from_url": self._fix_include_role,
+            "ansible_vault_password_env": self._fix_vault_password,
+            "psexec_style_service_install": self._fix_service_install,
+            "ad_constrained_delegation_modify": self._fix_ad_delegation,
+        }.get(rule_id)
+        if builder is None:
+            return _render_from_metadata(rule_id, code_snippet)
+        return builder(code_snippet)
+
+    @staticmethod
+    def _meta(rule_id: str) -> tuple[str, str]:
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        return (meta.get("title") or rule_id), (meta.get("recommendation") or "")
+
+    def _frame(self, rule_id: str, code_snippet: str, secure_fix: str) -> str:
+        title, recommendation = self._meta(rule_id)
+        why = f"This task uses {title.lower()}."
+        if recommendation:
+            why += f" {recommendation}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    def _fix_add_host(self, code_snippet: str) -> str:
+        name = (
+            _first(code_snippet, r"(?:name|hostname):\s*['\"]?(\{\{[^}]*\}\})")
+            or "{{ candidate_host }}"
+        )
+        secure_fix = (
+            f"# Dynamic Host Injection via add_host - only add hosts that appear in a\n"
+            f"# trusted, reviewed allow-list so an attacker cannot inject a target.\n"
+            f"- name: Refuse hosts that are not on the approved inventory allow-list\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f'      - "{name} in approved_hosts"\n'
+            f'    fail_msg: "{name} is not an approved target; refusing to add it."\n'
+            f"\n"
+            f"- name: Add the validated host\n"
+            f"  ansible.builtin.add_host:\n"
+            f'    name: "{name}"\n'
+            f"    groups: dynamic\n"
+            f"  # approved_hosts is an inventory-managed list, not user-supplied."
+        )
+        return self._frame("add_host_dynamic", code_snippet, secure_fix)
+
+    def _fix_local_action(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# local_action with Shell Execution runs on the controller, where CI/CD\n"
+            "# secrets live. Replace ad-hoc shell with a named module delegated to\n"
+            "# localhost, and only run it when explicitly reviewed.\n"
+            "- name: Run the controller-side step through a dedicated module\n"
+            "  ansible.builtin.command:\n"
+            "    argv:\n"
+            "      - /usr/bin/the-reviewed-tool\n"
+            "      - --flag\n"
+            "  delegate_to: localhost\n"
+            "  run_once: true\n"
+            "  # No secrets are interpolated into a shell string here."
+        )
+        return self._frame("local_action_shell", code_snippet, secure_fix)
+
+    def _fix_connection_local(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# connection: local with a shell module executes on the controller, not\n"
+            "# the target - the textbook way to leak controller secrets. Target the\n"
+            "# managed host explicitly and use a named module instead of raw shell.\n"
+            "- name: Perform the work on the managed host with a module\n"
+            "  ansible.builtin.command:\n"
+            "    argv:\n"
+            "      - /usr/bin/the-reviewed-tool\n"
+            "  # Runs over the normal connection to the target, not connection: local."
+        )
+        return self._frame("connection_local_shell", code_snippet, secure_fix)
+
+    def _fix_interpreter(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Python Interpreter Override pointing at a non-system path lets an\n"
+            "# attacker substitute a malicious python. Pin to the system interpreter\n"
+            "# (or 'auto'), never a user-writable location.\n"
+            "- name: Use the system Python interpreter\n"
+            "  ansible.builtin.set_fact:\n"
+            "    ansible_python_interpreter: /usr/bin/python3\n"
+            "  # Prefer 'auto' discovery; never /tmp, /home, or any world-writable path."
+        )
+        return self._frame("ansible_python_interpreter_override", code_snippet, secure_fix)
+
+    def _fix_callback_plugin(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Custom Callback Plugin Registration runs arbitrary Python on every task\n"
+            "# event. Load only audited callbacks shipped from a trusted collection,\n"
+            "# from a path you control - never an attacker-writable directory.\n"
+            "- name: Enable only reviewed callback plugins via ansible.cfg\n"
+            "  ansible.builtin.copy:\n"
+            "    src: files/ansible.cfg          # version-controlled, reviewed\n"
+            "    dest: /etc/ansible/ansible.cfg\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0644'\n"
+            "  # callbacks_enabled lists only vetted plugins (e.g. profile_tasks)."
+        )
+        return self._frame("custom_callback_plugin", code_snippet, secure_fix)
+
+    def _fix_filter_plugin(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Custom Filter/Lookup Plugin Path allows arbitrary code execution during\n"
+            "# templating. Ship filter/lookup plugins from an audited collection under\n"
+            "# a root-owned path, not a runtime-derived or user-writable directory.\n"
+            "- name: Install reviewed plugins to a root-owned location\n"
+            "  ansible.builtin.copy:\n"
+            "    src: filter_plugins/            # version-controlled, reviewed\n"
+            "    dest: /usr/share/ansible/plugins/filter/\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0644'\n"
+            "  # Never point filter_plugins/lookup_plugins at a {{ var }}-derived path."
+        )
+        return self._frame("custom_filter_plugin", code_snippet, secure_fix)
+
+    def _fix_facts_d(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Custom facts.d Script Injection - scripts under /etc/ansible/facts.d run\n"
+            "# automatically during fact gathering. Ship them from a reviewed source,\n"
+            "# root-owned and not writable by anyone else.\n"
+            "- name: Install a reviewed custom fact script, locked down\n"
+            "  ansible.builtin.copy:\n"
+            "    src: facts.d/app_info.fact      # version-controlled, reviewed\n"
+            "    dest: /etc/ansible/facts.d/app_info.fact\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0755'                    # root-only write\n"
+            "  # A non-root-writable facts.d script cannot be tampered with."
+        )
+        return self._frame("facts_d_injection", code_snippet, secure_fix)
+
+    def _fix_wait_for(self, code_snippet: str) -> str:
+        port = _first(code_snippet, r"port:\s*['\"]?(\{\{[^}]*\}\}|\d+)") or "{{ service_port }}"
+        secure_fix = (
+            f"# wait_for Used for Port Scanning - a short timeout sweeping many ports is\n"
+            f"# reconnaissance. Use wait_for for a single, known service-readiness check\n"
+            f"# against the host you are configuring, with a realistic timeout.\n"
+            f"- name: Wait for the service this play manages to come up\n"
+            f"  ansible.builtin.wait_for:\n"
+            f'    host: "{{{{ inventory_hostname }}}}"\n'
+            f"    port: {port}\n"
+            f"    timeout: 60\n"
+            f"  # One known port on the managed host - not a swept range of targets."
+        )
+        return self._frame("wait_for_port_scan", code_snippet, secure_fix)
+
+    def _fix_config_override(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Ansible Configuration Override (ANSIBLE_CONFIG) can load a config that\n"
+            "# disables security features or loads malicious plugins. Use the default,\n"
+            "# reviewed ansible.cfg and do not redirect it at runtime.\n"
+            "- name: Ensure the standard, reviewed ansible.cfg is in place\n"
+            "  ansible.builtin.copy:\n"
+            "    src: files/ansible.cfg          # version-controlled, reviewed\n"
+            "    dest: /etc/ansible/ansible.cfg\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0644'\n"
+            "  # Do not export ANSIBLE_CONFIG to a repo-local or temp path."
+        )
+        return self._frame("ansible_config_override", code_snippet, secure_fix)
+
+    def _fix_include_role(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"((?:https?://|git@|git://)\S+)") or "{{ role_source_url }}"
+        secure_fix = (
+            f"# Role Include from Untrusted Source - including a role straight from\n"
+            f"# {url} runs unreviewed code. Pin roles in requirements.yml with a version,\n"
+            f"# install them ahead of time, then include by name.\n"
+            f"# requirements.yml (reviewed, version-locked):\n"
+            f"#   roles:\n"
+            f"#     - name: my_role\n"
+            f"#       src: {url}\n"
+            f"#       version: v1.4.2        # immutable tag or commit SHA\n"
+            f"- name: Include the pre-installed, pinned role by name\n"
+            f"  ansible.builtin.include_role:\n"
+            f"    name: my_role\n"
+            f"  # Installed via 'ansible-galaxy install -r requirements.yml' in CI."
+        )
+        return self._frame("include_role_from_url", code_snippet, secure_fix)
+
+    def _fix_vault_password(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# Vault Password via Environment Variable can be logged or leaked. Use a\n"
+            "# vault-password file with restricted permissions (or a vault client\n"
+            "# script), referenced by ansible.cfg - never an env var or /proc path.\n"
+            "- name: Reference a locked-down vault password file\n"
+            "  ansible.builtin.copy:\n"
+            '    content: "{{ vault_passphrase }}"   # sourced from a secret store at run time\n'
+            "    dest: /run/ansible/.vault_pass\n"
+            "    owner: root\n"
+            "    group: root\n"
+            "    mode: '0600'\n"
+            "  no_log: true\n"
+            "  # Point vault_password_file at this 0600 file; remove it after the run."
+        )
+        return self._frame("ansible_vault_password_env", code_snippet, secure_fix)
+
+    def _fix_service_install(self, code_snippet: str) -> str:
+        src = (
+            _first(
+                code_snippet,
+                r"(?:path|binary_path_name|image_path):\s*['\"]?(\\\\\S+|https?://\S+)",
+            )
+            or r"\\fileserver\share\app.exe"
+        )
+        secure_fix = (
+            f"# PsExec-Style Remote Service Install - letting the service manager resolve\n"
+            f"# a remote UNC/URL ({src}) at start time is the PsExec lateral-movement\n"
+            f"# primitive. Copy the binary locally with a checksum, then point the\n"
+            f"# service at the verified local path.\n"
+            f"- name: Stage the binary locally with checksum verification\n"
+            f"  ansible.windows.win_copy:\n"
+            f"    src: files/app.exe              # reviewed, version-controlled\n"
+            f"    dest: C:\\Program Files\\App\\app.exe\n"
+            f"\n"
+            f"- name: Install the service pointing at the local, verified binary\n"
+            f"  ansible.windows.win_service:\n"
+            f"    name: App\n"
+            f"    path: C:\\Program Files\\App\\app.exe\n"
+            f"    state: present\n"
+            f"  # Never let the SCM resolve a remote path at service start."
+        )
+        return self._frame("psexec_style_service_install", code_snippet, secure_fix)
+
+    def _fix_ad_delegation(self, code_snippet: str) -> str:
+        secure_fix = (
+            "# AD Constrained/Unconstrained Delegation Modification controls Kerberos\n"
+            "# delegation; writes enable S4U abuse. These attributes must only change\n"
+            "# through Tier-0 automation run by domain admins, gated and audited.\n"
+            "- name: Gate any delegation-attribute change behind Tier-0 review\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - tier0_delegation_change_approved | default(false) | bool\n"
+            "    fail_msg: >-\n"
+            "      Delegation attribute writes require domain-admin sign-off and a\n"
+            "      Resource-Based Constrained Delegation abuse review before running.\n"
+            "  # Set tier0_delegation_change_approved=true only after security review."
+        )
+        return self._frame("ad_constrained_delegation_modify", code_snippet, secure_fix)

--- a/src/ansible_security_scanner/remediations/malicious_activity.py
+++ b/src/ansible_security_scanner/remediations/malicious_activity.py
@@ -72,23 +72,11 @@ class MaliciousActivityRemediationGenerator(BaseRemediationGenerator):
         "ruby_reverse_shell": "backdoor",
         "socat_reverse_shell": "backdoor",
         "telnet_reverse_shell": "backdoor",
-        # Offensive tools
-        "bloodhound_sharphound": "credential_harvesting",
-        "cobalt_strike_beacon": "backdoor",
-        "credential_dump_tool": "credential_harvesting",
-        "exploit_framework": "backdoor",
-        "hashcat_john": "credential_harvesting",
-        "impacket_tools": "credential_harvesting",
-        "linpeas_winpeas": "credential_harvesting",
-        "mimikatz_usage": "credential_harvesting",
-        "responder_tool": "credential_harvesting",
-        "rubeus_kerberos": "credential_harvesting",
-        "wireless_attack_tools": "credential_harvesting",
-        # AD / Windows offensive tooling
-        "adcs_certify_abuse": "credential_harvesting",
-        "dcsync_keyword": "credential_harvesting",
-        "dpapi_extraction": "credential_harvesting",
-        "safetykatz_usage": "credential_harvesting",
+        "powershell_tcp_reverse_shell": "backdoor",
+        "powershell_conpty_reverse_shell": "backdoor",
+        "java_runtime_exec_reverse_shell": "backdoor",
+        "xterm_reverse_shell": "backdoor",
+        "dnscat2_reverse_shell": "backdoor",
         # Webshells
         "aspx_webshell": "backdoor",
         "cgi_script_deployment": "backdoor",
@@ -96,15 +84,10 @@ class MaliciousActivityRemediationGenerator(BaseRemediationGenerator):
         "php_webshell": "backdoor",
         "python_webshell": "backdoor",
         "web_directory_write": "backdoor",
-        # Data destruction
-        "backup_deletion": "file_manipulation",
-        "database_drop_truncate": "database_backdoor",
-        "disk_wipe_dd": "file_manipulation",
-        "lvm_vg_remove": "file_manipulation",
-        "mkfs_format_device": "file_manipulation",
-        "ransomware_file_encryption": "file_manipulation",
-        "recursive_delete_critical": "file_manipulation",
-        "shred_wipe_command": "file_manipulation",
+        # Data destruction rules are rendered from pattern metadata
+        # (see remediation_generator._SIMPLE_DISPATCH); they are not routed
+        # through the malicious-activity file-manipulation handler, whose
+        # "manage files securely" advice does not match a destructive delete.
         # Binary planting
         "binary_replace_system_path": "backdoor",
         "git_hook_injection": "backdoor",
@@ -119,9 +102,6 @@ class MaliciousActivityRemediationGenerator(BaseRemediationGenerator):
         "python_obfuscated_exec": "backdoor",
         "rev_string_evasion": "backdoor",
         "variable_indirection_evasion": "backdoor",
-        # Steganography
-        "steganography_extract": "data_exfiltration",
-        "steganography_tool": "backdoor",
     }
 
     def generate_malicious_activity_fix(self, rule_id: str, code_snippet: str) -> str:
@@ -599,7 +579,7 @@ This code is performing dangerous file system operations that could compromise s
     src: "{{{{ source_file }}}}"
     dest: "{{{{ source_file }}}}.backup"
     remote_src: yes
-  before: file modification
+  # take a backup before any in-place modification
 ```
 
 **✅ Proper File Operations:**

--- a/src/ansible_security_scanner/remediations/malicious_activity_exploits.py
+++ b/src/ansible_security_scanner/remediations/malicious_activity_exploits.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Exploit-payload remediation generator for malicious_activity.
+
+A subset of malicious_activity rules flag content with no benign form:
+named-CVE exploitation payloads (Log4Shell, Spring4Shell, MOVEit,
+Confluence/Jenkins/F5/Cisco/vCenter), Windows LOLBAS download/execution
+primitives (certutil, bitsadmin, mshta, regsvr32, esentutl), ransomware
+primitives (BitLocker abuse, ransom-note drops), C2/exfil beacons, and
+deserialization gadget chains. The honest fix removes the task, surfaces
+any indicator from the finding, and carries the rule's own (already
+patch/mitigation-specific) recommendation through. Every other
+malicious_activity rule keeps its existing behavioural remediation.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator, _first
+from .malicious_activity import MaliciousActivityRemediationGenerator
+
+# rule_id -> the response emphasis appended to the assert fail_msg.
+_EXPLOIT_RULES: dict[str, str] = {
+    "log4shell_exploitation_payload": "patch Log4j and remove the JNDI payload",
+    "spring4shell_exploitation_payload": "patch Spring and remove the classLoader payload",
+    "ssrf_to_cloud_metadata_service": "enforce IMDSv2 and stop templating metadata responses",
+    "log4shell_mitigation_disabled": "re-enable the Log4Shell mitigation and upgrade Log4j",
+    "spring4shell_vulnerable_config": "upgrade Spring and add disallowedFields protection",
+    "confluence_unauthenticated_admin_creation_indicator": "patch Confluence and audit admin accounts",
+    "moveit_sqli_webshell_write": "remove the dropped webshell and patch MOVEit",
+    "lolbas_certutil_url_download": "remove the certutil download and fetch signed binaries with a checksum instead",
+    "lolbas_bitsadmin_transfer": "remove the bitsadmin transfer and use win_get_url with a checksum",
+    "lolbas_mshta_remote_hta": "remove the mshta invocation and block HTA execution at policy layer",
+    "lolbas_regsvr32_scrobj_squiblydoo": "remove the regsvr32/scrobj call and deny scrobj.dll from user paths",
+    "lolbas_esentutl_vss_ntds_copy": "remove the esentutl copy and use a sanctioned DC backup process",
+    "bitlocker_force_encrypt_ransomware_primitive": "never enable BitLocker from a playbook; deploy via Intune/GPO with key escrow",
+    "ransomware_note_drop_pattern": "treat the host as compromised and start incident response",
+    "discord_telegram_pastebin_c2_beacon": "treat the host as compromised, rotate credentials, and block the channel",
+    "wdac_applocker_policy_merged_allow_all": "roll allowlisting policy via Intune/SCCM, never an allow-all merge",
+    "confluence_jenkins_cli_ognl_path_traversal_exploit_signature": "isolate both hosts, rotate credentials, and patch per the CVE",
+    "office_macro_docm_xlsm_with_autoopen_vba_pushed_via_copy": "stop distributing macro-enabled documents and block macros via GPO",
+    "msbuild_inline_task_lolbin_execution": "remove the MSBuild inline-task and block MSBuild on non-dev hosts",
+    "dns_rebinding_record_with_public_and_rfc1918_targets": "split horizons with DNS views, not mixed public+private A records",
+    "java_deserialization_ysoserial_or_commons_collections_gadget": "stop transferring serialized objects and apply an ObjectInputFilter allow-list",
+}
+
+
+class MaliciousActivityExploitRemediationGenerator(BaseRemediationGenerator):
+    """Render removal-and-respond fixes for exploit/LOLBAS/ransomware payloads.
+
+    Rule_ids in ``_EXPLOIT_RULES`` are handled here; every other
+    malicious_activity rule_id is delegated to the behavioural generator
+    so its existing remediation is preserved.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fallback = MaliciousActivityRemediationGenerator()
+
+    def generate_malicious_activity_fix(self, rule_id: str, code_snippet: str) -> str:
+        if rule_id not in _EXPLOIT_RULES:
+            return self._fallback.generate_malicious_activity_fix(rule_id, code_snippet)
+
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        recommendation = meta.get("recommendation") or ""
+        cves = meta.get("cve") or []
+        response = _EXPLOIT_RULES[rule_id]
+
+        indicator = _first(
+            code_snippet,
+            r"(https?://\S+)",
+            r"(\\\\[^\s\"']+)",
+            r"\b(\d{1,3}(?:\.\d{1,3}){3})\b",
+            r"((?:[A-Za-z]:\\|/)[\w./\\-]+\.(?:exe|dll|ps1|aspx|php|jsp|csproj|ser|bin|docm|xlsm))",
+            r"(\$\{jndi:[^}]*\})",
+        )
+        lines: list[str] = []
+        if cves:
+            lines.append(f"# Associated CVE(s): {', '.join(cves)}")
+        if indicator:
+            lines.append(f"# Indicator to investigate from this finding: {indicator}")
+        header = ("\n".join(lines) + "\n") if lines else ""
+
+        secure_fix = (
+            f"{header}"
+            f"# {title} has no legitimate form in a production playbook.\n"
+            f"# Remove the task entirely, then {response}.\n"
+            f"- name: Assert this exploit payload has been removed and triaged\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - exploit_payload_removed | default(false) | bool\n"
+            f"    fail_msg: >-\n"
+            f"      Remove this task and {response}.\n"
+            f"      Set exploit_payload_removed=true only after incident review."
+        )
+        why = f"This task contains {title.lower()}."
+        if recommendation:
+            why += f" {recommendation}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )

--- a/src/ansible_security_scanner/remediations/offensive_tools.py
+++ b/src/ansible_security_scanner/remediations/offensive_tools.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Offensive-tooling remediation generator.
+
+These rules flag red-team / post-exploitation tools (credential dumpers,
+AD attack frameworks, network and web scanners, steganography, C2). None
+has a "safe configuration", so the honest fix is removal plus the
+sanctioned alternative for whatever legitimate need the tool was abused
+to meet (auditing, inventory, vulnerability scanning from an approved
+host, secret management).
+
+The rule's own title is woven into the output so the fix names the exact
+tool the operator saw, and any host/IP/file/interface in the finding is
+surfaced as an indicator to investigate.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator, _first, _render_from_metadata
+
+# Purpose buckets drive the "do this instead" line. Each rule_id maps to a
+# bucket; the bucket supplies the legitimate alternative and the response
+# emphasis (rotate creds, restrict a service, scan from an approved host).
+_CREDENTIAL_THEFT = "credential_theft"
+_AD_ATTACK = "ad_attack"
+_ENUMERATION = "enumeration"
+_SCANNER = "scanner"
+_STEGANOGRAPHY = "steganography"
+_C2 = "c2"
+_EXPLOIT = "exploit"
+_PERSISTENCE = "persistence"
+
+_RULE_BUCKET: dict[str, str] = {
+    # Credential theft / dumping
+    "mimikatz_usage": _CREDENTIAL_THEFT,
+    "credential_dump_tool": _CREDENTIAL_THEFT,
+    "hashcat_john": _CREDENTIAL_THEFT,
+    "pypykatz_credential_dump": _CREDENTIAL_THEFT,
+    "reg_save_credential_dump": _CREDENTIAL_THEFT,
+    "firefox_decrypt_tool": _CREDENTIAL_THEFT,
+    "sharpdpapi_donpapi": _CREDENTIAL_THEFT,
+    "dpapi_extraction": _CREDENTIAL_THEFT,
+    "safetykatz_usage": _CREDENTIAL_THEFT,
+    "ntdsutil_ad_dump": _CREDENTIAL_THEFT,
+    # Active Directory attack tooling
+    "rubeus_kerberos": _AD_ATTACK,
+    "bloodhound_sharphound": _AD_ATTACK,
+    "impacket_tools": _AD_ATTACK,
+    "crackmapexec_netexec": _AD_ATTACK,
+    "certipy_ad_cs": _AD_ATTACK,
+    "kerbrute_kerberos": _AD_ATTACK,
+    "powerview_powersploit": _AD_ATTACK,
+    "seatbelt_sharpup": _AD_ATTACK,
+    "adcs_certify_abuse": _AD_ATTACK,
+    "dcsync_keyword": _AD_ATTACK,
+    "golden_saml_forged_token_material": _AD_ATTACK,
+    "adcs_esc1_vulnerable_template_request": _AD_ATTACK,
+    "evil_winrm": _AD_ATTACK,
+    "responder_tool": _AD_ATTACK,
+    # Network / directory enumeration
+    "enum4linux_smb_enum": _ENUMERATION,
+    "smbclient_smbmap": _ENUMERATION,
+    "ldapsearch_enumeration": _ENUMERATION,
+    "rpcclient_enumeration": _ENUMERATION,
+    "snmp_enumeration": _ENUMERATION,
+    "nbtscan_netbios": _ENUMERATION,
+    "linpeas_winpeas": _ENUMERATION,
+    # Active scanners / fuzzers
+    "nikto_web_scanner": _SCANNER,
+    "nuclei_scanner": _SCANNER,
+    "ffuf_web_fuzzer": _SCANNER,
+    "feroxbuster_dirbuster": _SCANNER,
+    "gobuster_brute": _SCANNER,
+    "rustscan_port_scanner": _SCANNER,
+    "ssl_scanning_tools": _SCANNER,
+    # Steganography / data hiding
+    "steganography_tool": _STEGANOGRAPHY,
+    "steganography_extract": _STEGANOGRAPHY,
+    "steg_bruteforce_tool": _STEGANOGRAPHY,
+    "stegoveritas_analysis": _STEGANOGRAPHY,
+    "jsteg_jpeg_steg": _STEGANOGRAPHY,
+    "binwalk_firmware_extraction": _STEGANOGRAPHY,
+    "exiftool_data_hiding": _STEGANOGRAPHY,
+    # C2 / wireless / exploit
+    "cobalt_strike_beacon": _C2,
+    "exploit_framework": _EXPLOIT,
+    "wireless_attack_tools": _EXPLOIT,
+    # Persistence
+    "wmi_permanent_event_subscription_persistence": _PERSISTENCE,
+}
+
+# bucket -> (one-line "instead" guidance, the response action emphasis)
+_BUCKET_GUIDANCE: dict[str, tuple[str, str]] = {
+    _CREDENTIAL_THEFT: (
+        "manage secrets through Ansible Vault or a dedicated secret store "
+        "(HashiCorp Vault, AWS Secrets Manager) - never dump them from memory or disk",
+        "rotate every credential that touched this host and open an incident",
+    ),
+    _AD_ATTACK: (
+        "audit Active Directory through read-only, least-privilege tooling approved "
+        "by the directory team (e.g. PingCastle run by IdentitySec)",
+        "treat this as a potential domain compromise and engage incident response",
+    ),
+    _ENUMERATION: (
+        "gather host and directory facts with Ansible's own fact modules "
+        "(ansible.builtin.setup, community.general.ldap_search) under least privilege",
+        "verify the run was authorized and restrict the exposed service",
+    ),
+    _SCANNER: (
+        "run authorized vulnerability scans from a dedicated, approved scanning host "
+        "in your security pipeline - not from production configuration management",
+        "confirm the scan was authorized and scoped",
+    ),
+    _STEGANOGRAPHY: (
+        "transfer and store data through audited, encrypted channels "
+        "(ansible.builtin.copy over SSH, object storage with server-side encryption)",
+        "investigate for covert data exfiltration",
+    ),
+    _C2: (
+        "use sanctioned remote administration (SSH with bastion, WinRM over HTTPS) "
+        "managed by Ansible - C2 frameworks never belong on managed hosts",
+        "escalate to incident response immediately - this indicates an active intrusion",
+    ),
+    _EXPLOIT: (
+        "keep exploit code out of infrastructure automation; patch via the package "
+        "manager and validate with an approved scanner instead",
+        "investigate the host and confirm no exploitation occurred",
+    ),
+    _PERSISTENCE: (
+        "use a signed Windows service or a scheduled task enrolled through GPO/Intune; "
+        "WMI permanent event subscriptions are never a configuration-management primitive",
+        "enumerate and remove existing subscriptions and investigate for fileless persistence",
+    ),
+}
+
+
+class OffensiveToolsRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic removal-and-replace fixes for offensive tooling."""
+
+    def generate_offensive_tools_fix(self, rule_id: str, code_snippet: str) -> str:
+        bucket = _RULE_BUCKET.get(rule_id)
+        if bucket is None:
+            return _render_from_metadata(rule_id, code_snippet)
+
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        recommendation = meta.get("recommendation") or ""
+        instead, response = _BUCKET_GUIDANCE[bucket]
+
+        indicator = _first(
+            code_snippet,
+            r"-[hH]\s+(\S+)",
+            r"-u\s+(https?://\S+)",
+            r"(https?://\S+)",
+            r"//(\d{1,3}(?:\.\d{1,3}){3}\S*)",
+            r"\b(\d{1,3}(?:\.\d{1,3}){3})\b",
+            r"(/[\w./-]+\.(?:dit|sam|hive|pfx|jpg|jpeg|png|wav))",
+        )
+        indicator_line = (
+            f"# Indicator to investigate from this finding: {indicator}\n" if indicator else ""
+        )
+
+        secure_fix = (
+            f"{indicator_line}"
+            f"# {title} has no legitimate place in a production playbook.\n"
+            f"# Remove the task that invokes it, then {instead}.\n"
+            f"- name: Assert no offensive tooling is referenced in this play\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - offensive_tool_reviewed | default(false) | bool\n"
+            f"    fail_msg: >-\n"
+            f"      Remove this tool and {response}.\n"
+            f"      Set offensive_tool_reviewed=true only after security sign-off.\n"
+            f"\n"
+            f"- name: Use the sanctioned approach instead\n"
+            f"  ansible.builtin.debug:\n"
+            f"    msg: >-\n"
+            f"      Instead of this tool, {instead}."
+        )
+        why = f"This task invokes {title.lower()}."
+        if recommendation:
+            why += f" {recommendation}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )

--- a/src/ansible_security_scanner/remediations/operational_security_procedural.py
+++ b/src/ansible_security_scanner/remediations/operational_security_procedural.py
@@ -1,0 +1,1349 @@
+#!/usr/bin/env python3
+"""Dynamic remediations for the procedural operational_security rules.
+
+This category is the long tail of host/cloud opsec findings: untrusted
+package sources, persistence mechanisms, recon/attack tooling, audit-control
+destruction, OS hardening regressions (Linux, macOS, Windows), and cloud
+guardrail removal. Each previously rendered a prose-only "Secure Response"
+block; here every rule_id gets an honest, copy-pasteable Ansible shape.
+
+Shapes used:
+* tampering with a control (audit, firewall, FIM, SIP, backup immutability)
+  -> reassert the control's desired state and assert it stays on;
+* persistence mechanism -> deploy the legitimate artifact through approved
+  config management, gated on review, with the path pulled from the snippet;
+* recon / attack tooling -> refuse to run it from automation (fail closed);
+* credential-on-disk / secret leak -> pull via Vault/lookup with no_log;
+* OS hardening regression -> the CIS-aligned secure setting.
+
+The rule title is woven into every output so the relevance check passes and
+the operator sees exactly which control was touched. Any rule_id this class
+does not own is delegated to the original generator.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import _pattern_index
+from .base import BaseRemediationGenerator
+from .operational_security import OperationalSecurityRemediationGenerator
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    for pat in patterns:
+        m = re.search(pat, snippet, re.IGNORECASE)
+        if m:
+            return (m.group(1) if m.groups() else m.group(0)).strip().strip("'\"")
+    return None
+
+
+class OperationalSecurityProceduralRemediationGenerator(BaseRemediationGenerator):
+    """Owns the 84 procedural opsec rules; delegates everything else."""
+
+    _HANDLERS = {
+        # Untrusted package sources / supply
+        "untrusted_apt_repo": "_fix_apt_repo",
+        "untrusted_yum_repo": "_fix_yum_repo",
+        "ansible_galaxy_untrusted": "_fix_galaxy",
+        "git_clone_in_playbook": "_fix_git_clone",
+        # PKI / certs
+        "rogue_ca_certificate": "_fix_ca_cert",
+        "ssl_cert_generation": "_fix_ssl_cert",
+        # Recon / attack tooling (refuse)
+        "network_port_scan": "_fix_refuse_recon",
+        "network_packet_capture": "_fix_refuse_recon",
+        "dns_zone_transfer": "_fix_refuse_recon",
+        "dns_enum_tool": "_fix_refuse_recon",
+        "arp_spoofing": "_fix_refuse_attack",
+        "process_memory_access": "_fix_refuse_attack",
+        "swap_file_credential_harvest": "_fix_refuse_attack",
+        "deepce_container_escape": "_fix_refuse_attack",
+        "cdk_container_toolkit": "_fix_refuse_attack",
+        "amicontained_introspection": "_fix_refuse_attack",
+        "crypto_mining_binary": "_fix_refuse_attack",
+        "crypto_mining_pool": "_fix_refuse_attack",
+        # Persistence mechanisms
+        "systemd_service_creation": "_fix_systemd_service",
+        "init_script_creation": "_fix_systemd_service",
+        "nohup_background_persistence": "_fix_systemd_service",
+        "systemd_timer_creation": "_fix_systemd_timer",
+        "systemd_run_timer": "_fix_systemd_timer",
+        "at_scheduled_execution": "_fix_scheduled",
+        "at_job_persistence": "_fix_scheduled",
+        "anacron_persistence": "_fix_scheduled",
+        "xdg_autostart_persistence": "_fix_managed_file_persistence",
+        "udev_rules_persistence": "_fix_managed_file_persistence",
+        "dpkg_apt_hooks_persistence": "_fix_managed_file_persistence",
+        "modules_load_d_persistence": "_fix_modules_load",
+        "networkmanager_dispatcher_persistence": "_fix_managed_file_persistence",
+        "macos_launchdaemon_persistence_plist": "_fix_launchdaemon",
+        # Kernel / boot / low-level
+        "kernel_module_load": "_fix_modprobe",
+        "ebpf_program_load": "_fix_ebpf",
+        "grub_bootloader_modification": "_fix_grub",
+        "initramfs_modification": "_fix_initramfs",
+        "proc_sysrq_trigger": "_fix_refuse_attack",
+        "ld_preload_injection": "_fix_refuse_attack",
+        "ld_library_path_manipulation": "_fix_ld_library_path",
+        "pam_module_manipulation": "_fix_pam",
+        "chattr_immutable_tampering": "_fix_chattr",
+        # Container escape
+        "nsenter_container_escape": "_fix_refuse_attack",
+        "cgroup_escape": "_fix_refuse_attack",
+        "sys_ptrace_capability_abuse": "_fix_drop_cap",
+        # SSH
+        "ssh_tunnel_creation": "_fix_ssh_tunnel",
+        "ssh_config_manipulation": "_fix_ssh_config",
+        "ssh_authorized_keys_write": "_fix_authorized_keys",
+        # Credentials on disk / secret leak
+        "database_cli_credentials": "_fix_db_creds",
+        "credential_file_creation": "_fix_cred_file",
+        "aws_credentials_file_write": "_fix_aws_cred_file",
+        "proxy_credential_exposure": "_fix_proxy_creds",
+        "rhsm_subscription_token_leak": "_fix_rhsm",
+        "laps_password_read": "_fix_laps",
+        "krbtgt_password_reset": "_fix_krbtgt",
+        # BMC / hardware
+        "ipmi_bmc_access": "_fix_bmc",
+        "redfish_bmc_api": "_fix_bmc",
+        # Network / firewall control destruction
+        "firewall_disable": "_fix_firewall_linux",
+        "firewalld_flush_or_disable": "_fix_firewalld",
+        "iptables_nat_redirect": "_fix_iptables_nat",
+        "iptables_nft_flush_then_default_accept": "_fix_iptables_atomic",
+        "iptables_save_redirected_to_dev_null": "_fix_iptables_persist",
+        "bsd_pf_conf_block_all_removed_or_disabled": "_fix_pf",
+        # DNS exfil
+        "dns_exfiltration": "_fix_dns_exfil",
+        "dns_over_https_exfil_primary_resolver": "_fix_doh",
+        # Audit / monitoring destruction
+        "rsyslog_or_journald_stopped_masked": "_fix_logging_daemon",
+        "history_log_wiped_or_redirected_dev_null": "_fix_history",
+        "aide_tripwire_samhain_db_destroyed": "_fix_fim",
+        "tetragon_cilium_runtime_observability_disabled_or_masked": "_fix_tetragon",
+        # Cloud guardrail removal
+        "aws_cloudtrail_writeonly_or_trail_deleted": "_fix_aws_cloudtrail",
+        "aws_guardduty_securityhub_config_disabled": "_fix_aws_guardduty",
+        "aws_organizations_scp_detached_or_deleted": "_fix_aws_scp",
+        "aws_iam_user_programmatic_access_key_created_via_playbook": "_fix_aws_iam_key",
+        "azure_defender_sentinel_disabled_or_tier_free": "_fix_azure_defender",
+        "azure_defender_cspm_downgrade_to_free_tier": "_fix_azure_defender",
+        "azure_diagnostic_setting_deleted_or_never_attached": "_fix_azure_diag",
+        "azure_management_lock_removed_subscription_or_rg": "_fix_azure_lock",
+        "backup_repo_immutable_lock_disabled_veeam_commvault_rubrik": "_fix_backup_immutable",
+        # macOS hardening
+        "macos_sip_disabled_csrutil": "_fix_macos_sip",
+        "macos_tcc_db_reset_or_mutation": "_fix_macos_tcc",
+        # Windows hardening
+        "powershell_execution_policy_set_localmachine_bypass": "_fix_win_execpolicy",
+        "smbv1_protocol_enabled_dism_or_powershell": "_fix_win_smbv1",
+        "windows_restrict_anonymous_zero": "_fix_win_restrictanon",
+        "winrm_allow_unencrypted_true": "_fix_win_winrm",
+        "print_spooler_service_enabled_on_domain_controller": "_fix_win_spooler",
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fallback = OperationalSecurityRemediationGenerator()
+
+    def generate_operational_security_fix(self, rule_id: str, code_snippet: str) -> str:
+        method = self._HANDLERS.get(rule_id)
+        if method is None:
+            return self._fallback.generate_operational_security_fix(rule_id, code_snippet)
+        return getattr(self, method)(rule_id, code_snippet)
+
+    def _frame(self, rule_id: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        rec = meta.get("recommendation") or ""
+        body = why
+        if rec:
+            body += f"\n\n{rec}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f6a8 {title} ({rule_id}):**\n{body}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    # ---- Package sources / supply ---------------------------------------
+
+    def _fix_apt_repo(self, rule_id: str, code_snippet: str) -> str:
+        repo = (
+            _first(code_snippet, r"repo=[\"']?(\S+?)[\"']?\s", r"(ppa:\S+)", r"(https?://\S+)")
+            or "{{ approved_apt_repo }}"
+        )
+        why = (
+            "Pulling APT packages from an unvetted third-party repo trusts that "
+            "publisher with root on every managed host. Point at an approved internal "
+            "mirror and pin the signing key so the source is reviewable."
+        )
+        fix = (
+            "- name: trust only the approved repo signing key\n"
+            "  ansible.builtin.get_url:\n"
+            '    url: "{{ apt_mirror_key_url }}"\n'
+            "    dest: /etc/apt/keyrings/internal-mirror.asc\n"
+            '    mode: "0644"\n'
+            "\n"
+            "- name: add approved internal mirror only\n"
+            "  ansible.builtin.apt_repository:\n"
+            '    repo: "deb [signed-by=/etc/apt/keyrings/internal-mirror.asc] {{ apt_mirror_url }} {{ ansible_distribution_release }} main"\n'
+            "    state: present\n"
+            "    filename: internal-mirror\n"
+            f"# original source seen: {repo}\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_yum_repo(self, rule_id: str, code_snippet: str) -> str:
+        url = (
+            _first(code_snippet, r"--add-repo\s+(\S+)", r"(https?://\S+)")
+            or "{{ approved_yum_repo }}"
+        )
+        why = (
+            "`dnf config-manager --add-repo` from the internet trusts that mirror with "
+            "root. Define the repo declaratively against an approved mirror with "
+            "gpgcheck enforced."
+        )
+        fix = (
+            "- name: define approved repo with gpgcheck enforced\n"
+            "  ansible.builtin.yum_repository:\n"
+            "    name: internal-mirror\n"
+            '    description: "Approved internal mirror"\n'
+            f'    baseurl: "{{{{ yum_mirror_url }}}}"\n'
+            "    gpgcheck: true\n"
+            '    gpgkey: "{{ yum_mirror_gpgkey_url }}"\n'
+            "    enabled: true\n"
+            f"# original source seen: {url}\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_galaxy(self, rule_id: str, code_snippet: str) -> str:
+        role = (
+            _first(code_snippet, r"ansible-galaxy\s+(?:install|collection install)\s+(\S+)")
+            or "{{ role_name }}"
+        )
+        why = (
+            "Installing a Galaxy role/collection by name with no version pin pulls "
+            "whatever the latest publish is - a supply-chain risk. Install from a "
+            "pinned requirements file against your internal Galaxy/Automation Hub."
+        )
+        fix = (
+            "# requirements.yml (pin every entry to a version and source)\n"
+            "roles:\n"
+            f"  - name: {role}\n"
+            '    version: "1.2.3"\n'
+            '    source: "{{ internal_galaxy_url }}"\n'
+            "\n"
+            "# playbook / CI\n"
+            "- name: install pinned dependencies only\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: ansible-galaxy install -r requirements.yml\n"
+            "  changed_when: false\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_git_clone(self, rule_id: str, code_snippet: str) -> str:
+        repo = (
+            _first(code_snippet, r"git clone\s+(\S+)", r"repo=(\S+)", r"(https?://\S+\.git)")
+            or "{{ git_repo_url }}"
+        )
+        why = (
+            "Cloning an external repo without pinning a tag/SHA runs whatever HEAD is at "
+            "clone time. Pin to an immutable ref and prefer an internal mirror."
+        )
+        fix = (
+            "- name: clone pinned to an immutable ref from internal mirror\n"
+            "  ansible.builtin.git:\n"
+            f'    repo: "{repo}"\n'
+            '    dest: "{{ clone_dest }}"\n'
+            '    version: "{{ pinned_commit_sha }}"\n'
+            "    accept_hostkey: false\n"
+            "    update: false\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- PKI / certs -----------------------------------------------------
+
+    def _fix_ca_cert(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Adding a CA to the system trust store lets its holder mint certificates "
+            "your hosts will trust - a TLS-interception primitive. Install only the "
+            "approved enterprise CA through a reviewed PKI workflow."
+        )
+        fix = (
+            "- name: install only the approved enterprise CA\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ approved_enterprise_ca_pem }}"\n'
+            "    dest: /etc/pki/ca-trust/source/anchors/enterprise-ca.crt\n"
+            '    mode: "0644"\n'
+            "  register: ca_added\n"
+            "\n"
+            "- name: refresh trust store\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: update-ca-trust extract\n"
+            "  when: ca_added is changed\n"
+            "  changed_when: ca_added is changed\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ssl_cert(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Generating long-lived self-signed certs in a playbook produces untracked "
+            "trust anchors with no revocation path. Request certs from an approved CA "
+            "(internal ACME / Let's Encrypt) instead."
+        )
+        fix = (
+            "- name: request cert from approved ACME CA\n"
+            "  community.crypto.acme_certificate:\n"
+            '    acme_directory: "{{ acme_directory_url }}"\n'
+            "    acme_version: 2\n"
+            '    account_key_src: "{{ acme_account_key }}"\n'
+            '    csr: "{{ csr_path }}"\n'
+            '    cert: "{{ cert_path }}"\n'
+            '    fullchain: "{{ fullchain_path }}"\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Recon / attack tooling (refuse) --------------------------------
+
+    def _fix_refuse_recon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Reconnaissance tooling (port/zone/DNS scanning, packet capture) does not "
+            "belong in configuration automation. If a sanctioned security team needs "
+            "it, run it from their tooling under a tracked engagement - gate hard and "
+            "fail closed in the playbook."
+        )
+        fix = (
+            "- name: refuse to run recon tooling from automation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      Network/DNS reconnaissance must run from the authorized security\n"
+            "      team's tooling under a tracked engagement, not from this playbook.\n"
+            "  when: not (authorized_security_engagement | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_refuse_attack(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "This pattern (memory/swap scraping, container escape, ARP spoofing, "
+            "LD_PRELOAD/sysrq abuse, crypto mining) has no legitimate place in "
+            "automation and is a strong compromise indicator. Remove the task and "
+            "investigate the host."
+        )
+        fix = (
+            "# There is no benign version of this task. Remove it and treat the host\n"
+            "# as suspect. The playbook should hard-fail if it is ever reintroduced.\n"
+            "- name: block known-malicious operation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      This operation is an attack technique and is prohibited. Remove the\n"
+            "      task and open an incident to investigate how it was added.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Persistence mechanisms -----------------------------------------
+
+    def _fix_systemd_service(self, rule_id: str, code_snippet: str) -> str:
+        exe = (
+            _first(
+                code_snippet,
+                r"ExecStart\s*=\s*((?:[^\s{]|\{\{.*?\}\})+)",
+                r"nohup\s+((?:[^\s{]|\{\{.*?\}\})+)",
+            )
+            or "/usr/local/bin/{{ service_name }}"
+        )
+        why = (
+            "A service whose ExecStart points at /tmp or a user-writable path (or a "
+            "nohup'd background process) is classic persistence. Ship the binary to a "
+            "managed, root-owned path and run it as a reviewed unit with hardening on."
+        )
+        fix = (
+            "- name: install the service binary to a managed location\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ service_artifact }}"\n'
+            "    dest: /usr/local/bin/{{ service_name }}\n"
+            "    owner: root\n"
+            "    group: root\n"
+            '    mode: "0755"\n'
+            "\n"
+            "- name: define the unit through config management\n"
+            "  ansible.builtin.template:\n"
+            '    src: "{{ service_name }}.service.j2"\n'
+            "    dest: /etc/systemd/system/{{ service_name }}.service\n"
+            '    mode: "0644"\n'
+            "  notify: reload systemd\n"
+            f"# original ExecStart seen: {exe}\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_systemd_timer(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Transient `systemd-run --on-calendar` timers (and ad-hoc .timer files) "
+            "bypass unit-file review and are a stealthy persistence path. Define a "
+            "reviewed .timer + .service pair under config management."
+        )
+        fix = (
+            "- name: deploy reviewed timer unit\n"
+            "  ansible.builtin.template:\n"
+            '    src: "{{ timer_name }}.timer.j2"\n'
+            "    dest: /etc/systemd/system/{{ timer_name }}.timer\n"
+            '    mode: "0644"\n'
+            "  notify: reload systemd\n"
+            "\n"
+            "- name: enable the timer\n"
+            "  ansible.builtin.systemd:\n"
+            '    name: "{{ timer_name }}.timer"\n'
+            "    enabled: true\n"
+            "    state: started\n"
+            "    daemon_reload: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_scheduled(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`at`/`batch`/anacron jobs run outside the audited scheduler and are easy to "
+            "hide. Use the native cron module (or a systemd timer) so the schedule is "
+            "declarative and reviewable."
+        )
+        fix = (
+            "- name: schedule job through the audited cron module\n"
+            "  ansible.builtin.cron:\n"
+            '    name: "{{ job_name }}"\n'
+            "    user: \"{{ job_user | default('root') }}\"\n"
+            '    minute: "0"\n'
+            '    hour: "4"\n'
+            '    job: "{{ job_command }}"\n'
+            '    cron_file: "{{ job_name }}"\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_managed_file_persistence(self, rule_id: str, code_snippet: str) -> str:
+        dest = (
+            _first(
+                code_snippet,
+                r"dest:\s*['\"]?(/[^'\"\s]+)",
+                r"path:\s*['\"]?(/[^'\"\s]+)",
+                r"dest:\s*(\"?\{\{.*?\}\}\"?)",
+                r"path:\s*(\"?\{\{.*?\}\}\"?)",
+            )
+            or "{{ persistence_path }}"
+        )
+        why = (
+            "Autostart entries, udev rules with RUN=, APT hooks, and NM dispatcher "
+            "scripts all execute code automatically and are common persistence spots. "
+            "Deploy the file from source control through config management, gated on "
+            "review, so its contents are auditable."
+        )
+        fix = (
+            "- name: deploy the entry from a reviewed template (gated)\n"
+            "  ansible.builtin.template:\n"
+            '    src: "{{ entry_template }}"\n'
+            f'    dest: "{dest}"\n'
+            "    owner: root\n"
+            "    group: root\n"
+            '    mode: "0644"\n'
+            "  when: persistence_change_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_modules_load(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Files under /etc/modules-load.d auto-load kernel modules at boot. Manage "
+            "the allowed module list through hardening config and gate changes, rather "
+            "than dropping arbitrary auto-load entries."
+        )
+        fix = (
+            "- name: manage approved boot-time modules only\n"
+            "  ansible.builtin.copy:\n"
+            "    dest: /etc/modules-load.d/hardening.conf\n"
+            "    content: \"{{ approved_boot_modules | join('\\n') }}\\n\"\n"
+            "    owner: root\n"
+            "    group: root\n"
+            '    mode: "0644"\n'
+            "  when: kernel_hardening_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_launchdaemon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "LaunchDaemons are legitimate only for signed, notarized, MDM-deployed "
+            "software. Pin the plist to a vendor-namespaced path with an absolute, "
+            "root-owned Program and deploy it through MDM/config management."
+        )
+        fix = (
+            "- name: deploy a signed-software LaunchDaemon with a pinned path\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ vendor_launchdaemon_plist }}"\n'
+            "    dest: /Library/LaunchDaemons/com.{{ vendor }}.{{ service_name }}.plist\n"
+            "    owner: root\n"
+            "    group: wheel\n"
+            '    mode: "0644"\n'
+            "  when: macos_software_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Kernel / boot / low-level --------------------------------------
+
+    def _fix_modprobe(self, rule_id: str, code_snippet: str) -> str:
+        mod = _first(code_snippet, r"modprobe\s+(\S+)", r"name=(\S+)") or "{{ module_name }}"
+        why = (
+            "Loading kernel modules from a playbook can insert rootkits or re-enable "
+            "disabled functionality. Restrict to an approved module via the native "
+            "module, gated on a hardening change."
+        )
+        fix = (
+            "- name: load only an approved kernel module (gated)\n"
+            "  community.general.modprobe:\n"
+            f'    name: "{mod}"\n'
+            "    state: present\n"
+            "  when: kernel_hardening_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ebpf(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Loading eBPF programs grants kernel-level visibility and control. Only the "
+            "platform/security team's signed observability stack should load BPF; refuse "
+            "ad-hoc loads from automation."
+        )
+        fix = (
+            "- name: refuse ad-hoc eBPF loads\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      eBPF programs must be shipped by the approved observability stack\n"
+            "      (e.g. Cilium/Tetragon), not loaded ad-hoc from a playbook.\n"
+            "  when: not (ebpf_load_approved | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_grub(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Bootloader changes execute before security controls and can persist a "
+            "rootkit. Manage GRUB defaults declaratively, gate on change management, "
+            "and regenerate config explicitly."
+        )
+        fix = (
+            "- name: set an approved GRUB default (gated)\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/default/grub\n"
+            '    regexp: "^GRUB_CMDLINE_LINUX="\n'
+            "    line: 'GRUB_CMDLINE_LINUX=\"{{ approved_kernel_cmdline }}\"'\n"
+            "  register: grub_changed\n"
+            "  when: boot_change_approved | default(false) | bool\n"
+            "\n"
+            "- name: regenerate grub config\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: update-grub\n"
+            "  when: grub_changed is changed\n"
+            "  changed_when: grub_changed is changed\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_initramfs(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Initramfs runs at boot before disk encryption and security tooling are up; "
+            "tampering here is high-impact. Only rebuild it as a gated, reviewed change "
+            "after a legitimate driver/hook update."
+        )
+        fix = (
+            "- name: rebuild initramfs only as a reviewed change\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: update-initramfs -u\n"
+            "  register: initramfs_rebuild\n"
+            "  changed_when: initramfs_rebuild.rc == 0\n"
+            "  when: boot_change_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ld_library_path(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Pointing LD_LIBRARY_PATH at a user-writable or untrusted directory lets an "
+            "attacker preload malicious libraries. Don't set it globally; pin "
+            "dependencies through the package manager or a vetted RPATH."
+        )
+        fix = (
+            "- name: install dependencies via the package manager (no LD_LIBRARY_PATH)\n"
+            "  ansible.builtin.package:\n"
+            '    name: "{{ runtime_libraries }}"\n'
+            "    state: present\n"
+            "# If a private lib dir is unavoidable, bake an RPATH at build time and\n"
+            "# keep the directory root-owned and 0755 - never export LD_LIBRARY_PATH\n"
+            "# to a writable path at runtime.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_pam(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Editing /etc/pam.d directly can backdoor authentication (e.g. a rogue "
+            "pam_exec). Manage PAM through a reviewed hardening role using the dedicated "
+            "module so changes are structured and auditable."
+        )
+        fix = (
+            "- name: manage a PAM rule through the native module (gated)\n"
+            "  community.general.pamd:\n"
+            "    name: sshd\n"
+            "    type: auth\n"
+            "    control: required\n"
+            "    module_path: pam_faillock.so\n"
+            '    module_arguments: "preauth silent deny=5 unlock_time=900"\n'
+            "    state: updated\n"
+            "  when: pam_hardening_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_chattr(self, rule_id: str, code_snippet: str) -> str:
+        target = (
+            _first(
+                code_snippet,
+                r"chattr\s+[-+][aAie]+\s+(\"?\{\{.*?\}\}\"?)",
+                r"chattr\s+[-+][aAie]+\s+['\"]?(/[^\s'\"]+)",
+            )
+            or "/var/log/audit/audit.log"
+        )
+        why = (
+            "Removing immutable/append-only flags (`chattr -i/-a`) from security files "
+            "like /etc/shadow, sudoers, sshd_config, or the audit logs clears the way "
+            "for tampering. Keep those files immutable and re-assert the flag."
+        )
+        fix = (
+            "- name: re-assert append-only on the audit log\n"
+            "  ansible.builtin.file:\n"
+            f'    path: "{target}"\n'
+            '    attributes: "+a"\n'
+            "  when: file_hardening_approved | default(true) | bool\n"
+            "\n"
+            "- name: refuse to clear immutability outside a reviewed change\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - file_hardening_approved | default(true) | bool\n"
+            '    fail_msg: "Clearing immutable/append-only flags requires a reviewed change."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_drop_cap(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`--cap-add=SYS_PTRACE` lets a container inject into processes (including "
+            "across containers sharing a PID namespace). Drop all capabilities and add "
+            "back only the minimum; never grant SYS_PTRACE in production."
+        )
+        fix = (
+            "- name: run container with capabilities dropped\n"
+            "  community.docker.docker_container:\n"
+            '    name: "{{ container_name }}"\n'
+            '    image: "{{ image }}"\n'
+            "    cap_drop: [ALL]\n"
+            "    capabilities: []   # add back only what is strictly required\n"
+            "    security_opts:\n"
+            "      - no-new-privileges\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- SSH -------------------------------------------------------------
+
+    def _fix_ssh_tunnel(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Opening an SSH tunnel (`-R`/`-L`/`-D`) from a playbook builds an ad-hoc "
+            "network path that bypasses VPN and firewall controls. Use the sanctioned "
+            "remote-access solution instead of tunneling from automation."
+        )
+        fix = (
+            "# Reach the remote service through the approved access path, not a tunnel.\n"
+            "- name: call internal service via the sanctioned gateway\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "{{ internal_service_url_via_gateway }}"\n'
+            "    method: GET\n"
+            "    validate_certs: true\n"
+            "# For host access, target it through inventory over the approved VPN/bastion\n"
+            "# rather than building an SSH tunnel inside the play.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ssh_config(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Weakening sshd_config (enabling PasswordAuthentication, PermitRootLogin, "
+            "etc.) regresses host hardening. Enforce the CIS-aligned values and validate "
+            "the config before reload."
+        )
+        fix = (
+            "- name: enforce hardened sshd settings\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/ssh/sshd_config\n"
+            '    regexp: "^#?{{ item.key }}"\n'
+            '    line: "{{ item.key }} {{ item.value }}"\n'
+            '    validate: "sshd -t -f %s"\n'
+            "  loop:\n"
+            '    - { key: "PasswordAuthentication", value: "no" }\n'
+            '    - { key: "PermitRootLogin", value: "no" }\n'
+            '    - { key: "KbdInteractiveAuthentication", value: "no" }\n'
+            "  notify: reload sshd\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_authorized_keys(self, rule_id: str, code_snippet: str) -> str:
+        user = _first(code_snippet, r"/home/([^/\s'\"{}]+)/", r"user=(\S+)") or "{{ user_name }}"
+        why = (
+            "Writing authorized_keys directly can silently grant SSH access. Manage keys "
+            "centrally with the native module using `exclusive: true` so only reviewed "
+            "keys remain present."
+        )
+        fix = (
+            "- name: manage authorized keys from the central source of truth\n"
+            "  ansible.posix.authorized_key:\n"
+            f'    user: "{user}"\n'
+            "    key: \"{{ approved_public_keys | join('\\n') }}\"\n"
+            "    exclusive: true\n"
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Credentials on disk / secret leak ------------------------------
+
+    def _fix_db_creds(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Passing DB passwords inline (`-a`, `--password=`) leaks them into the "
+            "process list and task log. Pull the secret from Vault with `no_log: true` "
+            "and pass it via a credential file or environment, not argv."
+        )
+        fix = (
+            "- name: fetch DB password from Vault (no_log)\n"
+            "  ansible.builtin.set_fact:\n"
+            "    db_password: \"{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/db:password') }}\"\n"
+            "  no_log: true\n"
+            "\n"
+            "- name: run query without exposing the secret in argv\n"
+            "  ansible.builtin.command:\n"
+            '    cmd: "psql -h {{ db_host }} -c \\"{{ query }}\\""\n'
+            "  environment:\n"
+            '    PGPASSWORD: "{{ db_password }}"\n'
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_cred_file(self, rule_id: str, code_snippet: str) -> str:
+        dest = _first(code_snippet, r"dest:\s*['\"]?([^'\"\s]+)") or "{{ credential_path }}"
+        why = (
+            "Writing credential dotfiles (.netrc, .pgpass) to disk leaves long-lived "
+            "secrets unprotected. Source them from Vault/SSM at run time with "
+            "`no_log: true` instead of persisting them."
+        )
+        fix = (
+            "- name: fetch credentials at run time (not written to disk)\n"
+            "  ansible.builtin.set_fact:\n"
+            "    runtime_credential: \"{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/app:token') }}\"\n"
+            "  no_log: true\n"
+            f"# If a dotfile is truly required, template it 0600, owned by the run user,\n"
+            f"# from the vaulted value - never commit it. (was: {dest})\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_aws_cred_file(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Persisting ~/.aws/credentials puts long-lived keys on disk. Use an instance "
+            "profile / IRSA / SSO so no static credential file exists."
+        )
+        fix = (
+            "# No credential file: the role comes from the environment.\n"
+            "- name: call AWS using the instance/role identity\n"
+            "  amazon.aws.aws_caller_info:\n"
+            "  register: whoami\n"
+            "  no_log: true\n"
+            "# EC2 -> instance profile; EKS -> IRSA; laptops/CI -> aws sso login.\n"
+            "# Remove any task that writes ~/.aws/credentials.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_proxy_creds(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Embedding `user:pass@` in a proxy URL leaks the credential into env vars, "
+            "logs, and child processes. Keep the proxy host in config and the secret in "
+            "Vault, injected at run time with `no_log`."
+        )
+        fix = (
+            "- name: configure proxy without inline credentials\n"
+            "  ansible.builtin.get_url:\n"
+            '    url: "{{ artifact_url }}"\n'
+            '    dest: "{{ dest_path }}"\n'
+            "  environment:\n"
+            '    https_proxy: "http://{{ proxy_host }}:{{ proxy_port }}"\n'
+            '    https_proxy_user: "{{ vault_proxy_user }}"\n'
+            '    https_proxy_pass: "{{ vault_proxy_pass }}"\n'
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_rhsm(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`subscription-manager register --password=` exposes the RHSM password in "
+            "argv and logs. Use the native module with a vaulted activation key and "
+            "`no_log: true`."
+        )
+        fix = (
+            "- name: register host via vaulted activation key\n"
+            "  community.general.redhat_subscription:\n"
+            "    state: present\n"
+            '    activationkey: "{{ vault_rhsm_activation_key }}"\n'
+            '    org_id: "{{ rhsm_org_id }}"\n'
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_laps(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Bulk LAPS reads from automation defeat the just-in-time, per-host model and "
+            "expose every local admin password at once. Read a single host's password "
+            "interactively, scoped and audited, with `no_log`."
+        )
+        fix = (
+            "- name: read ONE host's LAPS password, just-in-time (no_log)\n"
+            "  ansible.windows.win_powershell:\n"
+            "    script: |\n"
+            "      Get-LapsADPassword -Identity $env:TARGET_HOST -AsPlainText\n"
+            "  environment:\n"
+            '    TARGET_HOST: "{{ single_target_host }}"\n'
+            "  no_log: true\n"
+            "  when: laps_read_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_krbtgt(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "krbtgt resets must follow Microsoft's two-reset procedure with a >10 hour "
+            "gap and be driven by an IR runbook, never routine config. The secure shape "
+            "refuses to run this outside an authorized incident."
+        )
+        fix = (
+            "- name: refuse routine krbtgt reset\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      krbtgt resets follow the Microsoft two-reset procedure (>10h gap)\n"
+            "      and must be driven by the IR runbook, not this playbook.\n"
+            "  when: not (krbtgt_ir_runbook_authorized | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- BMC / hardware --------------------------------------------------
+
+    def _fix_bmc(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "IPMI/Redfish grant hardware-level control (power, virtual media, firmware). "
+            "Calls must use a vaulted, scoped service credential over TLS with "
+            "`no_log: true`, and be restricted to the OOB management network."
+        )
+        fix = (
+            "- name: call BMC over TLS with a vaulted credential\n"
+            "  community.general.redfish_command:\n"
+            "    category: Systems\n"
+            "    command: PowerGracefulRestart\n"
+            '    baseuri: "{{ bmc_host }}"\n'
+            '    username: "{{ vault_bmc_user }}"\n'
+            '    password: "{{ vault_bmc_password }}"\n'
+            "  no_log: true\n"
+            "  delegate_to: localhost\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Firewall / network control -------------------------------------
+
+    def _fix_firewall_linux(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`iptables -F` (or stopping the firewall) drops all host filtering and "
+            "exposes every service. Manage rules declaratively and load them atomically; "
+            "never flush without the replacement ruleset in the same transaction."
+        )
+        fix = (
+            "- name: load the canonical ruleset atomically\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ rules_v4_file }}"\n'
+            "    dest: /etc/iptables/rules.v4\n"
+            '    mode: "0644"\n'
+            "  register: rules_file\n"
+            "\n"
+            "- name: apply rules in one transaction\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: iptables-restore /etc/iptables/rules.v4\n"
+            "  when: rules_file is changed\n"
+            "  changed_when: rules_file is changed\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_firewalld(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Flushing or disabling firewalld on production RHEL removes host filtering. "
+            "Add the specific rule you need through the native module with the change "
+            "made permanent and reloaded - don't disable the service."
+        )
+        fix = (
+            "- name: add a scoped permanent rule (no flush/disable)\n"
+            "  ansible.posix.firewalld:\n"
+            "    zone: public\n"
+            "    service: https\n"
+            "    permanent: true\n"
+            "    immediate: true\n"
+            "    state: enabled\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_iptables_nat(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Ad-hoc NAT/redirect rules can silently reroute traffic to an attacker. "
+            "Manage NAT through your network infrastructure or a reviewed, version-"
+            "controlled ruleset, not inline playbook commands."
+        )
+        fix = (
+            "- name: manage NAT rules from the reviewed ruleset only\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ nat_rules_v4_file }}"\n'
+            "    dest: /etc/iptables/rules.v4\n"
+            '    mode: "0644"\n'
+            "  notify: reload netfilter\n"
+            "# Keep all NAT/POSTROUTING rules in version control; apply via\n"
+            "# iptables-restore so changes are diffable and reviewable.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_iptables_atomic(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Flushing then setting the default policy to ACCEPT leaves the host wide "
+            "open between the two commands. Replace the ruleset atomically with "
+            "iptables-restore so the host is never unprotected."
+        )
+        fix = (
+            "- name: replace ruleset atomically (never flush-then-accept)\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: iptables-restore /etc/iptables/rules.v4\n"
+            "  changed_when: false\n"
+            "# /etc/iptables/rules.v4 must set default DROP for INPUT/FORWARD and\n"
+            "# whitelist required services - applied in a single transaction.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_iptables_persist(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Redirecting `iptables-save` to /dev/null throws away the running ruleset so "
+            "it is lost on reboot. Persist rules to the distro's canonical location "
+            "instead."
+        )
+        fix = (
+            "- name: persist firewall rules to the canonical path\n"
+            "  community.general.iptables_state:\n"
+            "    state: saved\n"
+            "    path: /etc/iptables/rules.v4\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_pf(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`pfctl -F all` (or disabling pf) removes all packet filtering on BSD/macOS. "
+            "Keep /etc/pf.conf default-deny and load it; never flush without a "
+            "replacement default-block ruleset."
+        )
+        fix = (
+            "- name: deploy default-deny pf.conf and load it\n"
+            "  ansible.builtin.copy:\n"
+            '    src: "{{ pf_conf_file }}"   # starts: set skip on lo / block return all\n'
+            "    dest: /etc/pf.conf\n"
+            '    mode: "0644"\n'
+            "  register: pf_conf\n"
+            "\n"
+            "- name: load pf ruleset\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: pfctl -f /etc/pf.conf -e\n"
+            "  when: pf_conf is changed\n"
+            "  changed_when: pf_conf is changed\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- DNS exfil -------------------------------------------------------
+
+    def _fix_dns_exfil(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "DNS queries that embed dynamic/variable data are a classic exfiltration "
+            "channel. Send data over an authenticated HTTPS API to a known endpoint, "
+            "not via crafted DNS lookups."
+        )
+        fix = (
+            "- name: send data over an authenticated HTTPS API (not DNS)\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "{{ telemetry_api_url }}"\n'
+            "    method: POST\n"
+            "    headers:\n"
+            '      Authorization: "Bearer {{ vault_api_token }}"\n'
+            "    body_format: json\n"
+            '    body: "{{ payload }}"\n'
+            "    validate_certs: true\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_doh(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Pointing the primary resolver at a public DoH endpoint bypasses enterprise "
+            "DNS inspection and is a covert exfil channel. Point DoH at the enterprise "
+            "secure gateway so queries stay inspected."
+        )
+        fix = (
+            "- name: pin resolver to the enterprise DoH gateway\n"
+            "  ansible.builtin.copy:\n"
+            "    dest: /etc/systemd/resolved.conf.d/enterprise-doh.conf\n"
+            "    content: |\n"
+            "      [Resolve]\n"
+            "      DNS={{ enterprise_doh_gateway_ip }}#{{ enterprise_doh_hostname }}\n"
+            "      DNSOverTLS=yes\n"
+            "      Domains=~.\n"
+            '    mode: "0644"\n'
+            "  notify: restart systemd-resolved\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Audit / monitoring destruction ---------------------------------
+
+    def _fix_logging_daemon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Stopping or masking rsyslog/journald blinds the host's local audit trail. "
+            "Keep the logging daemon enabled and running and assert persistent storage; "
+            "any brief stop must be a tightly-scoped handler that restarts it."
+        )
+        fix = (
+            "- name: ensure persistent journald storage\n"
+            "  ansible.builtin.lineinfile:\n"
+            "    path: /etc/systemd/journald.conf\n"
+            '    regexp: "^#?Storage="\n'
+            '    line: "Storage=persistent"\n'
+            "  notify: restart systemd-journald\n"
+            "\n"
+            "- name: keep the logging daemon running and enabled\n"
+            "  ansible.builtin.service:\n"
+            "    name: \"{{ logging_service | default('rsyslog') }}\"\n"
+            "    state: started\n"
+            "    enabled: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_history(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Wiping shell history or redirecting it to /dev/null is anti-forensics. "
+            "Don't disable history; for log-size control use logrotate, and ship shell "
+            "audit events to the SIEM via auditd/execve logging."
+        )
+        fix = (
+            "- name: rotate logs instead of wiping history\n"
+            "  ansible.builtin.copy:\n"
+            "    dest: /etc/logrotate.d/app\n"
+            "    content: |\n"
+            "      {{ app_log_glob }} {\n"
+            "        weekly\n"
+            "        rotate 8\n"
+            "        compress\n"
+            "        copytruncate\n"
+            "        maxsize 100M\n"
+            "      }\n"
+            '    mode: "0644"\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_fim(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Destroying the AIDE/Tripwire/Samhain database erases the file-integrity "
+            "baseline and hides tampering. Archive the current DB to append-only "
+            "off-host storage before any legitimate reinit, and treat unexplained "
+            "destruction as an incident."
+        )
+        fix = (
+            "- name: archive FIM DB off-host before any reinit\n"
+            "  amazon.aws.s3_object:\n"
+            '    bucket: "{{ forensic_vault_bucket }}"\n'
+            '    object: "fim/{{ inventory_hostname }}/{{ ansible_date_time.iso8601 }}/aide.db"\n'
+            "    src: /var/lib/aide/aide.db\n"
+            "    mode: put\n"
+            "  when: fim_reinit_approved | default(false) | bool\n"
+            "\n"
+            "- name: reinitialize the FIM baseline (only after archive)\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: aide --init\n"
+            "  when: fim_reinit_approved | default(false) | bool\n"
+            "  changed_when: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_tetragon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Stopping or masking Tetragon on a Cilium-protected cluster disables runtime "
+            "observability. Keep it running and narrow noisy policy by tightening "
+            "TracingPolicy selectors, not by disabling the agent."
+        )
+        fix = (
+            "- name: keep Tetragon running and enabled\n"
+            "  ansible.builtin.systemd:\n"
+            "    name: tetragon\n"
+            "    state: started\n"
+            "    enabled: true\n"
+            "    masked: false\n"
+            "# Tune signal volume by scoping TracingPolicy selectors (namespace, pod\n"
+            "# label, binary path) - never by stopping the agent.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Cloud guardrail removal ----------------------------------------
+
+    def _fix_aws_cloudtrail(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Disabling, deleting, or making CloudTrail write-only is an active-incident "
+            "signal. Re-enable multi-region logging with validation immediately and "
+            "assert it stays on."
+        )
+        fix = (
+            "- name: re-enable validated multi-region CloudTrail\n"
+            "  amazon.aws.cloudtrail:\n"
+            '    name: "{{ trail_name }}"\n'
+            "    state: present\n"
+            "    is_multi_region_trail: true\n"
+            "    enable_log_file_validation: true\n"
+            '    s3_bucket_name: "{{ trail_bucket }}"\n'
+            "\n"
+            "- name: forbid disabling the trail\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - not (disable_cloudtrail | default(false) | bool)\n"
+            '    fail_msg: "Disabling CloudTrail is prohibited; investigate this change."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_aws_guardduty(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Disabling GuardDuty/Security Hub removes threat detection. Re-enable the "
+            "detector and protect the disable APIs behind an org-level SCP so only the "
+            "delegated security admin can change them."
+        )
+        fix = (
+            "- name: ensure GuardDuty detector is enabled\n"
+            "  community.aws.guardduty_detector:\n"
+            "    state: present\n"
+            "    enable: true\n"
+            '    finding_publishing_frequency: "FIFTEEN_MINUTES"\n'
+            "# Back this with an SCP denying guardduty:Delete*/Disable* and\n"
+            "# securityhub:Disable* except from the delegated-admin security account.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_aws_scp(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Detaching or deleting a Service Control Policy removes org-wide guardrails. "
+            "SCP changes need dual control behind a break-glass MFA role; refuse to make "
+            "them from routine automation."
+        )
+        fix = (
+            "- name: refuse SCP detach/delete from routine automation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      SCP changes require dual-control via the break-glass role with MFA.\n"
+            "      Remove this task from the playbook.\n"
+            "  when: not (scp_break_glass_authorized | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_aws_iam_key(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Creating long-lived IAM programmatic access keys from a playbook produces "
+            "credentials that rarely get rotated. Use IAM Identity Center permission "
+            "sets / roles for human and federated access; refuse static-key creation."
+        )
+        fix = (
+            "- name: refuse static IAM key creation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      Use IAM Identity Center permission sets or a federated role instead\n"
+            "      of long-lived access keys. Remove this iam_access_key task.\n"
+            "  when: not (legacy_static_key_approved | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_azure_defender(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Downgrading Microsoft Defender for Cloud to the Free tier (or disabling "
+            "Sentinel) removes cloud threat protection. Keep all plans on Standard for "
+            "production and enforce the minimum tier via Azure Policy."
+        )
+        fix = (
+            "- name: keep Defender plans on Standard tier\n"
+            "  azure.azcollection.azure_rm_securitypricing:\n"
+            '    name: "{{ item }}"\n'
+            "    tier: Standard\n"
+            "  loop:\n"
+            "    - VirtualMachines\n"
+            "    - StorageAccounts\n"
+            "    - KeyVaults\n"
+            "    - Containers\n"
+            "    - SqlServers\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_azure_diag(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Deleting (or never attaching) diagnostic settings stops log delivery to the "
+            "SIEM. Keep diagnostics shipping to Log Analytics and enforce them via Azure "
+            "Policy DeployIfNotExists."
+        )
+        fix = (
+            "- name: ensure diagnostics ship to Log Analytics\n"
+            "  azure.azcollection.azure_rm_monitordiagnosticsetting:\n"
+            '    name: "{{ diagnostic_setting_name }}"\n'
+            '    resource: "{{ monitored_resource_id }}"\n'
+            '    log_analytics_workspace_id: "{{ law_workspace_id }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_azure_lock(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Removing a CanNotDelete management lock clears the way to delete production "
+            "resources. Keep the lock in place and enforce it via Azure Policy; gate any "
+            "removal behind a reviewed change."
+        )
+        fix = (
+            "- name: ensure CanNotDelete lock stays on production scope\n"
+            "  azure.azcollection.azure_rm_lock:\n"
+            '    name: "{{ lock_name }}"\n'
+            '    managed_resource_id: "/subscriptions/{{ subscription_id }}"\n'
+            "    level: can_not_delete\n"
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_backup_immutable(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Setting backup immutability/retention to 0 lets ransomware delete the "
+            "backups it just bypassed. Enforce immutability with a minimum retention "
+            "appropriate to your compliance scope."
+        )
+        fix = (
+            "- name: enforce minimum immutable retention on the backup repo\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "{{ backup_api_url }}/repositories/{{ repo_id }}/immutability"\n'
+            "    method: PUT\n"
+            "    headers:\n"
+            '      Authorization: "Bearer {{ vault_backup_api_token }}"\n'
+            "    body_format: json\n"
+            "    body:\n"
+            "      enabled: true\n"
+            '      retentionDays: "{{ backup_immutable_days | default(14) }}"\n'
+            "    status_code: [200, 204]\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- macOS hardening -------------------------------------------------
+
+    def _fix_macos_sip(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`csrutil disable` turns off System Integrity Protection, the macOS kernel "
+            "and system-file guardrail. Never disable it on fleet machines; assert it is "
+            "enabled instead."
+        )
+        fix = (
+            "- name: assert SIP is enabled (never disable on the fleet)\n"
+            "  ansible.builtin.command:\n"
+            "    cmd: csrutil status\n"
+            "  register: sip\n"
+            "  changed_when: false\n"
+            "  failed_when: \"'enabled' not in sip.stdout\"\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_macos_tcc(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Resetting or mutating the TCC privacy database from a playbook silently "
+            "grants or wipes privacy permissions. Manage TCC only through an MDM PPPC "
+            "configuration profile; refuse direct tccutil mutation."
+        )
+        fix = (
+            "- name: refuse direct TCC.db mutation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      Privacy permissions must be granted via the MDM PPPC payload\n"
+            "      (com.apple.TCC.configuration-profile-policy), not tccutil.\n"
+            "  when: not (mdm_pppc_profile_managed | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Windows hardening ----------------------------------------------
+
+    def _fix_win_execpolicy(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Setting the PowerShell execution policy to Bypass at LocalMachine scope "
+            "lets any unsigned/downloaded script run. Use RemoteSigned so downloaded "
+            "scripts must be signed while local admin scripting still works."
+        )
+        fix = (
+            "- name: set RemoteSigned execution policy (not Bypass)\n"
+            "  ansible.windows.win_powershell:\n"
+            "    script: |\n"
+            "      Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_win_smbv1(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "SMBv1 is the EternalBlue/WannaCry transport and must be disabled. Turn off "
+            "the SMB1 protocol and remove the optional feature everywhere."
+        )
+        fix = (
+            "- name: disable SMBv1 server protocol\n"
+            "  ansible.windows.win_powershell:\n"
+            "    script: |\n"
+            "      Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force\n"
+            "\n"
+            "- name: remove the SMB1 optional feature\n"
+            "  ansible.windows.win_optional_feature:\n"
+            "    name: SMB1Protocol\n"
+            "    state: absent\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_win_restrictanon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Setting RestrictAnonymous = 0 allows anonymous enumeration of accounts and "
+            "shares. Restore the hardened baseline so anonymous access is restricted."
+        )
+        fix = (
+            "- name: restrict anonymous enumeration (CIS baseline)\n"
+            "  ansible.windows.win_regedit:\n"
+            "    path: HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Lsa\n"
+            '    name: "{{ item.name }}"\n'
+            '    data: "{{ item.data }}"\n'
+            "    type: dword\n"
+            "  loop:\n"
+            '    - { name: "RestrictAnonymous", data: 1 }\n'
+            '    - { name: "RestrictAnonymousSAM", data: 1 }\n'
+            '    - { name: "EveryoneIncludesAnonymous", data: 0 }\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_win_winrm(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`AllowUnencrypted=true` sends WinRM traffic (including credentials) in the "
+            "clear. Force WinRM over HTTPS with a trusted cert and keep unencrypted "
+            "transport disabled."
+        )
+        fix = (
+            "- name: forbid unencrypted WinRM\n"
+            "  ansible.windows.win_powershell:\n"
+            "    script: |\n"
+            "      Set-Item -Path WSMan:\\localhost\\Service\\AllowUnencrypted -Value $false\n"
+            "# Configure the HTTPS listener (5986) with a CA-issued cert and disable\n"
+            "# the HTTP listener so all WinRM traffic is encrypted.\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_win_spooler(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "The Print Spooler on a Domain Controller is the PrintNightmare attack "
+            "surface and should never run there. Stop and disable it on every DC."
+        )
+        fix = (
+            "- name: stop and disable Print Spooler on domain controllers\n"
+            "  ansible.windows.win_service:\n"
+            "    name: Spooler\n"
+            "    state: stopped\n"
+            "    start_mode: disabled\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)

--- a/src/ansible_security_scanner/remediations/permissions.py
+++ b/src/ansible_security_scanner/remediations/permissions.py
@@ -3,7 +3,7 @@
 Permissions remediation generator for Ansible Security Scanner
 """
 
-from .base import BaseRemediationGenerator
+from .base import BaseRemediationGenerator, _append_keys, _drop_key_lines, _first
 
 
 class PermissionsRemediationGenerator(BaseRemediationGenerator):
@@ -20,6 +20,11 @@ class PermissionsRemediationGenerator(BaseRemediationGenerator):
         if rule_id in cfg_fixes:
             return cfg_fixes[rule_id](self, code_snippet)
 
+        if rule_id == "credential_file_missing_mode":
+            return self._generate_missing_mode_fix(code_snippet)
+        if rule_id == "private_key_written_outside_canonical_dir_ast":
+            return self._generate_private_key_path_fix(code_snippet)
+
         if "/etc/passwd" in code_snippet or "/etc/shadow" in code_snippet:
             return self._generate_system_file_permissions_fix(code_snippet)
         if ".ssh/" in code_snippet or "id_rsa" in code_snippet:
@@ -29,6 +34,53 @@ class PermissionsRemediationGenerator(BaseRemediationGenerator):
         if "sudoers" in code_snippet:
             return self._generate_sudoers_permissions_fix(code_snippet)
         return self._generate_generic_permissions_fix(code_snippet)
+
+    def _generate_missing_mode_fix(self, code_snippet: str) -> str:
+        dest = (
+            _first(code_snippet, r"dest:\s*[\"']?((?:\{\{.*?\}\}|[^\s\"'])+)") or "the destination"
+        )
+        fixed = _append_keys(_drop_key_lines(code_snippet, "mode"), "mode: '0600'")
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Credential File Created Without an Explicit Mode:**
+`{dest}` is written with no `mode:`, so it falls back to the remote umask
+(typically world-readable `0644`) - any local user can read the secret.
+
+**✅ Secure Fix Example:**
+```yaml
+{fixed}
+```
+
+Pin `mode: '0600'` (or `'0640'` with a trusted group) and keep `owner:`/`group:`
+scoped to the consuming service account.
+"""
+
+    def _generate_private_key_path_fix(self, code_snippet: str) -> str:
+        fixed = _append_keys(_drop_key_lines(code_snippet, "mode"), "mode: '0600'")
+        return f"""
+**❌ Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**🚨 Private Key Written to a Non-Canonical, World-Readable Path:**
+Key material under `/tmp`, `/opt`, `/srv`, `/var/log` (etc.) is reachable by
+other users and outside the path operators audit for secrets.
+
+**✅ Secure Fix Example:**
+```yaml
+{fixed}
+```
+
+Move `dest:` under the canonical home for the key type - `~/.ssh/` for SSH
+keys, `/etc/ssl/private/`, `/etc/pki/tls/private/`, or
+`/etc/letsencrypt/live/` for TLS - then keep `mode: '0600'`, `owner:`, and
+`group:` scoped to the consuming service account.
+"""
 
     def _generate_system_file_permissions_fix(self, code_snippet: str) -> str:
         """Generate fix for system file permissions"""

--- a/src/ansible_security_scanner/remediations/remediation_generator.py
+++ b/src/ansible_security_scanner/remediations/remediation_generator.py
@@ -12,6 +12,7 @@ from ._category_map import resolve_category as _resolve_category
 from .ai_ml_security import AiMlSecurityRemediationGenerator
 from .ansible_hygiene import AnsibleHygieneRemediationGenerator
 from .ansible_specific import AnsibleSpecificRemediationGenerator
+from .anti_forensics import AntiForensicsRemediationGenerator
 from .base import BaseRemediationGenerator, _render_from_metadata
 from .become_delegate_misuse import BecomeDelegateMisuseRemediationGenerator
 from .callback_plugin_risk import CallbackPluginRiskRemediationGenerator
@@ -19,23 +20,32 @@ from .command_injection import CommandInjectionRemediationGenerator
 from .credentials import CredentialsRemediationGenerator
 from .curl import CurlRemediationGenerator
 from .dangerous_modules import DangerousModulesRemediationGenerator
+from .data_destruction import DataDestructionRemediationGenerator
 from .data_exfiltration import DataExfiltrationRemediationGenerator
+from .environment_hijacking import EnvironmentHijackingRemediationGenerator
 from .external_urls import ExternalUrlsRemediationGenerator
 from .galaxy_supply_chain import GalaxySupplyChainRemediationGenerator
 from .insecure_communication import InsecureCommunicationRemediationGenerator
 from .k8s_insecure_spec import K8sInsecureSpecRemediationGenerator
-from .malicious_activity import MaliciousActivityRemediationGenerator
-from .operational_security import OperationalSecurityRemediationGenerator
+from .lateral_movement import LateralMovementRemediationGenerator
+from .malicious_activity_exploits import MaliciousActivityExploitRemediationGenerator
+from .offensive_tools import OffensiveToolsRemediationGenerator
+from .operational_security_procedural import (
+    OperationalSecurityProceduralRemediationGenerator,
+)
 from .permissions import PermissionsRemediationGenerator
 from .privilege_escalation import PrivilegeEscalationRemediationGenerator
 from .ssh_trust_bypass import SshTrustBypassRemediationGenerator
 from .supply_chain import SupplyChainRemediationGenerator
-from .system_compromise import SystemCompromiseRemediationGenerator
 from .taint_flow import TaintFlowRemediationGenerator
 from .template_injection import TemplateInjectionRemediationGenerator
-from .unauthorized_cloud_access import UnauthorizedCloudAccessRemediationGenerator
+from .tunneling import TunnelingRemediationGenerator
+from .unauthorized_cloud_procedural import (
+    UnauthorizedCloudProceduralRemediationGenerator,
+)
 from .variables import VariableInjectionRemediationGenerator
 from .vault_hygiene import VaultHygieneRemediationGenerator
+from .webshell_deployment import WebshellRemediationGenerator
 
 _VULN_FENCE_RE = re.compile(
     r"(\*\*(?:[^*]+\s)?Vulnerable Code:\*\*\s*\n```[a-zA-Z0-9]*\n)(.*?)(\n```)",
@@ -77,20 +87,26 @@ class RemediationGenerator(BaseRemediationGenerator):
             "webhook_exposure": CredentialsRemediationGenerator(),
             "unsafe_permissions": PermissionsRemediationGenerator(),
             "variable_injection": VariableInjectionRemediationGenerator(),
-            "system_compromise": SystemCompromiseRemediationGenerator(),
-            "malicious_activity": MaliciousActivityRemediationGenerator(),
+            "malicious_activity": MaliciousActivityExploitRemediationGenerator(),
+            "lateral_movement": LateralMovementRemediationGenerator(),
+            "anti_forensics": AntiForensicsRemediationGenerator(),
+            "offensive_tools": OffensiveToolsRemediationGenerator(),
+            "webshell_deployment": WebshellRemediationGenerator(),
+            "data_destruction": DataDestructionRemediationGenerator(),
             "data_exfiltration": DataExfiltrationRemediationGenerator(),
+            "environment_hijacking": EnvironmentHijackingRemediationGenerator(),
+            "tunneling": TunnelingRemediationGenerator(),
             "insecure_communication": InsecureCommunicationRemediationGenerator(),
             "privilege_escalation": PrivilegeEscalationRemediationGenerator(),
             "template_injection": TemplateInjectionRemediationGenerator(),
             "jinja_lookup_rce": TemplateInjectionRemediationGenerator(),
             "dangerous_modules": DangerousModulesRemediationGenerator(),
             "external_urls": ExternalUrlsRemediationGenerator(),
-            "unauthorized_cloud_access": UnauthorizedCloudAccessRemediationGenerator(),
+            "unauthorized_cloud_access": UnauthorizedCloudProceduralRemediationGenerator(),
             "supply_chain": SupplyChainRemediationGenerator(),
             "ansible_hygiene": AnsibleHygieneRemediationGenerator(),
             "ai_ml_security": AiMlSecurityRemediationGenerator(),
-            "operational_security": OperationalSecurityRemediationGenerator(),
+            "operational_security": OperationalSecurityProceduralRemediationGenerator(),
             "ansible_specific": AnsibleSpecificRemediationGenerator(),
             "ssh_trust_bypass": SshTrustBypassRemediationGenerator(),
             "k8s_insecure_spec": K8sInsecureSpecRemediationGenerator(),
@@ -106,18 +122,18 @@ class RemediationGenerator(BaseRemediationGenerator):
     # context (command injection, credentials, permissions, variable injection)
     # have their own explicit handlers below and are looked up separately.
     _SIMPLE_DISPATCH: dict[str, tuple] = {
-        "system_compromise": ("system_compromise", "generate_system_compromise_fix"),
+        "system_compromise": ("anti_forensics", "generate_system_compromise_fix"),
         "malicious_activity": ("malicious_activity", "generate_malicious_activity_fix"),
-        "offensive_tools": ("malicious_activity", "generate_malicious_activity_fix"),
+        "offensive_tools": ("offensive_tools", "generate_offensive_tools_fix"),
         "reverse_shells": ("malicious_activity", "generate_malicious_activity_fix"),
-        "tunneling": ("malicious_activity", "generate_malicious_activity_fix"),
-        "lateral_movement": ("malicious_activity", "generate_malicious_activity_fix"),
-        "anti_forensics": ("malicious_activity", "generate_malicious_activity_fix"),
-        "webshell_deployment": ("malicious_activity", "generate_malicious_activity_fix"),
-        "environment_hijacking": ("malicious_activity", "generate_malicious_activity_fix"),
-        "obfuscation_evasion": ("malicious_activity", "generate_malicious_activity_fix"),
-        "data_destruction": ("malicious_activity", "generate_malicious_activity_fix"),
-        "binary_planting": ("malicious_activity", "generate_malicious_activity_fix"),
+        "tunneling": ("tunneling", "generate_tunneling_fix"),
+        "lateral_movement": ("lateral_movement", "generate_lateral_movement_fix"),
+        "anti_forensics": ("anti_forensics", "generate_anti_forensics_fix"),
+        "webshell_deployment": ("webshell_deployment", "generate_webshell_deployment_fix"),
+        "environment_hijacking": ("environment_hijacking", "generate_environment_hijacking_fix"),
+        "obfuscation_evasion": ("webshell_deployment", "generate_obfuscation_evasion_fix"),
+        "binary_planting": ("webshell_deployment", "generate_binary_planting_fix"),
+        "data_destruction": ("data_destruction", "generate_data_destruction_fix"),
         "data_exfiltration": ("data_exfiltration", "generate_data_exfiltration_fix"),
         "insecure_communication": ("insecure_communication", "generate_insecure_communication_fix"),
         "privilege_escalation": ("privilege_escalation", "generate_privilege_escalation_fix"),
@@ -185,12 +201,46 @@ class RemediationGenerator(BaseRemediationGenerator):
         # Structural rule (no pattern entry) with caller-supplied
         # fallbacks: skip per-category dispatch so the expander renders
         # the rule's real text, not the ``this <rule_id> issue`` stub.
-        if not _pattern_index.get(rule_id) and (description_fallback or recommendation_fallback):
+        # A tailored dynamic handler is the exception - it reuses the
+        # finding's own code to emit a real Secure Fix, which beats the
+        # procedural metadata text, so let it run.
+        if (
+            not _pattern_index.get(rule_id)
+            and (description_fallback or recommendation_fallback)
+            and not self._has_dynamic_handler(rule_id)
+        ):
             return render_meta()
         out = self._dispatch(rule_id, code_snippet, file_path, line_number)
         if not self._is_relevant(rule_id, code_snippet, out):
             return render_meta()
         return _swap_vulnerable_code_block(out, code_snippet, rendered_snippet)
+
+    # Structural rules (no patterns/*.yml entry) whose special-category
+    # handler reuses the finding's own code to emit a real Secure Fix.
+    # Listing them here lets ``generate_remediation_example`` bypass the
+    # procedural-metadata short-circuit and dispatch to that handler.
+    _DYNAMIC_SPECIAL_RULES = frozenset(
+        {
+            "credential_file_missing_mode",
+            "hardcoded_credentials",
+            "private_key_written_outside_canonical_dir_ast",
+        }
+    )
+
+    def _has_dynamic_handler(self, rule_id: str) -> bool:
+        """True when the rule's category generator has a tailored handler.
+
+        Used to let structural rules (no ``patterns/*.yml`` entry) still
+        reach a code-reusing Secure Fix instead of the procedural
+        metadata renderer.
+        """
+        if rule_id in self._DYNAMIC_SPECIAL_RULES:
+            return True
+        spec = self._SIMPLE_DISPATCH.get(_resolve_category(rule_id))
+        if spec is None:
+            return False
+        generator = self._generators.get(spec[0])
+        return bool(generator and rule_id in getattr(generator, "_FIX_MAP", {}))
 
     def _dispatch(
         self,
@@ -311,6 +361,10 @@ class RemediationGenerator(BaseRemediationGenerator):
         )
 
     def _gen_permissions(self, *, rule_id, code_snippet, **_kw):
+        if rule_id == "raw_module_with_become":
+            return self._generators["become_delegate_misuse"].generate_become_delegate_misuse_fix(
+                rule_id, code_snippet
+            )
         return self._generators["unsafe_permissions"].generate_context_aware_permissions_fix(
             code_snippet, rule_id=rule_id
         )
@@ -435,7 +489,7 @@ class RemediationGenerator(BaseRemediationGenerator):
         if any(p in output for p in cls._LEGACY_BOILERPLATE):
             return False
 
-        meta = _pattern_index.get(rule_id)
+        meta = _pattern_index.get(rule_id) or {}
         keywords = cls._distinctive_tokens(meta.get("title") or "") | cls._distinctive_tokens(
             meta.get("recommendation") or ""
         )

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -80,6 +80,7 @@ rules_by_category:
     - no_log_explicitly_false_on_credential_task_ast
     - no_log_false_on_secret_handling_task
     - secret_in_comment
+    - set_fact_secret_alias
     - tags_never_on_security_task
 
   ansible_specific:

--- a/src/ansible_security_scanner/remediations/supply_chain.py
+++ b/src/ansible_security_scanner/remediations/supply_chain.py
@@ -5,7 +5,18 @@ Remediation generator for supply chain integrity issues
 
 from __future__ import annotations
 
+import re
+
+from . import _pattern_index
 from .base import BaseRemediationGenerator, _render_from_metadata
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    for pat in patterns:
+        m = re.search(pat, snippet, re.IGNORECASE)
+        if m:
+            return (m.group(1) if m.groups() else m.group(0)).strip().strip("'\"")
+    return None
 
 
 class SupplyChainRemediationGenerator(BaseRemediationGenerator):
@@ -46,7 +57,40 @@ class SupplyChainRemediationGenerator(BaseRemediationGenerator):
         "git_hook_or_config_write": "git_hook_or_config_write",
         "self_modifying_ci_config": "self_modifying_ci_config",
         "selfhosted_runner_untrusted_event": "selfhosted_runner_untrusted_event",
+        # Remote-access / tunnel tools that should be removed
+        "cloudflared_tunnel_install_arbitrary": "remove_tunnel_tool",
+        "frp_fast_reverse_proxy_install": "remove_tunnel_tool",
+        "gost_tunnel_listener_install": "remove_tunnel_tool",
+        "adb_tcpip_remote_debug_enabled": "adb_tcpip",
+        # Vulnerable vendor installs (CVE) -> pin to a patched version
+        "xz_liblzma_backdoored_version_install": "vuln_pkg_pin",
+        "fortios_ssl_vpn_vulnerable_version_install": "vuln_vendor_upgrade",
+        "palo_alto_globalprotect_vulnerable_install": "vuln_vendor_upgrade",
+        "ivanti_connect_secure_vulnerable_install": "vuln_vendor_upgrade",
+        "check_point_quantum_vulnerable_install": "vuln_vendor_upgrade",
+        "connectwise_screenconnect_vulnerable_install": "vuln_vendor_upgrade",
+        "fortimanager_fortijndi_vulnerable_install": "vuln_vendor_upgrade",
+        "cisco_unified_communications_vulnerable_install": "vuln_vendor_upgrade",
+        # Network exposure
+        "citrix_netscaler_management_interface_exposed_to_internet": "mgmt_iface_exposed",
+        "compose_db_port_bound_0_0_0_0": "compose_db_bind",
+        # Supply-chain verification gaps
+        "s3_download_no_integrity_check": "s3_integrity",
+        "slsa_provenance_verification_missing": "slsa_verify",
+        "release_artifact_fetched_without_slsa_or_attestation_verify": "slsa_verify",
+        "sigstore_policy_controller_warn_not_enforce": "sigstore_enforce",
+        "python_typosquat_package_install": "pip_typosquat",
+        # CI / secret hygiene
+        "git_hook_or_post_merge_script_fetched_from_remote": "git_hook_remote",
+        "sccm_client_push_installation_account_plaintext": "sccm_naa",
+        "jenkins_agent_secret_in_url_or_plaintext": "jenkins_secret",
+        "github_actions_script_block_injection_untrusted_context": "gh_script_injection",
+        "uri_get_url_token_in_url_query_or_userinfo": "token_in_url",
     }
+
+    # Issue types whose generator needs the rule_id (e.g. to look up the
+    # vendor-specific title) and is therefore called as gen(code_snippet, rule_id).
+    _RULE_ID_AWARE_FIXES = frozenset({"vuln_vendor_upgrade"})
 
     def generate_supply_chain_fix(self, rule_id: str, code_snippet: str) -> str:
         generators = {
@@ -77,192 +121,266 @@ class SupplyChainRemediationGenerator(BaseRemediationGenerator):
             "self_modifying_ci_config": self._generate_self_modifying_ci_config_fix,
             "git_hook_or_config_write": self._generate_git_hook_or_config_write_fix,
             "selfhosted_runner_untrusted_event": self._generate_selfhosted_runner_untrusted_event_fix,
+            "remove_tunnel_tool": self._generate_remove_tunnel_tool_fix,
+            "adb_tcpip": self._generate_adb_tcpip_fix,
+            "vuln_pkg_pin": self._generate_vuln_pkg_pin_fix,
+            "vuln_vendor_upgrade": self._generate_vuln_vendor_upgrade_fix,
+            "mgmt_iface_exposed": self._generate_mgmt_iface_exposed_fix,
+            "compose_db_bind": self._generate_compose_db_bind_fix,
+            "slsa_verify": self._generate_slsa_verify_fix,
+            "s3_integrity": self._generate_s3_integrity_fix,
+            "sigstore_enforce": self._generate_sigstore_enforce_fix,
+            "pip_typosquat": self._generate_pip_typosquat_fix,
+            "git_hook_remote": self._generate_git_hook_remote_fix,
+            "sccm_naa": self._generate_sccm_naa_fix,
+            "jenkins_secret": self._generate_jenkins_secret_fix,
+            "gh_script_injection": self._generate_gh_script_injection_fix,
+            "token_in_url": self._generate_token_in_url_fix,
         }
         issue_type = self._FIX_MAP.get(rule_id, "generic")
         gen = generators.get(issue_type)
         if gen is None:
             return self._generate_pattern_driven_fix(rule_id, code_snippet)
+        if issue_type in self._RULE_ID_AWARE_FIXES:
+            return gen(code_snippet, rule_id)
         return gen(code_snippet)
 
     def _generate_curl_pipe_fix(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"|]+)") or "{{ script_url }}"
         return f"""
-**Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**\U0001f6a8 curl Piped Directly to a Shell:**
+Piping `curl` output straight into a shell runs whatever the network serves at
+that instant, with no integrity check - a MITM or a compromised host gets RCE.
+
+**\u2705 Secure Fix - Download, Verify, Then Execute:**
 ```yaml
-- name: Download install script
-  get_url:
-    url: "https://example.com/install.sh"
+- name: Download the script to disk (not piped)
+  ansible.builtin.get_url:
+    url: "{url}"
     dest: /tmp/install.sh
     mode: '0755'
-    checksum: "sha256:abc123..."  # pin to known-good hash
+    checksum: "sha256:{{{{ script_sha256 }}}}"
+    validate_certs: true
 
-- name: Verify and execute install script
-  ansible.builtin.shell: /tmp/install.sh
-  args:
-    executable: /bin/bash
+- name: Execute the verified script
+  ansible.builtin.command: /bin/sh /tmp/install.sh
+  # script_sha256 is the reviewed digest; a content change fails the download above.
 
-- name: Clean up install script
+- name: Clean up the script
   ansible.builtin.file:
     path: /tmp/install.sh
     state: absent
 ```
 
-**Why this matters:** Piping remote content to a shell allows MITM or compromised-host attacks to execute arbitrary code. Download first, verify integrity, then execute.
+**Why this matters:** Piping remote content to a shell lets a MITM or
+compromised host execute arbitrary code. Let the checksum, not the network,
+decide what runs.
 """
 
     def _generate_wget_pipe_fix(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"|]+)") or "{{ script_url }}"
         return f"""
-**Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**\U0001f6a8 wget Piped Directly to a Shell:**
+Piping `wget` output straight into a shell runs whatever the network serves at
+that instant, with no integrity check - a MITM or a compromised host gets RCE.
+
+**\u2705 Secure Fix - Download, Verify, Then Execute:**
 ```yaml
-- name: Download script with integrity check
-  get_url:
-    url: "https://example.com/script.sh"
+- name: Download the script to disk (not piped)
+  ansible.builtin.get_url:
+    url: "{url}"
     dest: /tmp/script.sh
     mode: '0755'
-    checksum: "sha256:<known-good-hash>"
+    checksum: "sha256:{{{{ script_sha256 }}}}"
+    validate_certs: true
 
-- name: Execute verified script
-  ansible.builtin.shell: /tmp/script.sh
-  args:
-    executable: /bin/bash
+- name: Execute the verified script
+  ansible.builtin.command: /bin/sh /tmp/script.sh
+  # script_sha256 is the reviewed digest; a content change fails the download above.
 ```
 
-**Why this matters:** wget piped to shell is equivalent to curl|bash - a supply chain attack vector.
-"""
-
-    def _generate_python_remote_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Secure Fix:**
-```yaml
-- name: Download Python script
-  get_url:
-    url: "https://example.com/setup.py"
-    dest: /tmp/setup.py
-    checksum: "sha256:<known-good-hash>"
-
-- name: Execute verified Python script
-  ansible.builtin.command: python3 /tmp/setup.py
-```
-"""
-
-    def _generate_pip_pin_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Secure Fix:**
-```yaml
-- name: Install pinned Python packages
-  ansible.builtin.pip:
-    name: "package_name==1.2.3"
-    state: present
-
-# Or better, use a requirements file with hashes:
-- name: Install from requirements with hash verification
-  ansible.builtin.pip:
-    requirements: /path/to/requirements.txt
-    # requirements.txt contains: package==1.2.3 --hash=sha256:abc123...
-```
+**Why this matters:** wget-pipe-to-shell is the same supply-chain primitive as
+`curl | bash`. Let the checksum, not the network, decide what runs.
 """
 
     def _generate_github_raw_fix(self, code_snippet: str) -> str:
+        url = (
+            _first(
+                code_snippet,
+                r"(https?://raw\.githubusercontent\.com/[^\s'\"|]+)",
+                r"(https?://[^\s'\"|]+)",
+            )
+            or "{{ raw_github_url }}"
+        )
         return f"""
-**Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**\U0001f6a8 raw.githubusercontent.com Payload Piped to Shell:**
+Raw GitHub content is not a distribution channel - a branch ref can change at
+any time, and piping it into a shell executes whatever it returns with no review.
+
+**\u2705 Secure Fix - Pin to a Commit, Verify, Then Execute:**
 ```yaml
-- name: Download script from pinned commit
-  get_url:
-    url: "https://raw.githubusercontent.com/org/repo/<commit-sha>/scripts/install.sh"
+- name: Download the script pinned to an immutable commit SHA
+  ansible.builtin.get_url:
+    url: "{url}"   # pin .../<commit-sha>/... not .../main/...
     dest: /tmp/install.sh
     mode: '0755'
-    checksum: "sha256:<known-good-hash>"
+    checksum: "sha256:{{{{ script_sha256 }}}}"
+    validate_certs: true
 
-- name: Execute verified script
-  ansible.builtin.shell: /tmp/install.sh
-  args:
-    executable: /bin/bash
+- name: Execute the verified script
+  ansible.builtin.command: /bin/sh /tmp/install.sh
 ```
 
-**Why this matters:** raw.githubusercontent.com URLs pointing to `master`/`main` can change at any time. Pin to a specific commit SHA and verify the checksum.
+**Why this matters:** Pin to a commit SHA and verify the checksum; better still,
+mirror the artefact into your own artefact store and reference that.
 """
 
     def _generate_install_script_fix(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"|]+)") or "{{ installer_url }}"
         return f"""
-**Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
-```yaml
-# Pin to a specific version and verify checksum
-- name: Download Helm install script (pinned version)
-  get_url:
-    url: "https://raw.githubusercontent.com/helm/helm/v3.14.0/scripts/get-helm-3"
-    dest: /tmp/get-helm-3.sh
-    mode: '0755'
-    checksum: "sha256:<known-good-hash>"
+**\U0001f6a8 Vendor Install-Script URL Piped to Shell:**
+A vendor `curl|sh` installer runs un-reviewed remote code as it downloads.
+Prefer the vendor's signed package repo; if only a script ships, vendor it and
+pin a checksum.
 
-- name: Install Helm from verified script
-  ansible.builtin.shell: /tmp/get-helm-3.sh
-  args:
-    executable: /bin/bash
-  environment:
-    DESIRED_VERSION: "v3.14.0"
+**\u2705 Secure Fix - Prefer the Package Repo; Otherwise Pin the Installer:**
+```yaml
+# Preferred: install the signed package from the vendor's apt/yum repo
+- name: Install from the vendor's signed package repository
+  ansible.builtin.package:
+    name: "{{{{ vendor_package }}}}"
+    state: present
+
+# If the vendor only ships a curl|sh installer, vendor it behind your CI:
+- name: Download the pinned installer to disk
+  ansible.builtin.get_url:
+    url: "{url}"
+    dest: /tmp/install.sh
+    mode: '0755'
+    checksum: "sha256:{{{{ installer_sha256 }}}}"
+    validate_certs: true
+
+- name: Run the verified installer
+  ansible.builtin.command: /bin/sh /tmp/install.sh
 ```
+
+**Why this matters:** The network should never decide what executes. Use signed
+packages, or download + checksum-verify + run explicitly.
+"""
+
+    def _generate_python_remote_fix(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"|]+)") or "{{ script_url }}"
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Remote Python Script Executed Without Verification:**
+Fetching a Python script over the network and running it immediately executes
+whatever the host serves, with no integrity guarantee.
+
+**\u2705 Secure Fix - Download, Verify, Then Execute:**
+```yaml
+- name: Download the Python script to disk
+  ansible.builtin.get_url:
+    url: "{url}"
+    dest: /tmp/setup.py
+    checksum: "sha256:{{{{ script_sha256 }}}}"
+    validate_certs: true
+
+- name: Execute the verified Python script
+  ansible.builtin.command: python3 /tmp/setup.py
+```
+
+**Why this matters:** Pin the script's checksum so a content change fails the
+download instead of running unreviewed code.
+"""
+
+    def _generate_pip_pin_fix(self, code_snippet: str) -> str:
+        pkg = (
+            _first(
+                code_snippet,
+                r"pip3?\s+install\s+(?:-[^\s]+\s+)*([A-Za-z0-9._-]+)",
+                r"name:\s*[\"']?([A-Za-z0-9._-]+)",
+            )
+            or "{{ package_name }}"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Unpinned Python Package Install:**
+Installing without a version pin resolves to whatever the index serves now,
+so a compromised or yanked release can silently change what you run.
+
+**\u2705 Secure Fix - Pin the Version (or Use a Hash-Locked Requirements File):**
+```yaml
+- name: Install the pinned package
+  ansible.builtin.pip:
+    name: "{pkg}=={{{{ {pkg}_version }}}}"
+    state: present
+
+# Better: install from a hash-locked requirements file
+- name: Install from requirements with hash verification
+  ansible.builtin.pip:
+    requirements: /path/to/requirements.txt
+    # requirements.txt pins: {pkg}==1.2.3 --hash=sha256:...
+```
+
+**Why this matters:** A pinned version plus a hash lets pip reject a tampered
+artefact instead of installing it.
 """
 
     def _generate_get_url_checksum_fix(self, code_snippet: str) -> str:
+        url = (
+            _first(code_snippet, r"url:\s*[\"']?(https?://[^\s'\"]+)", r"(https?://[^\s'\"|]+)")
+            or "{{ artifact_url }}"
+        )
         return f"""
-**Vulnerable Code:**
+**\u274c Vulnerable Code:**
 ```yaml
 {code_snippet}
 ```
 
-**Secure Fix:**
+**\U0001f6a8 Download Without Checksum Verification:**
+`get_url` without a `checksum:` accepts whatever bytes arrive, so a MITM or a
+mutated upstream artefact is installed without detection.
+
+**\u2705 Secure Fix - Verify the Download Against a Known Digest:**
 ```yaml
-- name: Download binary with checksum verification
-  get_url:
-    url: "https://releases.example.com/tool/v1.2.3/tool_linux_amd64.tar.gz"
-    dest: /tmp/tool.tar.gz
-    checksum: "sha256:<known-good-hash>"
+- name: Download the artifact with checksum verification
+  ansible.builtin.get_url:
+    url: "{url}"
+    dest: /tmp/artifact
+    checksum: "sha256:{{{{ artifact_sha256 }}}}"
+    validate_certs: true
 ```
 
-**Why this matters:** Without checksum verification, a compromised mirror or MITM attack could replace the binary with a malicious one.
-"""
-
-    def _generate_generic_supply_chain_fix(self, code_snippet: str) -> str:
-        return f"""
-**Vulnerable Code:**
-```yaml
-{code_snippet}
-```
-
-**Secure Fix:**
-- Pin all remote resources to specific versions or commit SHAs
-- Verify checksums of all downloaded artifacts
-- Use `get_url` with `checksum:` instead of curl/wget
-- Use a requirements/lock file with hash pinning for package managers
+**Why this matters:** A pinned checksum makes the task fail closed when the
+artefact changes, instead of installing tampered content.
 """
 
     def _generate_pattern_driven_fix(self, rule_id: str, code_snippet: str) -> str:
@@ -359,7 +477,7 @@ container full control of the Docker daemon on the host. A compromised role
 under test runs `docker run --privileged --pid=host --net=host` on your
 CI runner - full host takeover, every `molecule test`.
 
-**Secure fix - remove the bind mount; use Molecule's native driver:**
+**\u2705 Secure Fix - remove the bind mount; use Molecule's native driver:**
 ```yaml
 platforms:
   - name: instance
@@ -387,7 +505,7 @@ sidecar service with its own socket - never bind-mount the host's.
 capability plus access to host devices. A bad role under test gets raw
 kernel-level reach on the CI host.
 
-**Secure fix - drop privileged; add only what's strictly needed:**
+**\u2705 Secure Fix - drop privileged; add only what's strictly needed:**
 ```yaml
 platforms:
   - name: instance
@@ -418,7 +536,7 @@ such scenarios on a dedicated runner.
 turns the registry pull into an MITM-able channel. An attacker on the CI
 network swaps the test image and runs arbitrary code in every test run.
 
-**Secure fix - keep TLS verification ON:**
+**\u2705 Secure Fix - keep TLS verification ON:**
 ```yaml
 driver:
   name: docker
@@ -1051,4 +1169,536 @@ jobs:
   your production VPC or secrets management; it sees only what it needs.
 - Monitor with `stepsecurity/harden-runner` (block-mode) - it denies
   outbound network calls not in an allowlist.
+"""
+
+    # --- Remote-access / tunnel tools (remove) ---
+    def _generate_remove_tunnel_tool_fix(self, code_snippet: str) -> str:
+        low = code_snippet.lower()
+        if "frp" in low:
+            tool = "frp (Fast Reverse Proxy)"
+        elif "gost" in low:
+            tool = "gost (Go Simple Tunnel)"
+        else:
+            tool = "cloudflared Tunnel"
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Outbound Tunnel / Reverse-Proxy Tool Installed ({tool}):**
+{tool} opens an outbound tunnel that bypasses ingress controls and egress
+inspection - it is never a legitimate configuration-management primitive and is
+a common post-exploitation persistence and C2 channel.
+
+**\u2705 Secure Fix - Remove the Task; Use an SSO-Gated Zero-Trust Proxy:**
+```yaml
+# Remove the {tool} install/run task. If private-host ingress is genuinely
+# required, route it through a sanctioned, change-controlled zero-trust proxy
+# (Cloudflare Access, Tailscale ACLs, Teleport, Pomerium) - never an ad-hoc tunnel.
+- name: Refuse remote-access tunnels without a documented exception
+  ansible.builtin.assert:
+    that:
+      - remote_access_exception_approved | default(false) | bool
+    fail_msg: >-
+      Outbound tunnels ({tool}) require a documented, change-controlled
+      remote-access exception. Use the sanctioned zero-trust proxy instead.
+
+- name: Ensure the tunnel binary and its service are absent
+  ansible.builtin.systemd:
+    name: "{{{{ tunnel_service_name }}}}"
+    state: stopped
+    enabled: false
+  failed_when: false
+```
+
+**Why this matters:** Audit the host for the binary and persistent units, and
+investigate how the task was introduced (often compromised CI or a planted role).
+"""
+
+    def _generate_adb_tcpip_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 adb tcpip Exposes a Device Over the Network:**
+`adb tcpip` opens an unauthenticated debug bridge over the network - anyone who
+can reach the port gets a root-capable shell on the device.
+
+**\u2705 Secure Fix - Remove It; Restrict to Loopback and Return to USB:**
+```yaml
+# Remove the `adb tcpip` task. If remote debugging is genuinely needed in CI,
+# bind it to a loopback/host-only emulator interface and switch back to USB at
+# the end of the job - never enable it on a physical device on a real network.
+- name: Refuse network adb unless this is a loopback-only CI emulator
+  ansible.builtin.assert:
+    that:
+      - adb_remote_debug_ci | default(false) | bool
+    fail_msg: "adb tcpip is only permitted on a loopback-only CI emulator."
+
+- name: Return the device to USB-only mode
+  ansible.builtin.command: adb usb
+  changed_when: false
+```
+
+**Why this matters:** A networked adb bridge is an unauthenticated remote shell;
+keep debugging on USB or a host-only interface.
+"""
+
+    # --- Vulnerable vendor installs ---
+    def _generate_vuln_pkg_pin_fix(self, code_snippet: str) -> str:
+        ver = _first(code_snippet, r"(?:xz-utils|liblzma)[=\s]+([0-9][\w.\-]*)") or "5.6.0"
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Backdoored xz-utils / liblzma ({ver}) - CVE-2024-3094:**
+xz-utils 5.6.0/5.6.1 shipped a backdoor in liblzma that targets sshd. Installing
+or building this version plants a remote-code-execution backdoor.
+
+**\u2705 Secure Fix - Pin to a Known-Good Version:**
+```yaml
+- name: Install a non-backdoored xz-utils (>= 5.6.2 or the 5.4.x LTS line)
+  ansible.builtin.package:
+    name: "xz-utils=5.4.6"   # last known-good for most distros; or >= 5.6.2
+    state: present
+
+- name: Fail if a backdoored version is present
+  ansible.builtin.assert:
+    that:
+      - "ansible_facts.packages['xz-utils'][0].version is version('5.6.0', '<') or
+         ansible_facts.packages['xz-utils'][0].version is version('5.6.2', '>=')"
+    fail_msg: "Backdoored xz-utils {ver} detected - rebuild image and rotate SSH host keys."
+```
+
+**Why this matters:** Rebuild any image whose layers installed 5.6.0/5.6.1 and
+rotate SSH host keys on machines that ran the vulnerable build.
+"""
+
+    def _generate_vuln_vendor_upgrade_fix(self, code_snippet: str, rule_id: str = "") -> str:
+        meta = _pattern_index.get(rule_id) or {}
+        title = meta.get("title") or "Vulnerable vendor appliance version installed"
+        ver = (
+            _first(code_snippet, r"([0-9]+\.[0-9]+(?:\.[0-9]+)?(?:\.[0-9]+)?)")
+            or "{{ current_version }}"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 {title} ({ver}):**
+This task installs a build with a known, actively exploited CVE. The fix is to
+install a patched version and treat an exposed/unpatched appliance as compromised.
+
+**\u2705 Secure Fix - Install the Patched Version, Gate the Source:**
+```yaml
+- name: Refuse vulnerable builds; require a patched, approved version
+  ansible.builtin.assert:
+    that:
+      - appliance_target_version in approved_patched_versions
+    fail_msg: >-
+      Install a vendor-patched version (per the product's security advisory),
+      not {ver}. Do not expose the management/portal interface to the internet.
+
+- name: Install the patched appliance version from the approved source
+  ansible.builtin.package:
+    name: "{{{{ appliance_package }}}}={{{{ appliance_target_version }}}}"
+    state: present
+```
+
+**Why this matters:** Apply the vendor advisory's patched build immediately. If
+the appliance was internet-reachable while unpatched, follow the vendor's
+compromise-recovery guidance (factory reset + rotate all credentials).
+"""
+
+    # --- Network exposure ---
+    def _generate_mgmt_iface_exposed_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Management Interface Exposed to 0.0.0.0:**
+Binding the NetScaler/ADC management (NSIP) interface to 0.0.0.0 exposes it to
+the internet - the precursor to Citrix Bleed and similar mass-exploitation events.
+
+**\u2705 Secure Fix - Bind Management to an Out-of-Band VLAN Only:**
+```yaml
+- name: Refuse a management bind that is reachable from the internet
+  ansible.builtin.assert:
+    that:
+      - mgmt_bind_address is ansible.utils.in_network '10.0.0.0/8'
+    fail_msg: >-
+      The NSIP/management interface must bind to an RFC1918 out-of-band VLAN,
+      never 0.0.0.0. Public access goes via the load-balanced VIP, not NSIP.
+
+- name: Bind the management interface to the OOB management address
+  ansible.builtin.command: >-
+    nscli set ns ip {{{{ mgmt_bind_address }}}} -mgmtAccess ENABLED -gui SECUREONLY
+  changed_when: true
+```
+
+**Why this matters:** Keep management on an out-of-band VLAN; user-facing access
+belongs on the load-balanced SSL-VPN/ICA-proxy VIP, never the NSIP.
+"""
+
+    def _generate_compose_db_bind_fix(self, code_snippet: str) -> str:
+        port = _first(code_snippet, r"(\d{2,5}):\d{2,5}", r"(\d{2,5})") or "5432"
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 docker-compose Publishes a DB Port on 0.0.0.0:**
+`ports: ["{port}:{port}"]` binds the database to every host interface, exposing
+it to the network (and often the internet) with no authentication boundary.
+
+**\u2705 Secure Fix - Bind to Loopback or Drop the Published Port:**
+```yaml
+# Loopback only (same-host app access):
+services:
+  db:
+    image: postgres:16.3
+    ports:
+      - "127.0.0.1:{port}:{port}"
+
+# Better - no published port at all; reach it over the compose network:
+services:
+  db:
+    image: postgres:16.3
+    expose:
+      - "{port}"   # compose-internal DNS only, no host binding
+```
+
+**Why this matters:** Databases should never publish on 0.0.0.0. Use a loopback
+bind for same-host access or `expose:` for service-to-service traffic.
+"""
+
+    # --- Supply-chain verification gaps ---
+    def _generate_s3_integrity_fix(self, code_snippet: str) -> str:
+        dest = (
+            _first(
+                code_snippet,
+                r"dest:\s*[\"']?((?:\{\{.*?\}\}|[^\s\"'])+)",
+            )
+            or "/path/to/object"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 S3 Object Download Without Integrity Verification:**
+The object is pulled with no follow-up checksum/signature assertion, so a
+tampered or swapped bucket object is consumed as-is.
+
+**\u2705 Secure Fix Example:**
+```yaml
+{code_snippet}
+
+- name: checksum the downloaded object
+  ansible.builtin.stat:
+    path: "{dest}"
+    checksum_algorithm: sha256
+    get_checksum: true
+  register: downloaded_object
+
+- name: fail unless the object matches the pinned digest
+  ansible.builtin.assert:
+    that:
+      - downloaded_object.stat.checksum == expected_sha256
+    fail_msg: "integrity check failed for {dest}"
+```
+
+Pin `expected_sha256` from a vault-stored manifest. For code-bearing artifacts,
+prefer a signed object verified before use.
+"""
+
+    def _generate_slsa_verify_fix(self, code_snippet: str) -> str:
+        url = (
+            _first(
+                code_snippet,
+                r"url:\s*[\"']([^\"']+)[\"']",
+                r"(https?://(?:[^\s'\"]|\{\{[^}]*\}\})+)",
+            )
+            or "{{ artifact_url }}"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 External Artifact Consumed Without Provenance Verification:**
+Fetching a release artifact with `get_url`/`unarchive` and no SLSA / in-toto /
+cosign / gh-attestation check means a tampered or swapped artifact is trusted blindly.
+
+**\u2705 Secure Fix - Verify Provenance Immediately After Download:**
+```yaml
+- name: Download the release artifact
+  ansible.builtin.get_url:
+    url: "{url}"
+    dest: /tmp/artifact
+    checksum: "sha256:{{{{ artifact_sha256 }}}}"
+
+- name: Verify SLSA provenance before using the artifact
+  ansible.builtin.command:
+    argv:
+      - slsa-verifier
+      - verify-artifact
+      - /tmp/artifact
+      - --provenance-path
+      - /tmp/artifact.intoto.jsonl
+      - --source-uri
+      - "{{{{ artifact_source_uri }}}}"
+  changed_when: false
+  # Or: gh attestation verify /tmp/artifact --owner {{{{ artifact_owner }}}}
+```
+
+**Why this matters:** A checksum proves the bytes did not change in transit;
+provenance verification proves they came from the build you expect.
+"""
+
+    def _generate_sigstore_enforce_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Image-Signature Policy in Warn Mode, Not Enforce:**
+A Sigstore policy-controller / Kyverno policy in `warn` mode logs unsigned
+images but still admits them - the gate is effectively off.
+
+**\u2705 Secure Fix - Set the Policy to Enforce:**
+```yaml
+- name: Apply the ClusterImagePolicy in enforce mode
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: policy.sigstore.dev/v1beta1
+      kind: ClusterImagePolicy
+      metadata:
+        name: require-signed-images
+      spec:
+        mode: enforce          # was: warn
+        images:
+          - glob: "**"
+        authorities:
+          - keyless:
+              identities:
+                - issuer: "https://token.actions.githubusercontent.com"
+                  subjectRegExp: "{{{{ signer_identity_regex }}}}"
+```
+
+**Why this matters:** Roll enforcement out narrowly first, confirm zero policy
+violations in the controller logs, then widen the namespace selector.
+"""
+
+    def _generate_pip_typosquat_fix(self, code_snippet: str) -> str:
+        pkg = (
+            _first(
+                code_snippet,
+                r"pip\s+install\s+([A-Za-z0-9_.\-]+)",
+                r"name:\s*([A-Za-z0-9_.\-]+)",
+            )
+            or "{{ package_name }}"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Likely Typosquat / Malicious Package ({pkg}):**
+`{pkg}` matches a known typosquat or removed/malicious PyPI name. Installing it
+runs attacker-controlled code at install time.
+
+**\u2705 Secure Fix - Install the Correct Name, Pinned and Hashed:**
+```yaml
+- name: Install the intended package, version-pinned and hash-locked
+  ansible.builtin.pip:
+    requirements: /opt/app/requirements.txt
+    # requirements.txt generated with: pip-compile --generate-hashes
+    # e.g. requests==2.32.3 --hash=sha256:70761cfe...
+
+- name: Refuse install if the name is on the typosquat denylist
+  ansible.builtin.assert:
+    that:
+      - "'{pkg}' not in pypi_typosquat_denylist"
+    fail_msg: "{pkg} is a known typosquat/malicious package - did you mean the canonical name?"
+```
+
+**Why this matters:** Pin every dependency with exact versions AND hashes
+(`pip-compile --generate-hashes`) and use an internal mirror to block
+dependency-confusion attacks.
+"""
+
+    # --- CI / secret hygiene ---
+    def _generate_git_hook_remote_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Git Hook Fetched From a Remote Source:**
+Writing a hook into `.git/hooks/` from a remote URL (or symlinking it externally)
+means the hook content is invisible to code review and can change silently -
+arbitrary code runs on the next git operation.
+
+**\u2705 Secure Fix - Commit Hooks Into the Repo Under .githooks/:**
+```yaml
+- name: Install repo-tracked hooks (visible in git log, reviewable in PRs)
+  ansible.builtin.command: git config --local core.hooksPath .githooks
+  args:
+    chdir: "{{{{ repo_path }}}}"
+  changed_when: true
+  # Hooks live at .githooks/* committed to the repo; never fetched at runtime
+  # into .git/hooks/ where they escape review and can be swapped silently.
+```
+
+**Why this matters:** Repo-tracked hooks under `.githooks/` are reviewable and
+cannot be changed without a PR; remote-fetched hooks are an untracked RCE primitive.
+"""
+
+    def _generate_sccm_naa_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 SCCM Client-Push / Network Access Account in Plaintext:**
+The legacy SCCM Network Access Account (NAA) pattern stores a reusable domain
+credential that is recoverable from clients - a classic credential-theft and
+lateral-movement primitive.
+
+**\u2705 Secure Fix - Use Enhanced HTTP / Entra Device Auth, No Shared NAA:**
+```yaml
+- name: Refuse plaintext NAA; require Enhanced HTTP + device auth
+  ansible.builtin.assert:
+    that:
+      - sccm_enhanced_http | default(false) | bool
+      - sccm_naa_credential is not defined
+    fail_msg: >-
+      Migrate off the Network Access Account: use SCCM Enhanced HTTP (>=2103)
+      with Entra-ID device tokens / device certs, not a shared plaintext NAA.
+
+- name: Configure the client to use Enhanced HTTP (token-based) auth
+  ansible.windows.win_shell: |
+    ccmsetup.exe /mp:https://{{{{ sccm_mp_fqdn }}}} /UsePKICert
+  no_log: true
+```
+
+**Why this matters:** Eliminate the shared NAA entirely; Enhanced HTTP with
+device-based authentication removes the recoverable plaintext credential.
+"""
+
+    def _generate_jenkins_secret_fix(self, code_snippet: str) -> str:
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Jenkins Agent JNLP Secret in URL or Plaintext:**
+Passing the JNLP secret on the command line (or in a URL) leaks it via the
+process table, shell history, and logs - anyone who can read those can attach a
+rogue agent.
+
+**\u2705 Secure Fix - Pass the Secret via a 0600 File or Use WebSocket Agents:**
+```yaml
+- name: Write the agent secret to a locked-down file
+  ansible.builtin.copy:
+    content: "{{{{ vault_jenkins_agent_secret }}}}"
+    dest: /etc/jenkins/agent.secret
+    owner: jenkins
+    group: jenkins
+    mode: '0600'
+  no_log: true
+
+- name: Start the agent reading the secret from the file (not the command line)
+  ansible.builtin.command:
+    argv:
+      - java
+      - -jar
+      - /opt/jenkins/agent.jar
+      - -secretFile
+      - /etc/jenkins/agent.secret
+      - -url
+      - "{{{{ jenkins_url }}}}"
+  no_log: true
+  # Better still: use the WebSocket agent protocol (Jenkins >= 2.217).
+```
+
+**Why this matters:** Keep the secret out of argv/URLs; a 0600 secret file or the
+WebSocket agent protocol avoids process-table and log exposure.
+"""
+
+    def _generate_gh_script_injection_fix(self, code_snippet: str) -> str:
+        ctx = (
+            _first(code_snippet, r"(\$\{\{\s*github\.event[^}]*\}\})")
+            or "${{ github.event.issue.title }}"
+        )
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Untrusted github.event Context Interpolated Into github-script:**
+Embedding `{ctx}` directly into an `actions/github-script` body lets an attacker
+craft issue/PR text that breaks out of the string and runs arbitrary JavaScript
+with the workflow token.
+
+**\u2705 Secure Fix - Pass Untrusted Text Through env, Reference process.env:**
+```yaml
+- uses: actions/github-script@<full-sha>  # v7.x
+  env:
+    TITLE: {ctx}        # untrusted text enters as data, not code
+  with:
+    script: |
+      const title = process.env.TITLE;   // safe: never interpolated into the script body
+      core.info(title);
+```
+
+**Why this matters:** Treat every `${{{{ github.event.* }}}}` value as untrusted
+input - move it through `env:` and read `process.env`, never inline it into a script.
+"""
+
+    def _generate_token_in_url_fix(self, code_snippet: str) -> str:
+        url = _first(code_snippet, r"(https?://[^\s'\"]+)") or "{{ api_url }}"
+        return f"""
+**\u274c Vulnerable Code:**
+```yaml
+{code_snippet}
+```
+
+**\U0001f6a8 Token in URL Query String or userinfo@host:**
+Secrets in a URL (`https://user:token@host` or `?token=...`) leak into server
+access logs, proxy logs, browser history, and Ansible's own output.
+
+**\u2705 Secure Fix - Move the Secret Into an Authorization Header:**
+```yaml
+- name: Call the API with the token in a header, not the URL
+  ansible.builtin.uri:
+    url: "{url}"
+    headers:
+      Authorization: "Bearer {{{{ lookup('community.hashi_vault.hashi_vault',
+                                 'secret=secret/data/api:token') }}}}"
+  no_log: true
+```
+
+**Why this matters:** URLs are logged everywhere; headers (with `no_log: true`)
+keep the token out of logs, history, and proxies. Source it from Vault, not inline.
 """

--- a/src/ansible_security_scanner/remediations/template_injection.py
+++ b/src/ansible_security_scanner/remediations/template_injection.py
@@ -707,7 +707,7 @@ ansible-playbook site.yml -e "app_token=$APP_TOKEN"
   ansible.builtin.set_fact:
     svc_password: >-
       {{{{ lookup('ansible.builtin.password',
-                  '{{{{ playbook_dir }}}}/.secrets/svc_password length=32 chars=ascii_letters,digits') }}}}
+                  playbook_dir ~ '/.secrets/svc_password length=32 chars=ascii_letters,digits') }}}}
   no_log: true
 # Check .secrets/ into ansible-vault, never into cleartext git.
 ```

--- a/src/ansible_security_scanner/remediations/tunneling.py
+++ b/src/ansible_security_scanner/remediations/tunneling.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tunneling / network-exposure remediation generator.
+
+Two honest shapes:
+
+* Pentest / C2 tunneling tools (chisel, ligolo, frp, revsocks, iodine,
+  dnscat2, icmptunnel, rathole, bore) have no safe configuration. The fix
+  removes the tool by its real name and routes any genuine need through an
+  approved, reviewed connectivity path.
+* Dual-use exposure tools (ngrok, cloudflared, localtunnel, serveo,
+  tailscale, VPN, ssh forwards, socat) are legitimate only when approved.
+  The fix replaces the ad-hoc tunnel with the sanctioned access method.
+
+Both weave the detected tool/host/port from the finding into the output.
+"""
+
+from __future__ import annotations
+
+from .base import BaseRemediationGenerator, _first, _render_from_metadata
+
+# rule_id -> (binary/package name to remove, human label)
+_TOOL_RULES: dict[str, tuple[str, str]] = {
+    "chisel_tunnel": ("chisel", "Chisel"),
+    "ligolo_tunnel": ("ligolo-ng", "Ligolo"),
+    "frp_tunnel": ("frpc", "FRP"),
+    "revsocks_tunnel": ("revsocks", "the reverse SOCKS proxy"),
+    "iodine_dns_tunnel": ("iodine", "Iodine"),
+    "dnscat2_tunnel": ("dnscat2", "dnscat2"),
+    "icmptunnel_tunnel": ("icmptunnel", "icmptunnel"),
+    "rathole_tunnel": ("rathole", "Rathole"),
+    "bore_tunnel": ("bore", "Bore"),
+}
+
+# rule_id -> (human label, the approved alternative sentence)
+_EXPOSURE_RULES: dict[str, tuple[str, str]] = {
+    "ssh_socks_proxy": ("the SSH SOCKS proxy", "an approved corporate VPN or bastion host"),
+    "ssh_remote_forward": (
+        "the SSH remote port forward",
+        "an approved reverse proxy with authentication",
+    ),
+    "ngrok_exposure": (
+        "ngrok",
+        "an approved ingress (load balancer + WAF) for any service that must be reachable",
+    ),
+    "cloudflared_tunnel": (
+        "the Cloudflare Tunnel",
+        "an approved Cloudflare Tunnel managed by the platform team with access policies",
+    ),
+    "vpn_setup_unauthorized": ("the VPN", "the corporate VPN approved by network security"),
+    "localtunnel_exposure": (
+        "LocalTunnel",
+        "an approved ingress for any service that must be reachable",
+    ),
+    "serveo_tunnel": ("the Serveo tunnel", "an approved reverse proxy with authentication"),
+    "socat_port_forward": (
+        "the socat relay",
+        "an explicit, reviewed firewall rule for the specific flow",
+    ),
+    "tailscale_unauthorized": (
+        "Tailscale",
+        "Tailscale enrolled through the sanctioned tailnet with ACLs, approved by network security",
+    ),
+}
+
+
+class TunnelingRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic fixes for tunnels, proxies and network exposure."""
+
+    def generate_tunneling_fix(self, rule_id: str, code_snippet: str) -> str:
+        if rule_id in _TOOL_RULES:
+            return self._fix_tool(rule_id, code_snippet)
+        if rule_id in _EXPOSURE_RULES:
+            return self._fix_exposure(rule_id, code_snippet)
+        return _render_from_metadata(rule_id, code_snippet)
+
+    @staticmethod
+    def _frame(rule_id: str, heading: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {heading} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    def _meta_heading(self, rule_id: str) -> tuple[str, str]:
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        return meta.get("title") or rule_id, meta.get("recommendation") or ""
+
+    def _fix_tool(self, rule_id: str, code_snippet: str) -> str:
+        binary, label = _TOOL_RULES[rule_id]
+        title, recommendation = self._meta_heading(rule_id)
+        secure_fix = (
+            f"# {label} is a tunneling tool with no safe production configuration.\n"
+            f"# Remove the binary and its unit, then route any genuine remote-access\n"
+            f"# need through an approved, reviewed path (corporate VPN or bastion).\n"
+            f"- name: Ensure {binary} is stopped and removed\n"
+            f"  block:\n"
+            f"    - name: Stop and disable any {binary} service\n"
+            f"      ansible.builtin.systemd:\n"
+            f"        name: {binary}\n"
+            f"        state: stopped\n"
+            f"        enabled: false\n"
+            f"      failed_when: false\n"
+            f"\n"
+            f"    - name: Remove the {binary} binary\n"
+            f"      ansible.builtin.file:\n"
+            f'        path: "/usr/local/bin/{binary}"\n'
+            f"        state: absent\n"
+            f"\n"
+            f"- name: Provide sanctioned connectivity instead\n"
+            f"  ansible.builtin.debug:\n"
+            f"    msg: >-\n"
+            f"      Use the approved corporate VPN or bastion host for remote access;\n"
+            f"      {label} must not run on managed hosts."
+        )
+        return self._frame(
+            rule_id,
+            title,
+            code_snippet,
+            f"This task runs {label}. {recommendation}",
+            secure_fix,
+        )
+
+    def _fix_exposure(self, rule_id: str, code_snippet: str) -> str:
+        label, alternative = _EXPOSURE_RULES[rule_id]
+        title, recommendation = self._meta_heading(rule_id)
+        port = _first(
+            code_snippet,
+            r"-[DRL]\s+(?:0\.0\.0\.0:)?(\d+)",
+            r"--port\s+(\d+)",
+            r"TCP-LISTEN:(\d+)",
+            r"\b(?:http|tcp|local|server)\s+(\d{2,5})\b",
+        )
+        port_note = f"\n# Detected exposed port: {port}" if port else ""
+        secure_fix = (
+            f"# {label} bypasses network controls and exposes internal services.{port_note}\n"
+            f"# Do not open an ad-hoc tunnel; reach the service through the\n"
+            f"# sanctioned path so access stays authenticated and auditable.\n"
+            f"- name: Route access through the approved mechanism\n"
+            f"  ansible.builtin.debug:\n"
+            f"    msg: >-\n"
+            f"      Reach this service via {alternative}.\n"
+            f"      Any internet-facing exposure must be approved by network security\n"
+            f"      and fronted by authentication and logging.\n"
+            f"\n"
+            f"- name: Confirm no ad-hoc tunnel remains enabled\n"
+            f"  ansible.builtin.systemd:\n"
+            f'    name: "{{{{ tunnel_service_name }}}}"\n'
+            f"    state: stopped\n"
+            f"    enabled: false\n"
+            f"  failed_when: false\n"
+            f"  when: tunnel_service_name is defined"
+        )
+        return self._frame(
+            rule_id,
+            title,
+            code_snippet,
+            f"This task uses {label} to expose internal services. {recommendation}",
+            secure_fix,
+        )

--- a/src/ansible_security_scanner/remediations/unauthorized_cloud_procedural.py
+++ b/src/ansible_security_scanner/remediations/unauthorized_cloud_procedural.py
@@ -1,0 +1,875 @@
+#!/usr/bin/env python3
+"""Dynamic remediations for the procedural unauthorized_cloud_access rules.
+
+These rule_ids previously rendered prose-only "Secure Response" advice. Each
+one has an honest, copy-pasteable Ansible shape:
+
+* read / recon calls -> the provider's native read module, gated behind an
+  explicit approval var so reconnaissance can't run silently;
+* mutate / provision calls -> the native module or a reviewed IaC pipeline
+  trigger, gated behind approval;
+* secret / data access -> the provider lookup plugin with ``no_log: true``;
+* audit-control destruction -> re-enable the control and assert it stays on;
+* the inline-CLI / boto3 cases -> the equivalent native module.
+
+The rule title is woven into every output so the relevance check passes and
+the operator sees exactly which API was touched. Any rule_id this class does
+not own is delegated to the original generator so existing behaviour is kept.
+"""
+
+from __future__ import annotations
+
+import re
+
+from . import _pattern_index
+from .base import BaseRemediationGenerator
+from .unauthorized_cloud_access import UnauthorizedCloudAccessRemediationGenerator
+
+
+def _first(snippet: str, *patterns: str) -> str | None:
+    for pat in patterns:
+        m = re.search(pat, snippet, re.IGNORECASE)
+        if m:
+            return (m.group(1) if m.groups() else m.group(0)).strip().strip("'\"")
+    return None
+
+
+class UnauthorizedCloudProceduralRemediationGenerator(BaseRemediationGenerator):
+    """Owns the 53 procedural cloud rules; delegates everything else."""
+
+    _HANDLERS = {
+        # Identity / recon
+        "aws_sts_assume_role": "_fix_sts_assume",
+        "aws_sts_enumeration": "_fix_recon",
+        "aws_ec2_recon_modify": "_fix_recon",
+        "cloud_instance_metadata": "_fix_metadata",
+        "gcp_metadata_access": "_fix_metadata",
+        # IAM mutate
+        "aws_iam_create_user": "_fix_iam_iac",
+        "aws_iam_create_access_key": "_fix_iam_iac",
+        "aws_iam_policy_manipulation": "_fix_iam_iac",
+        "aws_iam_destructive": "_fix_iam_destructive",
+        "aws_organization_manipulation": "_fix_org",
+        # Provisioning via CLI / IaC-from-Ansible
+        "aws_ec2_run_instances": "_fix_ec2_run",
+        "aws_lambda_create": "_fix_lambda_create",
+        "aws_rds_management": "_fix_rds",
+        "aws_dynamodb_access": "_fix_dynamodb",
+        "aws_ecs_run_task": "_fix_ecs",
+        "aws_eks_get_token": "_fix_eks_token",
+        "aws_ecr_login": "_fix_ecr_login",
+        "aws_cloudformation_deploy": "_fix_iac_pipeline",
+        "aws_cdk_deploy": "_fix_iac_pipeline",
+        "pulumi_deploy_from_ansible": "_fix_iac_pipeline",
+        "serverless_deploy": "_fix_iac_pipeline",
+        "terraform_apply_from_ansible": "_fix_iac_pipeline",
+        # Inline CLI / boto3
+        "inline_boto3_script": "_fix_inline_boto3",
+        "boto3_s3_client": "_fix_s3_data",
+        "gcloud_direct_command": "_fix_gcloud_cli",
+        "az_cli_direct_command": "_fix_az_cli",
+        "oci_cli_command": "_fix_oci_cli",
+        # Data access
+        "aws_s3_data_access": "_fix_s3_data",
+        "aws_s3_list_or_delete": "_fix_s3_data",
+        "gsutil_data_access": "_fix_gcs_data",
+        "oci_object_storage": "_fix_oci_object",
+        # Secrets / KMS
+        "aws_kms_decrypt": "_fix_kms",
+        "az_keyvault_secret": "_fix_az_keyvault",
+        "gcloud_kms_operations": "_fix_gcloud_kms",
+        # Remote exec
+        "aws_ssm_send_command": "_fix_ssm",
+        # Audit-control destruction
+        "aws_cloudtrail_disable": "_fix_audit_aws",
+        "aws_cloudtrail_delete": "_fix_audit_aws",
+        "aws_guardduty_disable": "_fix_audit_aws",
+        "aws_config_disable": "_fix_audit_aws",
+        "aws_config_delete": "_fix_audit_aws",
+        "aws_cloudwatch_delete_alarms": "_fix_audit_aws",
+        "aws_logs_delete": "_fix_audit_aws",
+        "gcloud_logging_modify": "_fix_audit_gcp",
+        "az_monitor_disable": "_fix_audit_az",
+        # Network / DNS / SG
+        "aws_route53_modification": "_fix_route53",
+        "aws_security_group_modify": "_fix_sg",
+        # Kubernetes
+        "kubectl_port_forward": "_fix_k8s_portforward",
+        "kubectl_cp_exfiltration": "_fix_k8s_cp",
+        "kubectl_delete_resource": "_fix_k8s_delete",
+        # Vault
+        "vault_cli_read_write": "_fix_vault_cli",
+        "vault_policy_manipulation": "_fix_vault_admin",
+        # Azure ops
+        "az_sql_operations": "_fix_az_sql",
+        "az_acr_operations": "_fix_az_acr",
+    }
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fallback = UnauthorizedCloudAccessRemediationGenerator()
+
+    def generate_unauthorized_cloud_access_fix(self, rule_id: str, code_snippet: str) -> str:
+        method = self._HANDLERS.get(rule_id)
+        if method is None:
+            return self._fallback.generate_unauthorized_cloud_access_fix(rule_id, code_snippet)
+        return getattr(self, method)(rule_id, code_snippet)
+
+    def _frame(self, rule_id: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        rec = meta.get("recommendation") or ""
+        body = why
+        if rec:
+            body += f"\n\n{rec}"
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f6a8 {title} ({rule_id}):**\n{body}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    # ---- Identity / reconnaissance ---------------------------------------
+
+    def _fix_sts_assume(self, rule_id: str, code_snippet: str) -> str:
+        role = (
+            _first(code_snippet, r"--role-arn\s+(\S+)", r"(arn:aws:iam::[^\s'\"]+)")
+            or "arn:aws:iam::{{ account_id }}:role/app-role"
+        )
+        why = (
+            "Assuming a role from inside a playbook escalates privileges beyond what "
+            "the execution environment was granted and hides the assumption from the "
+            "task log. Let the runner identity carry the permissions instead."
+        )
+        fix = (
+            "# Attach the role to the execution environment (instance profile, ECS\n"
+            "# task role, or CI runner) so no in-playbook assume-role is needed.\n"
+            "# When a distinct role is genuinely required, use the native module so\n"
+            "# the credentials register as a fact you can scope with no_log.\n"
+            f"- name: assume scoped role for this play\n"
+            f"  community.aws.sts_assume_role:\n"
+            f'    role_arn: "{role}"\n'
+            f"    role_session_name: \"{{{{ ansible_play_name | default('ansible') }}}}\"\n"
+            f"    duration_seconds: 900\n"
+            f"  register: assumed\n"
+            f"  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_recon(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Read-only identity/inventory calls in a playbook are a common recon "
+            "primitive. Gate them behind an explicit approval var and use the native "
+            "read module so the output is a structured fact instead of shelled-out CLI."
+        )
+        fix = (
+            "- name: gather account/instance facts (read-only, gated)\n"
+            "  amazon.aws.ec2_instance_info:\n"
+            "    filters:\n"
+            '      "tag:Environment": "{{ target_env }}"\n'
+            "  register: ec2_facts\n"
+            "  when: cloud_read_approved | default(false) | bool\n"
+            "\n"
+            "# Fail closed if someone runs recon without approval.\n"
+            "- name: require explicit approval for cloud reads\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - cloud_read_approved | default(false) | bool\n"
+            '    fail_msg: "Set cloud_read_approved=true only with a reviewed change ticket."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_metadata(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Reading the instance metadata endpoint can extract IAM credentials and "
+            "project/account identifiers. Don't query it from a playbook; require the "
+            "token-based (IMDSv2 / metadata-concealment) path and source identity from "
+            "facts the controller already trusts."
+        )
+        fix = (
+            "# AWS: require IMDSv2 so a stray SSRF can't read credentials.\n"
+            "- name: enforce IMDSv2 on the instance\n"
+            "  amazon.aws.ec2_instance:\n"
+            '    instance_ids: ["{{ instance_id }}"]\n'
+            "    metadata_options:\n"
+            "      http_tokens: required\n"
+            "      http_put_response_hop_limit: 1\n"
+            "\n"
+            "# Need identity in the play? Use the SDK-backed module, not a metadata curl.\n"
+            "- name: confirm caller identity\n"
+            "  amazon.aws.aws_caller_info:\n"
+            "  register: whoami\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- IAM mutate ------------------------------------------------------
+
+    def _fix_iam_iac(self, rule_id: str, code_snippet: str) -> str:
+        user = (
+            _first(code_snippet, r"--user-name\s+(\S+)", r"create-user\s+\S+\s+(\S+)")
+            or "{{ iam_user }}"
+        )
+        why = (
+            "Creating IAM users, keys, or policies imperatively bypasses identity "
+            "governance and peer review. Manage IAM declaratively and gate the run on "
+            "an approved change so the diff is reviewable and auditable."
+        )
+        fix = (
+            "# Declarative IAM keeps the desired state in source control and review.\n"
+            f"- name: managed IAM user (reviewed change only)\n"
+            f"  amazon.aws.iam_user:\n"
+            f'    name: "{user}"\n'
+            f"    state: present\n"
+            f"    managed_policies:\n"
+            f"      - arn:aws:iam::aws:policy/ReadOnlyAccess\n"
+            f"  when: iam_change_approved | default(false) | bool\n"
+            f"\n"
+            f"- name: block unreviewed IAM mutations\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - iam_change_approved | default(false) | bool\n"
+            f'    fail_msg: "IAM changes require an approved change ticket (set iam_change_approved=true)."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_iam_destructive(self, rule_id: str, code_snippet: str) -> str:
+        target = (
+            _first(code_snippet, r"--user-name\s+(\S+)", r"--role-name\s+(\S+)")
+            or "{{ iam_principal }}"
+        )
+        why = (
+            "Deleting IAM principals from a playbook can be sabotage or track-covering. "
+            "Require an explicit, ticketed confirmation and keep the action declarative "
+            "so the removal is a reviewable state change, not an ad-hoc CLI delete."
+        )
+        fix = (
+            "- name: decommission IAM principal (double-gated)\n"
+            "  amazon.aws.iam_user:\n"
+            f'    name: "{target}"\n'
+            "    state: absent\n"
+            "  when:\n"
+            "    - iam_change_approved | default(false) | bool\n"
+            '    - confirm_iam_delete | default("") == iam_principal_to_delete\n'
+            "\n"
+            "- name: require typed confirmation before any IAM deletion\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - iam_change_approved | default(false) | bool\n"
+            '      - confirm_iam_delete | default("") == iam_principal_to_delete\n'
+            '    fail_msg: "Re-type the principal name in confirm_iam_delete to authorize deletion."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_org(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Organization changes (leaving the org, removing accounts, detaching SCPs) "
+            "strip security guardrails tenant-wide and need executive sign-off. Never "
+            "do this from automation; gate hard and fail closed."
+        )
+        fix = (
+            "# Organization structure is not an Ansible concern. Encode it in reviewed\n"
+            "# IaC and refuse to run the destructive path from a playbook.\n"
+            "- name: refuse org-level mutation from automation\n"
+            "  ansible.builtin.fail:\n"
+            "    msg: >-\n"
+            "      AWS Organizations changes require executive approval and a reviewed\n"
+            "      IaC change. Remove this task from the playbook.\n"
+            "  when: not (org_change_break_glass | default(false) | bool)\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Provisioning via CLI / IaC-from-Ansible -------------------------
+
+    def _fix_ec2_run(self, rule_id: str, code_snippet: str) -> str:
+        itype = _first(code_snippet, r"--instance-type\s+(\S+)") or "t3.micro"
+        ami = _first(code_snippet, r"--image-id\s+(\S+)") or "{{ approved_ami }}"
+        why = (
+            "Launching instances with raw `aws ec2 run-instances` skips tagging, IMDSv2, "
+            "and review. Use the idempotent module with enforced metadata options and a "
+            "vetted AMI."
+        )
+        fix = (
+            "- name: launch instance via native module with IMDSv2 enforced\n"
+            "  amazon.aws.ec2_instance:\n"
+            '    name: "{{ instance_name }}"\n'
+            f'    image_id: "{ami}"\n'
+            f"    instance_type: {itype}\n"
+            "    metadata_options:\n"
+            "      http_tokens: required\n"
+            "      http_put_response_hop_limit: 1\n"
+            "    tags:\n"
+            '      Environment: "{{ target_env }}"\n'
+            "      ManagedBy: ansible\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_lambda_create(self, rule_id: str, code_snippet: str) -> str:
+        name = _first(code_snippet, r"--function-name\s+(\S+)") or "{{ function_name }}"
+        why = (
+            "Creating Lambda functions imperatively bypasses the deployment pipeline, "
+            "code signing, and review. Deploy through the native module from CI with a "
+            "pinned, scoped execution role."
+        )
+        fix = (
+            "- name: deploy function via reviewed pipeline\n"
+            "  amazon.aws.lambda:\n"
+            f'    name: "{name}"\n'
+            "    state: present\n"
+            "    runtime: python3.12\n"
+            "    handler: app.handler\n"
+            '    role: "arn:aws:iam::{{ account_id }}:role/lambda-{{ function_name }}-exec"\n'
+            '    zip_file: "{{ build_artifact_path }}"\n'
+            "  when: deploy_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_rds(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Creating or deleting RDS instances from the CLI risks data loss and skips "
+            "provisioning controls. Use the idempotent module with deletion protection "
+            "and gate the run."
+        )
+        fix = (
+            "- name: manage RDS instance declaratively\n"
+            "  amazon.aws.rds_instance:\n"
+            '    db_instance_identifier: "{{ db_identifier }}"\n'
+            "    state: present\n"
+            "    engine: postgres\n"
+            "    deletion_protection: true\n"
+            "    storage_encrypted: true\n"
+            "  when: db_change_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_dynamodb(self, rule_id: str, code_snippet: str) -> str:
+        table = _first(code_snippet, r"--table-name\s+(\S+)") or "{{ table_name }}"
+        why = (
+            "Direct DynamoDB item/table CLI calls bypass data-pipeline controls. Manage "
+            "table schema with the native module; route item-level data through your "
+            "application, not playbooks."
+        )
+        fix = (
+            "- name: manage DynamoDB table schema only\n"
+            "  community.aws.dynamodb_table:\n"
+            f'    name: "{table}"\n'
+            "    state: present\n"
+            "    hash_key_name: id\n"
+            "    hash_key_type: STRING\n"
+            "    billing_mode: PAY_PER_REQUEST\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ecs(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`aws ecs run-task` launches workloads outside the deployment pipeline and "
+            "service controls. Register the task declaratively and run it as a tracked "
+            "service/scheduled task instead."
+        )
+        fix = (
+            "- name: run ECS task via native module (tracked)\n"
+            "  community.aws.ecs_task:\n"
+            "    operation: run\n"
+            '    cluster: "{{ ecs_cluster }}"\n'
+            '    task_definition: "{{ task_definition }}"\n'
+            "    launch_type: FARGATE\n"
+            "    count: 1\n"
+            "  when: deploy_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_eks_token(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Minting an EKS token in a playbook hands cluster credentials to the task "
+            "log and bypasses RBAC review. Configure kubeconfig in the execution "
+            "environment and use the declarative k8s module."
+        )
+        fix = (
+            "# kubeconfig comes from the runner/IRSA, not an in-play `aws eks get-token`.\n"
+            "- name: apply manifest with cluster creds from the environment\n"
+            "  kubernetes.core.k8s:\n"
+            "    state: present\n"
+            '    src: "{{ manifest_path }}"\n'
+            "  environment:\n"
+            "    KUBECONFIG: \"{{ lookup('env', 'KUBECONFIG') }}\"\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_ecr_login(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`aws ecr get-login-password | docker login` puts a registry credential on "
+            "the command line. Let the CI runner handle registry auth, or use the "
+            "native module that keeps the token out of argv."
+        )
+        fix = (
+            "- name: obtain ECR auth without leaking it to argv\n"
+            "  community.aws.ecs_ecr:\n"
+            '    registry_id: "{{ account_id }}"\n'
+            "  register: ecr\n"
+            "  no_log: true\n"
+            "\n"
+            "- name: pull image using the scoped token\n"
+            "  community.docker.docker_image:\n"
+            '    name: "{{ ecr.repository.repository_uri }}:{{ image_tag }}"\n'
+            "    source: pull\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_iac_pipeline(self, rule_id: str, code_snippet: str) -> str:
+        tool = (
+            _first(
+                code_snippet,
+                r"\b(terraform)\b",
+                r"\b(pulumi)\b",
+                r"\b(cdk)\b",
+                r"\b(serverless)\b",
+                r"(cloudformation)",
+            )
+            or "the IaC tool"
+        )
+        why = (
+            f"Running {tool} from Ansible skips plan review, state locking, and approval "
+            "gates. Trigger the reviewed pipeline (and wait for it) rather than applying "
+            "infrastructure inline."
+        )
+        fix = (
+            "# Kick the reviewed IaC pipeline; Ansible orchestrates, it does not apply.\n"
+            "- name: trigger infrastructure pipeline\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "{{ iac_pipeline_dispatch_url }}"\n'
+            "    method: POST\n"
+            "    headers:\n"
+            '      Authorization: "Bearer {{ vault_pipeline_token }}"\n'
+            "    body_format: json\n"
+            "    body:\n"
+            '      ref: "{{ iac_git_ref }}"\n'
+            '      workspace: "{{ target_env }}"\n'
+            "    status_code: [200, 201, 202]\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Inline CLI / boto3 ---------------------------------------------
+
+    def _fix_inline_boto3(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Embedding a boto3 script inside command/shell hides the cloud API call from "
+            "static analysis and drops idempotency. Use the equivalent native module so "
+            "the call is declarative and scannable."
+        )
+        fix = (
+            "# Replace the inline `python -c 'import boto3 ...'` with the native module.\n"
+            "- name: put object via module (idempotent, scannable)\n"
+            "  amazon.aws.s3_object:\n"
+            '    bucket: "{{ bucket }}"\n'
+            '    object: "{{ key }}"\n'
+            '    src: "{{ local_path }}"\n'
+            "    mode: put\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_gcloud_cli(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Shelling out to `gcloud` skips IaC review and leaves resources untracked. "
+            "Use the google.cloud collection module for the resource you are managing."
+        )
+        fix = (
+            "- name: manage instance via native module\n"
+            "  google.cloud.gcp_compute_instance:\n"
+            '    name: "{{ instance_name }}"\n'
+            "    machine_type: e2-small\n"
+            '    zone: "{{ gcp_zone }}"\n'
+            '    project: "{{ gcp_project_id }}"\n'
+            "    auth_kind: serviceaccount\n"
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_az_cli(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Direct `az` CLI calls bypass IaC governance and managed-identity auth. Use "
+            "the azure.azcollection module for the resource."
+        )
+        fix = (
+            "- name: manage resource group via native module\n"
+            "  azure.azcollection.azure_rm_resourcegroup:\n"
+            '    name: "{{ resource_group }}"\n'
+            '    location: "{{ azure_location }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_oci_cli(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Shelling out to the `oci` CLI skips review and uses long-lived API keys. "
+            "Use the oracle.oci collection with instance-principal auth."
+        )
+        fix = (
+            "- name: manage OCI instance via native module\n"
+            "  oracle.oci.oci_compute_instance:\n"
+            '    compartment_id: "{{ oci_compartment_id }}"\n'
+            '    display_name: "{{ instance_name }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Data access -----------------------------------------------------
+
+    def _fix_s3_data(self, rule_id: str, code_snippet: str) -> str:
+        bucket = _first(code_snippet, r"s3://([^/\s'\"]+)", r"--bucket\s+(\S+)") or "{{ bucket }}"
+        destructive = bool(re.search(r"\b(rm|rb|delete)\b", code_snippet, re.IGNORECASE))
+        why = (
+            "Raw `aws s3` / boto3 access can exfiltrate data or stage payloads with no "
+            "application audit trail. Use the native module with scoped IAM and "
+            "`no_log: true`."
+        )
+        if destructive:
+            fix = (
+                "- name: delete object via module (gated, no_log)\n"
+                "  amazon.aws.s3_object:\n"
+                f'    bucket: "{bucket}"\n'
+                '    object: "{{ key }}"\n'
+                "    mode: delobj\n"
+                "  no_log: true\n"
+                "  when: s3_delete_approved | default(false) | bool\n"
+            )
+        else:
+            fix = (
+                "- name: transfer object via module (scoped IAM, no_log)\n"
+                "  amazon.aws.s3_object:\n"
+                f'    bucket: "{bucket}"\n'
+                '    object: "{{ key }}"\n'
+                '    dest: "{{ local_path }}"\n'
+                "    mode: get\n"
+                "  no_log: true\n"
+            )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_gcs_data(self, rule_id: str, code_snippet: str) -> str:
+        bucket = _first(code_snippet, r"gs://([^/\s'\"]+)") or "{{ gcs_bucket }}"
+        why = (
+            "`gsutil cp/rsync` from a playbook can move data without an application audit "
+            "trail. Use the google.cloud storage module with scoped IAM."
+        )
+        fix = (
+            "- name: transfer object via module (scoped IAM)\n"
+            "  google.cloud.gcp_storage_object:\n"
+            f'    bucket: "{bucket}"\n'
+            '    src: "{{ local_path }}"\n'
+            '    dest: "{{ object_name }}"\n'
+            "    action: upload\n"
+            "    auth_kind: serviceaccount\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_oci_object(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`oci os object put/get` from a playbook moves data outside reviewed "
+            "pipelines. Use the oracle.oci object module with instance-principal auth."
+        )
+        fix = (
+            "- name: put object via native OCI module\n"
+            "  oracle.oci.oci_object_storage_object:\n"
+            '    namespace_name: "{{ oci_namespace }}"\n'
+            '    bucket_name: "{{ oci_bucket }}"\n'
+            '    object_name: "{{ object_name }}"\n'
+            '    src: "{{ local_path }}"\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Secrets / KMS ---------------------------------------------------
+
+    def _fix_kms(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Running KMS decrypt in a playbook pulls plaintext into Ansible facts and "
+            "logs. Decrypt at the application layer, or pull the protected secret via "
+            "the lookup with `no_log: true`."
+        )
+        fix = (
+            "- name: fetch decrypted secret without exposing it\n"
+            "  ansible.builtin.set_fact:\n"
+            "    app_secret: \"{{ lookup('amazon.aws.aws_secret', 'app/prod/db') }}\"\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_az_keyvault(self, rule_id: str, code_snippet: str) -> str:
+        name = _first(code_snippet, r"--name\s+(\S+)", r"secret show\s+\S+\s+(\S+)")
+        secret_arg = f"'{name}'" if name and "{{" not in name else "secret_name"
+        why = (
+            "`az keyvault secret show` prints the secret to stdout and the task log. Use "
+            "the Key Vault lookup with `no_log: true` so it never lands in output."
+        )
+        fix = (
+            "- name: read Key Vault secret via lookup\n"
+            "  ansible.builtin.set_fact:\n"
+            f"    kv_secret: \"{{{{ lookup('azure.azcollection.azure_keyvault_secret', {secret_arg}, vault_url=keyvault_url) }}}}\"\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_gcloud_kms(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`gcloud kms decrypt` returns plaintext into the task log. Pull the protected "
+            "value via the GCP Secret Manager lookup with `no_log: true` instead of "
+            "decrypting in the playbook."
+        )
+        fix = (
+            "- name: fetch secret from Secret Manager (no_log)\n"
+            "  ansible.builtin.set_fact:\n"
+            "    gcp_secret: \"{{ lookup('google.cloud.gcp_secret_manager', 'app-prod-db') }}\"\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Remote exec -----------------------------------------------------
+
+    def _fix_ssm(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`aws ssm send-command` runs code on instances outside Ansible's control "
+            "flow and audit trail. Add the hosts to inventory and run the task through "
+            "Ansible's own connection (SSH or the SSM connection plugin)."
+        )
+        fix = (
+            "# Target instances through inventory; the run is logged by Ansible itself.\n"
+            "- name: run command on managed hosts\n"
+            "  ansible.builtin.command:\n"
+            '    cmd: "{{ remediation_command }}"\n'
+            "  register: result\n"
+            "  changed_when: false\n"
+            "# Inventory uses the SSM connection plugin where SSH is unavailable:\n"
+            "#   ansible_connection: community.aws.aws_ssm\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Audit-control destruction --------------------------------------
+
+    def _fix_audit_aws(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Disabling or deleting CloudTrail, GuardDuty, Config, CloudWatch alarms, or "
+            "log groups blinds the security team and is a classic attacker move. The "
+            "secure shape re-enables the control and asserts it stays on; treat a host "
+            "where this ran as suspect."
+        )
+        fix = (
+            "# Audit controls must stay on. Reassert state instead of disabling it.\n"
+            "- name: ensure CloudTrail multi-region logging is enabled\n"
+            "  amazon.aws.cloudtrail:\n"
+            '    name: "{{ trail_name }}"\n'
+            "    state: present\n"
+            "    is_multi_region_trail: true\n"
+            "    enable_log_file_validation: true\n"
+            "\n"
+            "- name: fail if anyone tries to disable monitoring\n"
+            "  ansible.builtin.assert:\n"
+            "    that:\n"
+            "      - not (disable_security_monitoring | default(false) | bool)\n"
+            '    fail_msg: "Disabling audit/monitoring is prohibited; investigate this change."\n'
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_audit_gcp(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Deleting or rerouting GCP logging sinks hides activity from the security "
+            "team. Keep the sink declared and enabled rather than removing it."
+        )
+        fix = (
+            "- name: ensure org log sink stays in place\n"
+            "  google.cloud.gcp_logging_metric:\n"
+            '    name: "{{ sink_name }}"\n'
+            '    filter: "severity >= WARNING"\n'
+            '    project: "{{ gcp_project_id }}"\n'
+            "    auth_kind: serviceaccount\n"
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_audit_az(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Deleting Azure Monitor diagnostic settings stops shipping logs to your SIEM. "
+            "Keep diagnostics enabled and pointed at the workspace instead of deleting."
+        )
+        fix = (
+            "- name: keep diagnostic settings shipping to Log Analytics\n"
+            "  azure.azcollection.azure_rm_monitordiagnosticsetting:\n"
+            '    name: "{{ diagnostic_setting_name }}"\n'
+            '    resource: "{{ monitored_resource_id }}"\n'
+            '    log_analytics_workspace_id: "{{ law_workspace_id }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Network / DNS / SG ---------------------------------------------
+
+    def _fix_route53(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Editing Route53 records directly can repoint traffic to attacker "
+            "infrastructure. Manage records declaratively through a reviewed change so "
+            "the target is auditable."
+        )
+        fix = (
+            "- name: manage DNS record through reviewed change\n"
+            "  amazon.aws.route53:\n"
+            "    state: present\n"
+            '    zone: "{{ dns_zone }}"\n'
+            '    record: "{{ record_name }}"\n'
+            "    type: A\n"
+            '    value: "{{ approved_target_ip }}"\n'
+            "    ttl: 300\n"
+            "  when: dns_change_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_sg(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Opening security-group rules from a playbook can expose services to the "
+            "internet (0.0.0.0/0). Manage rules declaratively and pin sources to known "
+            "CIDRs, never the world."
+        )
+        fix = (
+            "- name: manage security group with pinned sources\n"
+            "  amazon.aws.ec2_security_group:\n"
+            '    name: "{{ sg_name }}"\n'
+            '    description: "app tier"\n'
+            '    vpc_id: "{{ vpc_id }}"\n'
+            "    rules:\n"
+            "      - proto: tcp\n"
+            "        ports: [443]\n"
+            '        cidr_ip: "{{ approved_ingress_cidr }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Kubernetes ------------------------------------------------------
+
+    def _fix_k8s_portforward(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`kubectl port-forward` opens an ad-hoc tunnel that bypasses NetworkPolicy "
+            "and firewall controls. Expose the workload through a Service governed by "
+            "NetworkPolicy instead."
+        )
+        fix = (
+            "- name: expose workload via Service (no ad-hoc tunnel)\n"
+            "  kubernetes.core.k8s:\n"
+            "    state: present\n"
+            "    definition:\n"
+            "      apiVersion: v1\n"
+            "      kind: Service\n"
+            "      metadata:\n"
+            '        name: "{{ app_name }}"\n'
+            '        namespace: "{{ namespace }}"\n'
+            "      spec:\n"
+            "        type: ClusterIP\n"
+            "        selector:\n"
+            '          app: "{{ app_name }}"\n'
+            "        ports:\n"
+            "          - port: 443\n"
+            "            targetPort: 8443\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_k8s_cp(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`kubectl cp` to/from a pod is a data-exfiltration and payload-injection "
+            "path. Deliver files declaratively via ConfigMap/Secret and collect logs "
+            "through a centralized logging stack."
+        )
+        fix = (
+            "- name: deliver file to pods via ConfigMap (no kubectl cp)\n"
+            "  kubernetes.core.k8s:\n"
+            "    state: present\n"
+            "    definition:\n"
+            "      apiVersion: v1\n"
+            "      kind: ConfigMap\n"
+            "      metadata:\n"
+            '        name: "{{ app_name }}-config"\n'
+            '        namespace: "{{ namespace }}"\n'
+            "      data:\n"
+            "        app.conf: \"{{ lookup('file', config_path) }}\"\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_k8s_delete(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Imperative `kubectl delete` causes outages and bypasses GitOps "
+            "reconciliation. Remove the resource from the tracked manifest and let "
+            "ArgoCD/Flux prune, or gate the delete explicitly."
+        )
+        fix = (
+            "- name: remove resource as a tracked, gated change\n"
+            "  kubernetes.core.k8s:\n"
+            "    state: absent\n"
+            "    api_version: apps/v1\n"
+            "    kind: Deployment\n"
+            '    name: "{{ workload_name }}"\n'
+            '    namespace: "{{ namespace }}"\n'
+            "  when: k8s_delete_approved | default(false) | bool\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Vault -----------------------------------------------------------
+
+    def _fix_vault_cli(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`vault read/write` on the CLI leaves secrets in process argv and the task "
+            "log. Read secrets through the hashi_vault lookup and manage config "
+            "declaratively."
+        )
+        fix = (
+            "- name: read secret via hashi_vault lookup (no_log)\n"
+            "  ansible.builtin.set_fact:\n"
+            "    db_password: \"{{ lookup('community.hashi_vault.hashi_vault', 'secret/data/db:password') }}\"\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_vault_admin(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Enabling auth backends, secrets engines, or writing policies from a playbook "
+            "changes secrets infrastructure without change control. Manage Vault config "
+            "through reviewed Terraform (vault_policy, vault_auth_backend, vault_mount)."
+        )
+        fix = (
+            "# Vault configuration belongs in reviewed IaC, not ad-hoc CLI writes.\n"
+            "- name: trigger reviewed Vault config pipeline\n"
+            "  ansible.builtin.uri:\n"
+            '    url: "{{ vault_config_pipeline_url }}"\n'
+            "    method: POST\n"
+            "    headers:\n"
+            '      Authorization: "Bearer {{ vault_pipeline_token }}"\n'
+            "    status_code: [200, 201, 202]\n"
+            "  no_log: true\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    # ---- Azure ops -------------------------------------------------------
+
+    def _fix_az_sql(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "Managing Azure SQL with raw `az sql` calls skips IaC review and managed "
+            "identity. Use the native module with encryption and auditing kept on."
+        )
+        fix = (
+            "- name: manage Azure SQL database via native module\n"
+            "  azure.azcollection.azure_rm_sqldatabase:\n"
+            '    resource_group: "{{ resource_group }}"\n'
+            '    server_name: "{{ sql_server }}"\n'
+            '    name: "{{ database_name }}"\n'
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)
+
+    def _fix_az_acr(self, rule_id: str, code_snippet: str) -> str:
+        why = (
+            "`az acr login` / push from a playbook puts registry creds on the command "
+            "line. Let CI handle registry auth, or manage the registry declaratively "
+            "with managed-identity auth."
+        )
+        fix = (
+            "- name: manage container registry declaratively\n"
+            "  azure.azcollection.azure_rm_containerregistry:\n"
+            '    resource_group: "{{ resource_group }}"\n'
+            '    name: "{{ acr_name }}"\n'
+            "    admin_user_enabled: false\n"
+            "    state: present\n"
+        )
+        return self._frame(rule_id, code_snippet, why, fix)

--- a/src/ansible_security_scanner/remediations/webshell_deployment.py
+++ b/src/ansible_security_scanner/remediations/webshell_deployment.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Webshell / binary-planting / obfuscation remediation generator.
+
+These rules flag content that has no benign form: a named webshell, an
+alias or function that shadows a privileged command, or a payload that is
+encoded purely to slip past inspection. The honest fix removes the planted
+artefact - using the path or shadowed command pulled from the finding -
+and points at the legitimate way to accomplish the underlying task
+(deploy through a reviewed pipeline, install a real binary, run the
+de-obfuscated command transparently).
+"""
+
+from __future__ import annotations
+
+import re
+
+from .base import BaseRemediationGenerator, _first
+from .malicious_activity import MaliciousActivityRemediationGenerator
+
+_WEB_PATHS = ("/var/www", "/srv/www", "/usr/share/nginx", "/opt/lampp")
+
+# rule_id -> (the "instead" guidance, the response emphasis)
+_WEBSHELL = (
+    "deploy web content only from a reviewed CI/CD pipeline that ships known "
+    "files to the document root - never a generated or named shell",
+    "remove the file, restore the web root from a trusted artefact, and investigate the host for compromise",
+)
+_ALIAS = (
+    "if a command genuinely needs wrapping, install a real, audited binary at a "
+    "fixed path via the package or copy module - do not shadow it with a shell alias/function",
+    "remove the alias/function and audit the shell profiles for other shadowed commands",
+)
+_OBFUSCATION = (
+    "run the de-obfuscated command transparently via a plain ansible.builtin.command "
+    "task so it is reviewable - never decode or reverse a payload into a shell",
+    "decode the payload, review what it actually does, and remove the obfuscated form",
+)
+
+_RULE_GUIDANCE: dict[str, tuple[str, str]] = {
+    # webshell_deployment named tools / payloads
+    "weevely_webshell": _WEBSHELL,
+    "antsword_webshell": _WEBSHELL,
+    "godzilla_webshell": _WEBSHELL,
+    "behinder_webshell": _WEBSHELL,
+    "china_chopper_webshell": _WEBSHELL,
+    "named_php_shells": _WEBSHELL,
+    "nodejs_web_backdoor": _WEBSHELL,
+    "perl_cgi_webshell": _WEBSHELL,
+    # binary_planting alias / function hijacks
+    "alias_command_hijack": _ALIAS,
+    "function_command_hijack": _ALIAS,
+    # obfuscation_evasion
+    "rev_string_evasion": _OBFUSCATION,
+}
+
+
+class WebshellRemediationGenerator(BaseRemediationGenerator):
+    """Render dynamic removal-and-replace fixes for planted web/binary/obfuscated artefacts.
+
+    Rules that have a benign form (a real file write to a web root, a system
+    binary install, a decodable payload) keep their existing malicious-activity
+    remediation; only the rule_ids in ``_RULE_GUIDANCE`` - the named webshells,
+    command shadows, and reverse-string evasion - are handled here.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._fallback = MaliciousActivityRemediationGenerator()
+
+    def _build(self, rule_id: str, code_snippet: str) -> str:
+        guidance = _RULE_GUIDANCE.get(rule_id)
+        if guidance is None:
+            return self._fallback.generate_malicious_activity_fix(rule_id, code_snippet)
+
+        from . import _pattern_index
+
+        meta = _pattern_index.get(rule_id)
+        title = meta.get("title") or rule_id
+        recommendation = meta.get("recommendation") or ""
+        instead, response = guidance
+
+        if rule_id in ("alias_command_hijack", "function_command_hijack"):
+            return self._fix_shadow(rule_id, title, recommendation, code_snippet, instead, response)
+        if rule_id == "rev_string_evasion":
+            return self._fix_obfuscation(
+                rule_id, title, recommendation, code_snippet, instead, response
+            )
+        return self._fix_webshell(rule_id, title, recommendation, code_snippet, instead, response)
+
+    # Public per-category entrypoints keep the dispatch table self-documenting.
+    def generate_webshell_deployment_fix(self, rule_id: str, code_snippet: str) -> str:
+        return self._build(rule_id, code_snippet)
+
+    def generate_binary_planting_fix(self, rule_id: str, code_snippet: str) -> str:
+        return self._build(rule_id, code_snippet)
+
+    def generate_obfuscation_evasion_fix(self, rule_id: str, code_snippet: str) -> str:
+        return self._build(rule_id, code_snippet)
+
+    @staticmethod
+    def _frame(rule_id: str, title: str, code_snippet: str, why: str, secure_fix: str) -> str:
+        return (
+            f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
+            f"\n**\U0001f50d {title} ({rule_id}):**\n{why}\n"
+            f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
+        )
+
+    def _fix_webshell(self, rule_id, title, recommendation, code_snippet, instead, response) -> str:
+        path = (
+            _first(
+                code_snippet,
+                r"(?:dest|path):\s*['\"]?((?:"
+                + "|".join(re.escape(p) for p in _WEB_PATHS)
+                + r")[\w./-]*)",
+                r"((?:"
+                + "|".join(re.escape(p) for p in _WEB_PATHS)
+                + r")[\w./-]*\.(?:php|jsp|aspx|asp|war|jar|js|py|pl|cgi))",
+            )
+            or "{{ web_root }}/<planted file>"
+        )
+        secure_fix = (
+            f"# {title} - this artefact is a webshell with no benign form.\n"
+            f"# Remove the planted file, then {instead}.\n"
+            f"- name: Remove the planted webshell\n"
+            f"  ansible.builtin.file:\n"
+            f'    path: "{path}"\n'
+            f"    state: absent\n"
+            f"\n"
+            f"- name: Redeploy the web root from a trusted artefact only\n"
+            f"  ansible.builtin.debug:\n"
+            f"    msg: >-\n"
+            f"      {response.capitalize()}."
+        )
+        return self._frame(
+            rule_id,
+            title,
+            code_snippet,
+            f"This task deploys {title.lower()}. {recommendation}",
+            secure_fix,
+        )
+
+    def _fix_shadow(self, rule_id, title, recommendation, code_snippet, instead, response) -> str:
+        cmd = (
+            _first(
+                code_snippet,
+                r"alias\s+(\w+)\s*=",
+                r"function\s+(\w+)",
+                r"\b(sudo|su|ssh|docker|kubectl|mysql|psql|aws|gcloud|az)\s*\(\s*\)",
+            )
+            or "{{ shadowed_command }}"
+        )
+        secure_fix = (
+            f"# {title} - a shell alias/function shadowing `{cmd}` can intercept\n"
+            f"# credentials and arguments. Remove the definition; {instead}.\n"
+            f"- name: Remove any alias/function that shadows {cmd}\n"
+            f"  ansible.builtin.lineinfile:\n"
+            f'    path: "{{{{ ansible_env.HOME }}}}/.bashrc"\n'
+            f"    regexp: '^\\s*(alias|function)\\s+{cmd}\\b'\n"
+            f"    state: absent\n"
+            f"\n"
+            f"- name: If a wrapper is truly needed, install it as a real binary\n"
+            f"  ansible.builtin.debug:\n"
+            f"    msg: >-\n"
+            f"      {response.capitalize()}."
+        )
+        return self._frame(
+            rule_id,
+            title,
+            code_snippet,
+            f"This task defines a shell {('function' if 'function' in rule_id else 'alias')} "
+            f"shadowing `{cmd}`. {recommendation}",
+            secure_fix,
+        )
+
+    def _fix_obfuscation(
+        self, rule_id, title, recommendation, code_snippet, instead, response
+    ) -> str:
+        secure_fix = (
+            f"# {title} - reversing/decoding a string into a shell exists only to\n"
+            f"# evade review. Remove the obfuscation and {instead}.\n"
+            f"- name: Run the reviewed, de-obfuscated command transparently\n"
+            f'  ansible.builtin.command: "{{{{ reviewed_command }}}}"\n'
+            f"  # reviewed_command is the plain, human-readable command this payload\n"
+            f"  # decoded to - committed in the clear so it can be audited.\n"
+            f"\n"
+            f"- name: Confirm the payload was decoded and reviewed\n"
+            f"  ansible.builtin.assert:\n"
+            f"    that:\n"
+            f"      - reviewed_command is defined\n"
+            f'    fail_msg: "{response.capitalize()}."'
+        )
+        return self._frame(
+            rule_id,
+            title,
+            code_snippet,
+            f"This task uses {title.lower()}. {recommendation}",
+            secure_fix,
+        )

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -64,6 +64,32 @@ def _collect_rule_ids() -> list[tuple[str, str]]:
 ALL_RULES = _collect_rule_ids()
 
 
+def _collect_rule_positive_examples() -> list[tuple[str, str, str]]:
+    """Return ``(rule_id, category, positive_example)`` triples - one per
+    positive example per rule. Rendering a rule's fix against the very
+    code it is built to match is the only way to catch extraction bugs
+    (truncated/nested Jinja, missing Secure Fix block) that never surface
+    against a generic placeholder snippet.
+    """
+    out: list[tuple[str, str, str]] = []
+    for yml in sorted(PATTERNS_DIR.glob("*.yml")):
+        data = yaml.safe_load(yml.read_text())
+        if not isinstance(data, dict):
+            continue
+        for p in data.get("patterns", []):
+            rid = p.get("id")
+            if not rid or p.get("exclude"):
+                continue
+            cat = p.get("category", yml.stem)
+            for ex in p.get("positive_examples") or []:
+                if isinstance(ex, str) and ex.strip():
+                    out.append((rid, cat, ex))
+    return out
+
+
+ALL_POSITIVE_EXAMPLES = _collect_rule_positive_examples()
+
+
 _UNRENDERED_PLACEHOLDER_PATTERNS = [
     re.compile(r"\{code_snippet[^a-zA-Z0-9_]"),
     re.compile(r"\{rule_id[^a-zA-Z0-9_]"),
@@ -101,6 +127,19 @@ _MARKDOWN_BULLET_RE = re.compile(r"^[ ]{0,2}- [A-Z]")
 # fence so we also strip the indented fences the MR comment renderer
 # emits for inline snippets.
 _FENCED_BLOCK_RE = re.compile(r"^[ ]{0,4}```[^\n]*\n.*?\n[ ]{0,4}```", re.DOTALL | re.MULTILINE)
+
+# `{{` that is followed only by optional whitespace/quote until end of line:
+# the signature of a Jinja expression whose value was truncated by a greedy
+# extractor that stopped at the space inside `{{ var }}` (e.g. `url: "...v{{"`
+# or `path: "{{"`). Valid single-line and multi-line Jinja never match this;
+# neither do JSON policy docs whose braces close as `...}}`.
+_TRUNCATED_JINJA_RE = re.compile(r"\{\{(?=\s*[\"']?\s*$)", re.MULTILINE)
+
+# A `{{ ... }}` expression that itself contains another `{{` before it closes:
+# invalid nested Jinja (e.g. `{{ lookup('x', '{{ playbook_dir }}/y') }}`),
+# the symptom of an f-string author pasting a literal `{{ var }}` inside an
+# already-interpolated expression.
+_NESTED_JINJA_RE = re.compile(r"\{\{(?:[^{}]|\}(?!\}))*\{\{")
 
 
 def _unfenced_yaml_runs(output: str) -> list[list[str]]:
@@ -315,9 +354,9 @@ _SECURE_FIX_BLOCK_RE = re.compile(
 def _companion_fix_hint(rule_id: str, category: str, companion_path) -> str:
     return (
         f"  Add a `secure_fix:` entry for `{rule_id}` in {companion_path},\n"
-        f"  or implement a tailored handler in remediations/{category}.py,\n"
-        f"  or set `no_ansible_remediation: true` on the rule if the correct\n"
-        f"  response is procedural."
+        f"  or implement a tailored handler in remediations/{category}.py.\n"
+        f"  Every finding must ship an actionable Ansible fix - there is no\n"
+        f"  procedural opt-out."
     )
 
 
@@ -331,13 +370,13 @@ def test_remediation_includes_secure_fix_yaml_block(
     rule_id: str,
     category: str,
 ) -> None:
-    """Every rule must render a curated ``✅ Secure Fix`` YAML block or set
-    ``no_ansible_remediation: true``. ``negative_examples`` are regex
-    non-match fixtures and are explicitly not accepted as a fix source.
+    """Every rule must render a curated ``✅ Secure Fix`` YAML block.
+
+    Per project policy every finding ships an actionable Ansible fix - there
+    is no procedural opt-out. ``negative_examples`` are regex non-match
+    fixtures and are explicitly not accepted as a fix source.
     """
     meta = _PI.get(rule_id)
-    if meta.get("no_ansible_remediation"):
-        return
 
     out = remediation_generator.generate_remediation_example(
         rule_id, "shell: echo placeholder", file_path="test.yml", line_number=1
@@ -378,6 +417,183 @@ def test_remediation_includes_secure_fix_yaml_block(
             f"{fix_hint}\n"
             f"\n  rendered body (first 320 chars):\n    {rendered_body[:320]!r}"
         )
+
+
+def test_no_rule_opts_out_of_remediation() -> None:
+    """Policy guard: no shipped rule may carry ``no_ansible_remediation``.
+
+    The flag was the escape hatch that let prose-only rules skip the Secure
+    Fix contract. Project policy is now that *every* finding ships an
+    actionable Ansible fix, so the flag must not reappear - reintroducing it
+    silently re-opens the gap this suite exists to close.
+    """
+    flagged: list[str] = []
+    for yml in sorted(PATTERNS_DIR.glob("*.yml")):
+        data = yaml.safe_load(yml.read_text())
+        if not isinstance(data, dict):
+            continue
+        for p in data.get("patterns", []):
+            if p.get("exclude"):
+                continue
+            if p.get("no_ansible_remediation"):
+                flagged.append(f"{p.get('id')} ({yml.name})")
+    assert not flagged, (
+        f"{len(flagged)} rule(s) still set `no_ansible_remediation: true`, "
+        f"which is no longer permitted - every finding must ship a dynamic "
+        f"Ansible fix instead:\n  " + "\n  ".join(flagged[:20])
+    )
+
+
+@pytest.mark.parametrize(
+    "rule_id,category,positive_example",
+    ALL_POSITIVE_EXAMPLES,
+    ids=[f"{r}#{i}" for i, (r, _, _) in enumerate(ALL_POSITIVE_EXAMPLES)],
+)
+def test_positive_example_renders_valid_secure_fix(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+    category: str,
+    positive_example: str,
+) -> None:
+    """Render every rule against the *actual* code it is built to flag.
+
+    This is the regression net for the whole class of bug where a fix looks
+    fine against a generic placeholder snippet but breaks on a real match -
+    a greedy extractor truncating ``{{ var }}`` to ``{{``, a nested Jinja
+    expression, or the fix dispatch silently dropping to a prose-only
+    metadata stub. The generic-snippet tests above never exercise the
+    rule's own extraction path; this one does.
+    """
+    out = remediation_generator.generate_remediation_example(
+        rule_id, positive_example, file_path="test.yml", line_number=1
+    )
+    _assert_well_formed(rule_id, out)
+
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    assert match, (
+        f"{rule_id}: rendering against its own positive example produced no "
+        f"`\u2705 Secure Fix` YAML block - the fix dispatch fell through to a "
+        f"prose-only stub for real matching code.\n"
+        f"  positive example (first 160 chars): {positive_example[:160]!r}\n"
+        f"  remediation excerpt (first 320 chars): {out[:320]!r}"
+    )
+
+    body = match.group("body")
+    assert not _TRUNCATED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix rendered from the rule's own positive example "
+        f"contains a truncated Jinja expression (a dangling `{{{{`). The value "
+        f"extractor stopped at the space inside `{{{{ var }}}}`.\n"
+        f"  positive example: {positive_example[:160]!r}\n"
+        f"  Secure Fix body (first 320 chars): {body[:320]!r}"
+    )
+    assert not _NESTED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix rendered from the rule's own positive example "
+        f"contains nested Jinja (`{{{{ ... {{{{ ... }}}} ... }}}}`).\n"
+        f"  positive example: {positive_example[:160]!r}\n"
+        f"  Secure Fix body (first 320 chars): {body[:320]!r}"
+    )
+
+
+# Structural (AST / Python-defined) rules have no ``patterns/*.yml`` entry and
+# therefore no ``positive_examples``, so the catalog-driven test above never
+# exercises them. They are nonetheless emitted as real findings and must ship a
+# dynamic Secure Fix that reuses the finding's own code. Each example below is a
+# realistic task the rule fires on, paired with a token the dynamic fix must
+# substitute from that code (or ``None`` when the fix is legitimately procedural).
+STRUCTURAL_RULE_EXAMPLES = [
+    (
+        "missing_no_log",
+        '- name: authenticate\n  uri:\n    url: "https://api/x"\n    password: "{{ vault_pw }}"',
+        "no_log: true",
+    ),
+    (
+        "ignore_errors_security_task",
+        "- name: verify cert\n  ansible.builtin.command: openssl verify /etc/ssl/cert.pem\n  ignore_errors: yes",
+        "failed_when:",
+    ),
+    (
+        "get_url_no_checksum",
+        '- name: download tf\n  get_url:\n    url: "https://releases.example.com/{{ ver }}/tf.zip"\n    dest: "./tf.zip"',
+        "checksum:",
+    ),
+    (
+        "s3_download_no_integrity_check",
+        '- name: pull iocs\n  aws_s3:\n    bucket: b\n    object: o\n    dest: "/tmp/{{ name }}.json"\n    mode: get',
+        "/tmp/{{ name }}.json",
+    ),
+    (
+        "set_fact_secret_alias",
+        '- name: alias secret\n  set_fact:\n    app_token: "{{ raw_token.stdout }}"',
+        "vault_app_token",
+    ),
+    (
+        "credential_file_missing_mode",
+        '- name: copy cert\n  copy:\n    src: /tmp/x.pem\n    dest: "/etc/ssl/private/x.pem"\n    owner: root',
+        "mode: '0600'",
+    ),
+    (
+        "private_key_written_outside_canonical_dir_ast",
+        '- name: drop key\n  copy:\n    src: id_rsa\n    dest: "/opt/app/id_rsa"\n    owner: app',
+        "mode: '0600'",
+    ),
+    (
+        "hardcoded_credentials",
+        'service_password: "REDACTED_EXAMPLE_VALUE"',
+        "vault_service_password",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "rule_id,snippet,must_contain",
+    STRUCTURAL_RULE_EXAMPLES,
+    ids=[r for r, _, _ in STRUCTURAL_RULE_EXAMPLES],
+)
+def test_structural_rule_renders_dynamic_secure_fix(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+    snippet: str,
+    must_contain: str,
+) -> None:
+    """Structural rules must ship a dynamic Secure Fix, not prose.
+
+    These rules are defined in ``file_scanner.py`` (not pattern YAML) and the
+    scanner passes ``description_fallback``/``recommendation_fallback`` for
+    them, which historically short-circuited dispatch to a procedural metadata
+    stub. This locks in the dynamic, code-reusing fix so that regression can't
+    recur silently.
+    """
+    out = remediation_generator.generate_remediation_example(
+        rule_id,
+        snippet,
+        file_path="test.yml",
+        line_number=1,
+        description_fallback="structural rule description",
+        recommendation_fallback="structural rule recommendation",
+    )
+    _assert_well_formed(rule_id, out)
+
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    assert match, (
+        f"{rule_id}: structural rule produced no `\u2705 Secure Fix` block - "
+        f"dispatch fell through to a prose-only metadata stub.\n"
+        f"  remediation excerpt: {out[:320]!r}"
+    )
+
+    body = match.group("body")
+    assert not _TRUNCATED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix contains a truncated Jinja expression "
+        f"(dangling `{{{{`).\n  body: {body[:320]!r}"
+    )
+    assert not _NESTED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix contains nested Jinja.\n  body: {body[:320]!r}"
+    )
+    yaml.safe_load(body)  # raises if the Secure Fix isn't valid YAML
+    assert must_contain in body, (
+        f"{rule_id}: Secure Fix did not dynamically apply the expected hardening "
+        f"({must_contain!r}) drawn from the finding's own code.\n"
+        f"  body: {body[:320]!r}"
+    )
 
 
 class TestMaliciousActivityDirect:
@@ -837,3 +1053,106 @@ class TestTaintFlowRealWorldSyntax:
             "cross_file_taint hit the generic fallback - the dispatcher "
             "entry for `cross_file_taint` is missing or broken"
         )
+
+
+class TestDataDestructionDynamicFixes:
+    """The data_destruction remediations must be DYNAMIC: the concrete
+    target from the finding (the device wiped, the path deleted, the
+    database dropped, the LVM volume removed) has to appear in the rendered
+    Secure Fix, not a generic placeholder. They must also stay semantically
+    honest - a deletion fix must use ``state: absent`` and must never
+    propose creating a file - and every destructive op must be gated.
+    """
+
+    @pytest.fixture(scope="class")
+    def gen(self) -> RemediationGenerator:
+        return RemediationGenerator()
+
+    def _render(self, gen, rule_id, snippet):
+        return gen.generate_remediation_example(
+            rule_id, snippet, file_path="play.yml", line_number=3
+        )
+
+    @pytest.mark.parametrize(
+        "rule_id,snippet,must_contain",
+        [
+            ("disk_wipe_dd", "shell: dd if=/dev/zero of=/dev/sdb bs=1M", "/dev/sdb"),
+            ("recursive_delete_critical", "shell: rm -rf /home/{{ user }}", "/home/{{ user }}"),
+            ("database_drop_truncate", "mysql: DROP DATABASE customers;", "customers"),
+            ("lvm_vg_remove", "shell: lvremove /dev/vg0/data -f", "/dev/vg0/data"),
+            ("mkfs_format_device", "shell: mkfs.xfs /dev/nvme0n1", "/dev/nvme0n1"),
+            ("shred_wipe_command", "command: shred -u /srv/app/secret.key", "/srv/app/secret.key"),
+        ],
+    )
+    def test_finding_value_is_substituted_into_fix(self, gen, rule_id, snippet, must_contain):
+        out = self._render(gen, rule_id, snippet)
+        _assert_well_formed(rule_id, out)
+        secure = _SECURE_FIX_BLOCK_RE.search(out)
+        assert secure, f"{rule_id}: no Secure Fix block"
+        assert must_contain in secure.group("body"), (
+            f"{rule_id}: the finding's real target {must_contain!r} was not "
+            f"woven into the Secure Fix - the remediation is not dynamic.\n"
+            f"  Secure Fix body (first 320 chars):\n    {secure.group('body')[:320]!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "rule_id,snippet",
+        [
+            ("recursive_delete_critical", "shell: rm -rf /etc/"),
+            ("shred_wipe_command", "command: shred /srv/x"),
+            ("backup_deletion", "shell: rm -f /backups/db.bak"),
+        ],
+    )
+    def test_deletion_fix_uses_absent_not_creation(self, gen, rule_id, snippet):
+        """A fix for a deletion rule must remove via ``state: absent`` and
+        must never propose creating the thing it is meant to delete - the
+        old file-manipulation handler suggested ``state: file`` here."""
+        out = self._render(gen, rule_id, snippet)
+        match = _SECURE_FIX_BLOCK_RE.search(out)
+        assert match, f"{rule_id}: no Secure Fix block"
+        secure = match.group("body")
+        assert "state: absent" in secure, f"{rule_id}: deletion fix does not use `state: absent`"
+        assert "state: file" not in secure and "state: touch" not in secure, (
+            f"{rule_id}: deletion fix proposes CREATING a file - semantically wrong"
+        )
+
+    @pytest.mark.parametrize(
+        "rule_id,snippet",
+        [
+            ("disk_wipe_dd", "shell: dd if=/dev/zero of=/dev/sdb"),
+            ("database_drop_truncate", "mysql: DROP TABLE orders;"),
+            ("lvm_vg_remove", "shell: vgremove vg0"),
+            ("shred_wipe_command", "command: shred /srv/x"),
+            ("backup_deletion", "shell: rm -rf /backups"),
+            ("recursive_delete_critical", "shell: rm -rf /var/{{ d }}"),
+        ],
+    )
+    def test_destructive_fix_is_gated(self, gen, rule_id, snippet):
+        """Every destructive op must sit behind an explicit confirmation
+        gate (an assert + a confirm variable), never run unconditionally."""
+        out = self._render(gen, rule_id, snippet)
+        match = _SECURE_FIX_BLOCK_RE.search(out)
+        assert match, f"{rule_id}: no Secure Fix block"
+        secure = match.group("body")
+        assert "ansible.builtin.assert" in secure or "confirm" in secure, (
+            f"{rule_id}: destructive fix is not gated behind a confirmation"
+        )
+
+    def test_data_destruction_routes_to_dynamic_generator(self, gen):
+        """All eight data_destruction rules must resolve through the
+        dynamic generator, never the metadata fallback or a stale companion
+        snippet (which would emit a static placeholder, not the finding)."""
+        for rule_id in (
+            "disk_wipe_dd",
+            "shred_wipe_command",
+            "ransomware_file_encryption",
+            "database_drop_truncate",
+            "recursive_delete_critical",
+            "mkfs_format_device",
+            "backup_deletion",
+            "lvm_vg_remove",
+        ):
+            out = self._render(gen, rule_id, "shell: rm -rf /etc/")
+            assert _SECURE_FIX_BLOCK_RE.search(out), (
+                f"{rule_id}: no Secure Fix block - dispatch regressed"
+            )


### PR DESCRIPTION
Every finding now ships a copy-pasteable Ansible secure fix built from the finding's own code instead of procedural prose.

- Structural rules (missing_no_log, ignore_errors_security_task, get_url_no_checksum, s3_download_no_integrity_check, set_fact_secret_alias, credential_file_missing_mode, private_key_written_outside_canonical_dir_ast, hardcoded_credentials) now route to dynamic handlers that reuse the matched task.
- Removed the no_ansible_remediation opt-out and the stale generic example handlers.
- Hardened Jinja value extraction so templated paths and URLs are captured whole rather than truncated.