### PR TITLE
Detect fork-triggerable AI coding agents with repository write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1128-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1144-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1128<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1144<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->426<!--/CRIT--> critical**, <!--HIGH-->548<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->442<!--/CRIT--> critical**, <!--HIGH-->548<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -152,7 +152,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1128<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1144<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -841,6 +841,308 @@ def _demote_severity(finding, eligible_rule_ids: frozenset[str]):
 # (``curl -k`` / ``--insecure``) both fire on the same line but
 # describe different issues (cred exposure vs TLS bypass), so
 # both remain.
+def _has_fork_reachable_trigger(content: str) -> bool:
+    """Return ``True`` when a workflow's ``on:`` block declares a trigger an
+    untrusted contributor can reach.
+
+    Fork-reachable triggers are ``pull_request_target``, ``issue_comment``,
+    ``issues``, ``pull_request``, ``pull_request_review_comment``,
+    ``pull_request_review``, and ``workflow_call`` (reusable workflows
+    inherit their caller's trigger). Triggers such as ``schedule``,
+    ``workflow_dispatch``, ``workflow_run``, and ``push`` are not, on their own,
+    reachable by a fork contributor.
+
+    Parses only the ``on:`` block so trigger names are not confused with
+    unrelated keys elsewhere in the file (e.g. ``issues: write`` under
+    ``permissions:``). Handles the mapping form (``on:`` then indented keys),
+    the inline-list form (``on: [issues, pull_request_target]``), and the
+    YAML 1.1 quoted key (``"on":`` / ``'on':``).
+    """
+    lines = content.splitlines()
+    on_idx = None
+    for i, line in enumerate(lines):
+        if re.match(r"""^\s*(?:["']?on["']?)\s*:""", line):
+            on_idx = i
+            break
+    if on_idx is None:
+        return False
+
+    header = lines[on_idx]
+    # Inline forms: ``on: [issues, ...]`` or ``on: pull_request_target``.
+    after_colon = header.split(":", 1)[1].strip()
+    if after_colon:
+        tokens = re.findall(r"[A-Za-z_]+", after_colon)
+        return any(t in _FORK_REACHABLE_TRIGGERS for t in tokens)
+
+    # Mapping form: collect keys indented deeper than ``on:`` until the block
+    # ends (a line at the same or shallower indent that is not blank/comment).
+    on_indent = len(header) - len(header.lstrip())
+    for line in lines[on_idx + 1 :]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= on_indent:
+            break
+        key_match = re.match(r"^\s*-?\s*([A-Za-z_]+)\s*:?", line)
+        if key_match and key_match.group(1) in _FORK_REACHABLE_TRIGGERS:
+            return True
+    return False
+
+
+def _enclosing_job_block(lines: list[str], line_index: int) -> str:
+    """Return the text of the top-level ``jobs:`` entry that contains
+    ``line_index`` (0-based), or the whole file when the job structure cannot be
+    parsed. Used to scope a per-job capability check to the job that actually
+    runs the agent, so a write permission granted to an unrelated sibling job
+    does not count.
+    """
+    jobs_idx = next((i for i, line in enumerate(lines) if re.match(r"^\s*jobs\s*:", line)), None)
+    if jobs_idx is None:
+        return "\n".join(lines)
+    jobs_indent = len(lines[jobs_idx]) - len(lines[jobs_idx].lstrip())
+    job_indent: int | None = None
+    starts: list[int] = []
+    for i in range(jobs_idx + 1, len(lines)):
+        line = lines[i]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent <= jobs_indent:
+            break
+        if job_indent is None:
+            job_indent = indent
+        if indent == job_indent and re.match(r"^\s*[A-Za-z0-9_.-]+\s*:", line):
+            starts.append(i)
+    starts.append(len(lines))
+    for start, end in zip(starts, starts[1:], strict=False):
+        if start <= line_index < end:
+            return "\n".join(lines[start:end])
+    return "\n".join(lines)
+
+
+def _workflow_level_write(content: str) -> bool:
+    """Return whether the workflow's top-level ``permissions:`` block (the one
+    above ``jobs:``) defaults to repository write. A top-level ``contents:
+    write`` / ``write-all`` applies to every job that does not narrow it, so an
+    agent job with no ``permissions:`` of its own inherits push access.
+    """
+    lines = content.splitlines()
+    jobs_idx = next(
+        (i for i, line in enumerate(lines) if re.match(r"^\s*jobs\s*:", line)),
+        len(lines),
+    )
+    head = "\n".join(lines[:jobs_idx])
+    return bool(
+        re.search(
+            r"^\s*permissions\s*:\s*write-all\b"
+            r"|^\s*permissions\s*:[^\n]*(?:\n\s+[^\n]*)*?\n\s+contents\s*:\s*write\b",
+            head,
+            re.MULTILINE,
+        )
+    )
+
+
+# Fork-triggerable AI-agent rules only describe a real risk when the workflow
+# can actually be reached by an untrusted contributor. They anchor on
+# ``allowed_non_write_users: "*"`` plus a tool grant, neither of which says
+# anything about the ``on:`` trigger; on a workflow that only runs on
+# ``schedule`` / ``workflow_dispatch`` / ``workflow_run`` that setting is inert
+# and the finding is a false positive. ``workflow_call`` counts as reachable
+# because a reusable workflow inherits its caller's (possibly fork-reachable)
+# trigger.
+_FORK_TRIGGERABLE_AI_RULE_IDS: frozenset[str] = frozenset(
+    {
+        "fork_triggerable_ai_agent_with_write_or_exec_tools",
+        "fork_triggerable_ai_agent_with_repo_mutating_gh_tools",
+        "fork_triggerable_gemini_or_copilot_agent_with_write_or_exec",
+        "fork_triggerable_codex_agent_with_write_or_exec_sandbox",
+    }
+)
+_FORK_REACHABLE_TRIGGERS: tuple[str, ...] = (
+    "pull_request_target",
+    "issue_comment",
+    "issues",
+    "pull_request",
+    "pull_request_review_comment",
+    "pull_request_review",
+    "workflow_call",
+)
+
+# These rules anchor on an installed-agent invocation, which says nothing about
+# the ``on:`` trigger, the enclosing job's write capability, or an
+# author-permission gate that may live in another step or a ``needs:`` job. A
+# finding survives ``_suppress_installed_agent_when_safe`` only when the
+# workflow has a fork-reachable trigger, the agent's job can mutate the repo,
+# and no author gate is present. Review bots (``contents: read``, comment-only
+# scope) and gated agents are dropped. Each entry maps a rule id to the
+# whole-file proof that confirms the family (the CLI/action can share a generic
+# binary name, so the proof keeps it precise).
+_INSTALLED_AGENT_PROOF: dict[str, re.Pattern[str]] = {
+    "fork_triggerable_cursor_agent_with_repo_write": re.compile(
+        r"cursor\.com/install|CURSOR_API_?KEY|@cursor/sdk|cursor[_-]sdk", re.IGNORECASE
+    ),
+    "fork_triggerable_opencode_agent_with_repo_write": re.compile(
+        r"sst/opencode|anomalyco/opencode|opencode\s+run|OPENCODE_API", re.IGNORECASE
+    ),
+    "fork_triggerable_amp_agent_with_repo_write": re.compile(
+        r"sourcegraph/amp|ampcode\.com|@sourcegraph/amp|AMP_API_KEY", re.IGNORECASE
+    ),
+    # ``goose run`` collides with unrelated CLIs (``git-goose``, the
+    # ``pressly/goose`` DB migrator), so require a Block-goose signal: the
+    # install script, a store/config path, one of the ``GOOSE_*`` env vars, or
+    # an agent-only invocation flag (``--recipe`` / ``--instructions`` /
+    # ``--with-extension`` / ``--no-session`` / ``-t`` / ``-i``).
+    "fork_triggerable_goose_agent_with_repo_write": re.compile(
+        r"block/goose|goose/releases|download_cli\.sh|GOOSE_(?:PROVIDER|MODEL|MODE)"
+        r"|\.config/goose|configure-goose|block-open-source/goose"
+        r"|goose\s+run\s+--(?:recipe|instructions|with-builtin|with-extension|no-session|text)"
+        r"|goose\s+run\s+-[ti]\b",
+        re.IGNORECASE,
+    ),
+    # Droid's action slug and CLI package are distinctive; the CLI install comes
+    # from ``app.factory.ai`` or ``@factory/cli`` and runs via ``droid exec``.
+    "fork_triggerable_droid_agent_with_repo_write": re.compile(
+        r"Factory-AI/droid|factory-ai|app\.factory\.ai|@factory/cli|FACTORY_API_KEY"
+        r"|droid\s+exec\b",
+        re.IGNORECASE,
+    ),
+    # ``aider`` is unambiguous once paired with its install (``aider-chat``) or a
+    # non-interactive run flag; the anchor regex already requires the run flag.
+    "fork_triggerable_aider_agent_with_repo_write": re.compile(
+        r"aider-chat|(?<![\w-])aider\b", re.IGNORECASE
+    ),
+    # OpenHands' resolver reusable workflow and ``@openhands-agent`` macro are
+    # distinctive; the anchor regex already carries the family, so the proof
+    # keeps it precise against unrelated "hands" text.
+    "fork_triggerable_openhands_agent_with_repo_write": re.compile(
+        r"All-Hands-AI/OpenHands|all-hands\.dev|openhands-resolver|@openhands-agent"
+        r"|(?<![\w-])openhands\b",
+        re.IGNORECASE,
+    ),
+    # ``qwen`` alone collides with unrelated Alibaba model references, so require
+    # a Qwen Code signal: the action/package slug, the ``@qwen-code`` macro, or
+    # the CLI paired with ``--yolo`` (the anchor already requires the latter).
+    "fork_triggerable_qwen_code_agent_with_repo_write": re.compile(
+        r"qwen-code|@qwen-code|QwenLM/qwen-code", re.IGNORECASE
+    ),
+    # ``crush`` collides with unrelated tools, so require a Charm-crush signal:
+    # the repo slug, the apt source, or the ``crush run`` invocation.
+    "fork_triggerable_crush_agent_with_repo_write": re.compile(
+        r"charmbracelet/crush|repo\.charm\.sh|(?<![\w-])crush\s+run\b", re.IGNORECASE
+    ),
+    # ``copilot`` is a common word, so require a GitHub Copilot CLI signal: the
+    # npm package, the install script, one of the ``COPILOT_*_TOKEN`` env vars,
+    # the ``gh aw`` copilot engine, or a ``copilot --version`` check. The anchor
+    # already requires the ``--allow-all-tools`` / ``--allow-tool`` grant.
+    "fork_triggerable_copilot_cli_agent_with_repo_write": re.compile(
+        r"@github/copilot|install_copilot_cli|gh\.io/copilot-install"
+        r"|COPILOT_(?:GITHUB|CLI)_TOKEN|COPILOT_ALLOW_ALL"
+        r"|GH_AW_ENGINE\s*[:=]\s*[\"']?copilot|command\s+-v\s+copilot|copilot\s+--version",
+        re.IGNORECASE,
+    ),
+    # ``cn`` is a two-letter binary that collides with unrelated tooling, so
+    # require a Continue signal: the npm package, the ``continuedev`` org slug
+    # in a config/agent reference, or a ``CONTINUE_*`` env var. The anchor
+    # already requires ``cn`` in agent/auto/remote mode.
+    "fork_triggerable_continue_cli_agent_with_repo_write": re.compile(
+        r"@continuedev/cli|continuedev/|CONTINUE_(?:API_KEY|CLI)", re.IGNORECASE
+    ),
+    # gptme ships an official ``@gptme`` bot action/workflow. The binary name is
+    # distinctive, but require a gptme signal (the CLI, the action, or the PyPI
+    # package) so a stray ``gptme`` string in prose does not count. The anchor
+    # already requires the non-interactive agent invocation.
+    "fork_triggerable_gptme_agent_with_repo_write": re.compile(
+        r"gptme|ErikBjare/gptme", re.IGNORECASE
+    ),
+    # SWE-agent (``SWE-agent/SWE-agent``, formerly ``princeton-nlp``) runs as
+    # ``sweagent run``. Require the project/package signal so the anchor is
+    # attributed to the real agent and not the ``swe-agent`` substring inside a
+    # bot-exclusion allowlist (``copilot-swe-agent``).
+    "fork_triggerable_swe_agent_with_repo_write": re.compile(
+        r"SWE-agent/SWE-agent|princeton-nlp/SWE-agent|python\s+-m\s+sweagent"
+        r"|pip\s+install\s+sweagent|sweagent\s+run\b",
+        re.IGNORECASE,
+    ),
+    # ``warp`` is a common word, so require a Warp signal: the release repo, the
+    # ``WARP_API_KEY`` env var, or the ``warp-cli`` binary. The anchor already
+    # requires the ``warp[-cli] agent run`` invocation.
+    "fork_triggerable_warp_agent_with_repo_write": re.compile(
+        r"releases\.warp\.dev|WARP_API_?KEY|(?<![\w-])warp-cli\b", re.IGNORECASE
+    ),
+    # ``claude`` collides with unrelated text, so require a Claude Code signal:
+    # the npm package, the ``ANTHROPIC_API_KEY`` credential, a ``CLAUDE_CODE`` env
+    # var, or the CLI auto-approve flags themselves (``--dangerously-skip-permissions``
+    # / ``--permission-mode bypassPermissions``), which the ``anthropics/claude-code-action``
+    # (covered by a separate rule) does not carry, so the two do not overlap. The
+    # anchor already requires the leading ``claude`` token before those flags, so
+    # ``opencode run --dangerously-skip-permissions`` is not matched by the rule.
+    "fork_triggerable_claude_cli_agent_with_repo_write": re.compile(
+        r"@anthropic-ai/claude-code|ANTHROPIC_API_?KEY|CLAUDE_CODE|(?<![\w-])claude-code\b"
+        r"|--dangerously-skip-permissions|--permission-mode[\s=]+['\"]?(?:bypassPermissions|acceptEdits)\b",
+        re.IGNORECASE,
+    ),
+}
+_INSTALLED_AGENT_JOB_WRITE = re.compile(
+    r"^\s*contents\s*:\s*write\b|permissions\s*:\s*write-all\b"
+    r"|\bgit\s+push\b|\bgh\s+pr\s+(?:create|merge)\b",
+    re.MULTILINE | re.IGNORECASE,
+)
+# The OpenHands resolver ships as a reusable workflow
+# (``<owner>/OpenHands/.github/workflows/openhands-resolver.yml``) that gates
+# the agent on ``author_association`` inside the *called* repo, so a caller
+# that only does ``uses: .../openhands-resolver.yml@<ref>`` inherits that gate
+# and is not fork-exploitable regardless of the permissions it passes in. The
+# whole-file author-gate check cannot see the downstream repo, so recognise the
+# delegation here. A file that invokes OpenHands directly (its CLI/action in a
+# step) does not match and is still evaluated normally.
+_OPENHANDS_REUSABLE_DELEGATION = re.compile(
+    r"uses\s*:\s*[^\n]*?/\.github/workflows/openhands-resolver\.yml", re.IGNORECASE
+)
+# Author / write-permission gate: any of these means only trusted actors reach
+# the job, so the agent is not fork-exploitable. Covers the collaborator API,
+# ``author_association`` membership checks, the ``fromJSON`` role-list idiom,
+# ``allow_forks: false``, a hardcoded ``login``/``actor`` equality gate, a label
+# gate (only users with write access can label an issue/PR, so a
+# ``labels.*.name`` / ``label.name`` / ``action == 'labeled'`` condition is a
+# write gate), and a fork-exclusion gate that skips the agent on PRs from forks
+# (``head.repo.full_name == github.repository`` / ``head.repo.fork`` /
+# ``is_fork``).
+_INSTALLED_AGENT_AUTHOR_GATE = re.compile(
+    r"getCollaboratorPermissionLevel"
+    r"|author_association\s*(?:==|!=|\bin\b|\bnot in\b)"
+    r"|author_association\b[^\n)]{0,120}?\)\s*(?:==|!=)\s*['\"]?(?:OWNER|MEMBER|COLLABORATOR)"
+    r"|contains\(\s*fromJSON\('\[\s*\"(?:OWNER|MEMBER|COLLABORATOR)"
+    # ``actions/github-script`` gates are written in JavaScript, so the role
+    # check is an array-membership test rather than an Actions expression:
+    # ``['OWNER','MEMBER','COLLABORATOR'].includes(author_association)``. The
+    # literal role allowlist array is a strong maintainer-gate signal.
+    r"|\[\s*['\"]OWNER['\"]\s*,\s*['\"](?:MEMBER|COLLABORATOR)['\"]"
+    # ``contains(fromJSON('["alice","bob"]'), github.event.comment.user.login)``
+    # is an explicit maintainer/username allowlist - the agent only runs for
+    # the named accounts, so it is gated just like an ``author_association``
+    # check. Anchor on the actor-identity operand so an unrelated ``fromJSON``
+    # list (matrix, labels) does not count as a gate.
+    r"|contains\(\s*fromJSON\([^)]*\)\s*,\s*[^)\n]*?"
+    r"(?:comment\.user\.login|sender\.login|github\.actor|triggering_actor"
+    r"|pull_request\.user\.login|issue\.user\.login)"
+    r"|allow_forks\s*:\s*[\"']?false"
+    r"|permission\.permission"
+    r"|collaborators/[^/\s]+/permission"
+    r"|[\"']?(?:admin|maintain|write)[\"']?\s*[!=]=\s*[\"']?\$?(?:PERMISSION|permission)"
+    r"|\$?(?:PERMISSION|permission)[\"']?\s*[!=]=\s*[\"'](?:admin|maintain|write)"
+    r"|(?:comment\.user\.login|sender\.login|github\.actor|triggering_actor)"
+    r"\s*==\s*['\"]"
+    r"|(?:github\.actor|triggering_actor|sender\.login|comment\.user\.login)"
+    r"\s*==\s*github\.(?:event\.)?repository\.owner\.login"
+    r"|==\s*github\.(?:event\.)?repository\.owner\.login"
+    r"|contains\(\s*github\.event\.[a-z_.]*labels\.\*\.name"
+    r"|contains\(\s*github\.event\.label\.name"
+    r"|github\.event\.label\.name\s*==|github\.event\.action\s*==\s*['\"]labeled"
+    r"|head\.repo\.full_name\s*(?:==|!==|!=)\s*"
+    r"|head\.repo\.fork\b|is_fork\s*(?:==|!=)",
+    re.IGNORECASE,
+)
+
 _OVERLAP_SUPPRESSION_GROUPS: tuple[tuple[str, ...], ...] = (
     # Pipe-to-shell family - all describe the same
     # "download-and-execute" RCE pattern with different scopes.
@@ -1741,6 +2043,23 @@ class FileScanner:
             # hardened fixtures. Running the lookup over the whole file
             # is both more precise and windowing-immune.
             line_findings = self._suppress_slsa_findings_when_verified(line_findings, content)
+
+            # Post-filter: fork-triggerable AI-agent rules anchor on
+            # ``allowed_non_write_users: "*"`` but the windowed regex cannot
+            # see the ``on:`` trigger block. Drop those findings when the
+            # workflow has no fork-reachable trigger (only ``schedule`` /
+            # ``workflow_dispatch`` / ``workflow_run``), where the open-user
+            # setting is inert and the finding is a false positive.
+            line_findings = self._suppress_fork_triggerable_ai_when_not_reachable(
+                line_findings, content
+            )
+
+            # Post-filter: the installed-agent rules anchor on the invocation
+            # line, which cannot see the trigger, the job's write capability, or
+            # an author gate. Drop findings on non-fork-reachable workflows,
+            # review-only jobs (``contents: read``), and jobs gated on repo
+            # write access.
+            line_findings = self._suppress_installed_agent_when_safe(line_findings, content)
 
             # Post-filter: suppress ``crontab_modification`` when the
             # matching task is removing (not installing) a cron entry
@@ -6930,6 +7249,93 @@ class FileScanner:
         if not any(v in code_only for v in verifiers):
             return findings
         return [f for f in findings if f.rule_id != "slsa_provenance_verification_missing"]
+
+    def _suppress_fork_triggerable_ai_when_not_reachable(
+        self, findings: list[SecurityFinding], content: str
+    ) -> list[SecurityFinding]:
+        """Drop fork-triggerable AI-agent findings that are not exploitable.
+
+        The rules anchor on ``allowed_non_write_users: "*"`` (plus a tool
+        grant) but the sliding-window regex never sees the ``on:`` block, the
+        job's write capability, or an author gate. A finding survives only when
+        all three hold: the workflow has a fork-reachable trigger, the agent's
+        job can write to the repo, and no author gate is present.
+
+        * Not reachable: on ``schedule`` / ``workflow_dispatch`` /
+          ``workflow_run`` only, no untrusted contributor can invoke the agent.
+          ``workflow_call`` is treated as reachable (a reusable workflow
+          inherits its caller's trigger).
+        * Read-only agent job: the split-privilege pattern runs the agent at
+          ``contents: read`` and hands its output to a separate reviewed job
+          for the commit/PR, so untrusted input never reaches a write token in
+          the agent's job. A custom gate the regex cannot parse is moot here.
+        """
+        if not findings or not any(f.rule_id in _FORK_TRIGGERABLE_AI_RULE_IDS for f in findings):
+            return findings
+        if not _has_fork_reachable_trigger(content):
+            return [f for f in findings if f.rule_id not in _FORK_TRIGGERABLE_AI_RULE_IDS]
+        if _INSTALLED_AGENT_AUTHOR_GATE.search(content):
+            return [f for f in findings if f.rule_id not in _FORK_TRIGGERABLE_AI_RULE_IDS]
+        lines = content.splitlines()
+        workflow_write = _workflow_level_write(content)
+        kept: list[SecurityFinding] = []
+        for f in findings:
+            if f.rule_id not in _FORK_TRIGGERABLE_AI_RULE_IDS:
+                kept.append(f)
+                continue
+            job_text = _enclosing_job_block(lines, max(f.line_number - 1, 0))
+            job_can_write = bool(_INSTALLED_AGENT_JOB_WRITE.search(job_text)) or (
+                workflow_write and not re.search(r"^\s+permissions\s*:", job_text, re.MULTILINE)
+            )
+            if job_can_write:
+                kept.append(f)
+        return kept
+
+    def _suppress_installed_agent_when_safe(
+        self, findings: list[SecurityFinding], content: str
+    ) -> list[SecurityFinding]:
+        """Drop installed-agent findings that are not actually exploitable.
+
+        These rules (the ``_INSTALLED_AGENT_PROOF`` keys) anchor on the agent
+        invocation, which says nothing about the trigger, the job's write
+        capability, or an author gate. A finding survives only when all three
+        hold: the workflow has a fork-reachable trigger, the agent's job can
+        write to the repo (a ``git push`` / ``gh pr create|merge`` or
+        ``contents: write`` / ``permissions: write-all`` in the job, or a
+        workflow-level write default the job does not narrow), and no author
+        gate is present. Because some agents share a generic binary name, each
+        finding also has to match its family's whole-file proof. Review bots
+        (``contents: read``, comment-only scope) and gated agents are dropped.
+        """
+        if not findings or not any(f.rule_id in _INSTALLED_AGENT_PROOF for f in findings):
+            return findings
+        reachable = _has_fork_reachable_trigger(content)
+        gated = bool(_INSTALLED_AGENT_AUTHOR_GATE.search(content))
+        workflow_write = _workflow_level_write(content)
+        openhands_delegates = bool(_OPENHANDS_REUSABLE_DELEGATION.search(content))
+        lines = content.splitlines()
+        kept: list[SecurityFinding] = []
+        for f in findings:
+            proof = _INSTALLED_AGENT_PROOF.get(f.rule_id)
+            if proof is None:
+                kept.append(f)
+                continue
+            if not reachable or gated or not proof.search(content):
+                continue
+            # OpenHands caller stubs delegate to the reusable resolver, which
+            # self-gates on ``author_association`` in the called repo.
+            if (
+                f.rule_id == "fork_triggerable_openhands_agent_with_repo_write"
+                and openhands_delegates
+            ):
+                continue
+            job_text = _enclosing_job_block(lines, max(f.line_number - 1, 0))
+            job_can_write = bool(_INSTALLED_AGENT_JOB_WRITE.search(job_text)) or (
+                workflow_write and not re.search(r"^\s+permissions\s*:", job_text, re.MULTILINE)
+            )
+            if job_can_write:
+                kept.append(f)
+        return kept
 
     def _suppress_crontab_cleanup(
         self, findings: list[SecurityFinding], lines: list[str]

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -931,15 +931,22 @@ def _workflow_level_write(content: str) -> bool:
         (i for i, line in enumerate(lines) if re.match(r"^\s*jobs\s*:", line)),
         len(lines),
     )
-    head = "\n".join(lines[:jobs_idx])
-    return bool(
-        re.search(
-            r"^\s*permissions\s*:\s*write-all\b"
-            r"|^\s*permissions\s*:[^\n]*(?:\n\s+[^\n]*)*?\n\s+contents\s*:\s*write\b",
-            head,
-            re.MULTILINE,
-        )
-    )
+    for i in range(jobs_idx):
+        header = re.match(r"^(\s*)permissions\s*:(.*)$", lines[i])
+        if not header:
+            continue
+        if re.search(r"\bwrite-all\b", header.group(2)):
+            return True
+        perms_indent = len(header.group(1))
+        for line in lines[i + 1 : jobs_idx]:
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if len(line) - len(line.lstrip()) <= perms_indent:
+                break
+            if re.match(r"\s*contents\s*:\s*write\b", line):
+                return True
+        break
+    return False
 
 
 # Fork-triggerable AI-agent rules only describe a real risk when the workflow

--- a/src/ansible_security_scanner/patterns/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/ai_ml_security.yml
@@ -672,11 +672,13 @@ patterns:
     title: "Fork-Triggerable AI Coding Agent Granted Shell / Write Tools In A Privileged CI Job"
     description: >-
         A CI workflow wires an autonomous AI coding agent (e.g. `anthropics/claude-code-action`)
-        so that any fork contributor can trigger it - `allowed_non_write_users: "*"`, which
-        removes the action's built-in write-access gate - and, in the same action invocation,
-        grants that agent an arbitrary-command or file-write tool - bare `Bash`, `Bash(*)`,
+        so that any fork contributor can trigger it - `allowed_non_write_users: "*"` or
+        `allowed_bots: "*"`, either of which removes the action's built-in write-access gate - and,
+        in the same action invocation, grants that agent an arbitrary-command or file-write tool -
+        bare `Bash`, `Bash(*)`,
         an unscoped interpreter/VCS scope like `Bash(gh:*)` / `Bash(git:*)` / `Bash(bash ...)`,
-        or `Edit` / `Write` / `MultiEdit` - through `allowedTools` / `claude_args`. On the
+        or `Edit` / `Write` / `MultiEdit` (including path-scoped forms like `Edit(*)`,
+        `Write(./**)`, or `EditFile(...)`) - through `allowedTools` / `claude_args`. On the
         `pull_request_target` / fork-reachable `issue_comment` triggers these agents run in the
         base repository's context: they hold `GITHUB_TOKEN`, the model provider credential
         (Anthropic OAuth token / API key), and frequently `id-token: write` for OIDC. The PR
@@ -690,7 +692,7 @@ patterns:
         an open trigger plus an arbitrary exec/write grant in the same step; a tool surface
         scoped to read-only commands (`Bash(gh pr view:*)`, `Bash(git diff:*)`, `Read`, `Grep`)
         or to comment/label-only GitHub commands is not flagged here.
-    regex: "^\\s*allowed_non_write_users\\s*:\\s*[\"']?\\*[\"']?(?:(?!allowed_non_write_users|^\\s*-?\\s*(?:uses|name)\\s*:|^\\s{0,6}\\w[\\w-]*\\s*:\\s*$)[\\s\\S]){0,12000}?(?<!dis)allowed[_-]?[Tt]ools[\\s=:]+(?:(?!disallowedTools|allowed_non_write_users|(?:direct_|system_|user_)?prompt\\s*:|^\\s*\\w[\\w-]*\\s*:\\s*(?:[|>]|[\"']|$))[\\s\\S]){0,400}?(?:\\bBash\\b(?!\\s*\\()|\\bBash\\(\\s*\\*\\s*\\)|\\bBash\\(\\s*(?:gh\\s*:\\s*\\*|gh\\s+api\\b|git\\s*:\\s*\\*|git\\s+(?:add|commit|push|branch|checkout|rebase|reset|tag|merge|clone|remote)\\b|(?:ba)?sh\\b|zsh\\b|python[0-9.]*\\b|node\\b|npm\\b|pnpm\\b|yarn\\b|npx\\b|pip[0-9]*\\b|ruby\\b|perl\\b|go\\b|curl\\b|wget\\b|eval\\b|exec\\b|chmod\\b|cp\\b|mv\\b|mkdir\\b|rm\\b|tee\\b|echo\\b|cat\\s*>|\\.?/|~/)|(?<![\\w(])(?-i:Edit|Write|MultiEdit|NotebookEdit)(?![\\w(]))"
+    regex: "(?:^\\s*allowed_(?:non_write_users|bots)\\s*:\\s*[\"']?\\*[\"']?(?:(?!allowed_(?:non_write_users|bots)|^\\s*-?\\s*(?:uses|name)\\s*:|^\\s{0,6}\\w[\\w-]*\\s*:\\s*$)[\\s\\S]){0,12000}?(?<!dis)allowed[_-]?[Tt]ools[\\s=:]+(?:(?!disallowedTools|allowed_(?:non_write_users|bots)|(?:direct_|system_|user_)?prompt\\s*:|^\\s*\\w[\\w-]*\\s*:\\s*(?:[|>]|[\"']|$))[\\s\\S]){0,400}?(?:\\bBash\\b(?!\\s*\\()|\\bBash\\(\\s*\\*\\s*\\)|\\bBash\\(\\s*(?:gh\\s*:\\s*\\*|gh\\s+api\\b|git\\s*:\\s*\\*|git\\s+(?:add|commit|push|branch|checkout|rebase|reset|tag|merge|clone|remote)\\b|(?:ba)?sh\\b|zsh\\b|python[0-9.]*\\b|node\\b|npm\\b|pnpm\\b|yarn\\b|npx\\b|pip[0-9]*\\b|ruby\\b|perl\\b|go\\b|curl\\b|wget\\b|eval\\b|exec\\b|chmod\\b|cp\\b|mv\\b|mkdir\\b|rm\\b|tee\\b|echo\\b|cat\\s*>|\\.?/|~/)|(?<![\\w(])(?-i:MultiEdit|NotebookEdit|EditFile|WriteFile|Edit|Write)(?:\\([^)]*\\))?(?![\\w]))|anthropics/claude-code-(?:base-)?action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,4000}?\"allowedTools\"\\s*:\\s*\\[(?:(?!\\]|allowed_(?:non_write_users|bots))[\\s\\S]){0,400}?(?:\"\\s*Bash\\s*\"|\"\\s*Edit\\s*\"|\"\\s*Write\\s*\"|\"\\s*MultiEdit\\s*\"|\"\\s*NotebookEdit\\s*\"))"
     multiline: true
     window: 200
     positive_examples:
@@ -703,6 +705,19 @@ patterns:
               allowed_non_write_users: "*"
               claude_args: |
                 --allowedTools "Bash(gh:*),Bash(git:*),Read,Glob,Grep,Edit,Write"
+      - |2-
+            - uses: anthropics/claude-code-base-action@main
+              with:
+                anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                settings: '{"allowedTools": ["Bash", "Edit", "Read", "Write", "Grep", "Glob"]}'
+      - |2-
+              allowed_non_write_users: "*"
+              claude_args: |
+                --allowedTools "Read,Glob,Grep,Edit(*),Write(./**)"
+      - |2-
+              allowed_bots: "*"
+              claude_args: |
+                --allowedTools "Edit,Read,Write,Bash"
     negative_examples:
       - |2-
               claude_args: |
@@ -720,6 +735,11 @@ patterns:
                 # allowed_non_write_users: "*"
                 claude_args: |
                   --allowedTools "Read,Glob,Grep"
+      - |2-
+            - uses: anthropics/claude-code-base-action@main
+              with:
+                anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                settings: '{"allowedTools": ["Read", "Grep", "Glob"]}'
     recommendation: >-
         Do not give a fork-triggerable AI agent shell or write tools. Remove
         `allowed_non_write_users: "*"` and gate the agent on write access
@@ -753,8 +773,8 @@ patterns:
     title: "Fork-Triggerable AI Agent Granted Repository-Mutating GitHub Tools"
     description: >-
         A CI workflow opens an AI coding agent to any fork contributor
-        (`allowed_non_write_users: "*"`) and grants it a GitHub tool that can mutate the
-        repository - `Bash(gh pr comment:*)`, `Bash(gh issue edit:*)`, `Bash(gh label:*)`,
+        (`allowed_non_write_users: "*"` or `allowed_bots: "*"`) and grants it a GitHub tool that
+        can mutate the repository - `Bash(gh pr comment:*)`, `Bash(gh issue edit:*)`,
         `Bash(gh pr merge:*)`, a broad `Bash(gh pr:*)` / `Bash(gh issue:*)` wildcard that
         includes those write subcommands, or an MCP write verb such as
         `mcp__github__update_issue` / `add_issue_comment`. Unlike a bare `Bash` grant this
@@ -767,7 +787,7 @@ patterns:
         (`Bash(gh pr view:*)`, `Bash(gh issue list:*)`, `Bash(gh search:*)`) are not flagged;
         arbitrary shell/write grants are covered by
         `fork_triggerable_ai_agent_with_write_or_exec_tools` at CRITICAL instead.
-    regex: "^\\s*allowed_non_write_users\\s*:\\s*[\"']?\\*[\"']?(?:(?!allowed_non_write_users|^\\s*-?\\s*(?:uses|name)\\s*:|^\\s{0,6}\\w[\\w-]*\\s*:\\s*$)[\\s\\S]){0,12000}?(?<!dis)allowed[_-]?[Tt]ools[\\s=:]+(?:(?!disallowedTools|allowed_non_write_users|(?:direct_|system_|user_)?prompt\\s*:|^\\s*\\w[\\w-]*\\s*:\\s*(?:[|>]|[\"']|$))[\\s\\S]){0,400}?(?:\\bBash\\(\\s*gh\\s+(?:pr|issue)\\s*:\\s*\\*|\\bBash\\(\\s*gh\\s+(?:pr|issue)\\s+(?:comment|edit|close|reopen|review|merge|ready|lock|unlock)\\b|\\bBash\\(\\s*gh\\s+label\\s+(?:create|edit|delete|clone)\\b|\\bBash\\(\\s*gh\\s+label\\b(?!\\s+list)|mcp__github(?:_[a-z_]*)?__(?:create|add|update|delete|merge|close|reopen|edit|submit)_)"
+    regex: "^\\s*allowed_(?:non_write_users|bots)\\s*:\\s*[\"']?\\*[\"']?(?:(?!allowed_(?:non_write_users|bots)|^\\s*-?\\s*(?:uses|name)\\s*:|^\\s{0,6}\\w[\\w-]*\\s*:\\s*$)[\\s\\S]){0,12000}?(?<!dis)allowed[_-]?[Tt]ools[\\s=:]+(?:(?!disallowedTools|allowed_(?:non_write_users|bots)|(?:direct_|system_|user_)?prompt\\s*:|^\\s*\\w[\\w-]*\\s*:\\s*(?:[|>]|[\"']|$))[\\s\\S]){0,400}?(?:\\bBash\\(\\s*gh\\s+(?:pr|issue)\\s*:\\s*\\*|\\bBash\\(\\s*gh\\s+(?:pr|issue)\\s+(?:comment|edit|close|reopen|review|merge|ready|lock|unlock)\\b|\\bBash\\(\\s*gh\\s+label\\s+(?:create|edit|delete|clone)\\b|\\bBash\\(\\s*gh\\s+label\\b(?!\\s+list)|mcp__github(?:_[a-z_]*)?__(?:create|add|update|delete|merge|close|reopen|edit|submit)_)"
     multiline: true
     window: 200
     positive_examples:
@@ -779,6 +799,10 @@ patterns:
               allowed_non_write_users: "*"
               claude_args: |
                 --allowedTools "Bash(gh pr:*),Bash(gh issue view:*),Read"
+      - |2-
+              allowed_bots: "*"
+              claude_args: |
+                --allowedTools "Bash(gh issue edit:*),Read,Grep"
     negative_examples:
       - |2-
               allowed_non_write_users: "*"
@@ -895,7 +919,7 @@ patterns:
         with those credentials - the same "Comment and Control" chain demonstrated
         against the Gemini CLI Action, generalised beyond `claude-code-action`. This rule
         covers the multi-vendor variants that the Anthropic-shaped rule does not.
-    regex: "(?:google-github-actions/run-gemini-cli@|GEMINI_API_KEY|gemini_api_key)(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,4000}?(?:\"?run_shell_command\"?\\s*[:=]\\s*true|\"?YOLO\"?|yolo_mode\\s*:\\s*true|approval[_-]?mode\\s*:\\s*[\"']?(?:yolo|auto|always)|--allow-shell|allow[_-]?shell\\s*:\\s*true)"
+    regex: "(?:google-github-actions/run-gemini-cli@|google-gemini/gemini-cli-action@|GEMINI_API_KEY|gemini_api_key)(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,4000}?(?:\"?run_shell_command\"?\\s*[:=]\\s*true|\"?YOLO\"?|yolo_mode\\s*:\\s*true|approval[_-]?mode\\s*:\\s*[\"']?(?:yolo|auto|always)|--allow-shell|allow[_-]?shell\\s*:\\s*true|run_shell_command\\s*\\(\\s*(?:\\)|bash|sh|zsh|python|node|eval|exec|sed|perl|ruby|xargs|(?:git|gh)\\s*\\)|git\\s+(?:push|commit|add|checkout|config|branch|merge|rebase|reset|tag)|gh\\s+(?:pr|issue)\\s+(?:edit|comment|close|reopen|merge|review|create|ready|lock|unlock)|gh\\s+label(?!\\s+list)))"
     multiline: true
     window: 200
     positive_examples:
@@ -911,6 +935,24 @@ patterns:
                 GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
               with:
                 approval_mode: "yolo"
+      - |2-
+            - uses: google-gemini/gemini-cli-action@v1
+              with:
+                GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                settings_json: |
+                  { "coreTools": ["run_shell_command(gh issue edit)"] }
+      - |2-
+            - uses: google-github-actions/run-gemini-cli@v0
+              with:
+                gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+                settings: |
+                  { "coreTools": ["run_shell_command(git push)", "run_shell_command(git commit)"] }
+      - |2-
+            - uses: google-github-actions/run-gemini-cli@v0
+              with:
+                gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+                settings: |
+                  { "tools": { "core": ["run_shell_command(git)", "run_shell_command(gh)"] } }
     negative_examples:
       - |2-
             - uses: google-github-actions/run-gemini-cli@v1
@@ -923,6 +965,18 @@ patterns:
               with:
                 mode: review
                 prompt: "Summarise the diff."
+      - |2-
+            - uses: google-gemini/gemini-cli-action@v1
+              with:
+                GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                settings_json: |
+                  { "coreTools": ["run_shell_command(gh issue list)", "run_shell_command(gh pr view)", "run_shell_command(cat)"] }
+      - |2-
+            - uses: google-github-actions/run-gemini-cli@v0
+              with:
+                gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
+                settings: |
+                  { "tools": { "core": ["run_shell_command(cat)", "run_shell_command(echo)", "run_shell_command(grep)"] } }
     recommendation: >-
         Do not give a fork-triggerable Gemini/Copilot agent shell or write capability.
         Gate the job on write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`
@@ -935,6 +989,1181 @@ patterns:
         hand its output to a separate non-AI job for any write. Never expose
         `id-token: write` or `GEMINI_API_KEY` to a job that also executes fork content.
         Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_codex_agent_with_write_or_exec_sandbox"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable OpenAI Codex Agent With A Write / Full-Access Sandbox In A Privileged CI Job"
+    description: >-
+        A CI workflow runs OpenAI's Codex agent on a fork-reachable trigger
+        (`pull_request_target`, `issue_comment`, `issues`, `workflow_call`) with a write or
+        full-access sandbox. Two shapes are covered. The action shape - `openai/codex-action`
+        opened to untrusted actors with `allow-users: "*"` or `allow-bots: true` (which removes
+        the action's built-in write-access gate) plus a mutating sandbox
+        (`sandbox: danger-full-access` / `workspace-write` / `unsafe`,
+        `--dangerously-bypass-approvals-and-sandbox`, `--full-auto`, or `approval_policy: never`).
+        The CLI shape - `codex exec` (installed via `npm i -g @openai/codex`) driven with
+        `--dangerously-bypass-approvals-and-sandbox`, `--full-auto`, `--yolo`, or a write sandbox
+        (`--sandbox workspace-write` / `danger-full-access`, `-s workspace-write`, or
+        `sandbox_mode = "workspace-write"` in a generated `config.toml`); the CLI has no built-in
+        actor gate, so the enclosing job's fork-reachable trigger and write scope are what expose
+        it. In either shape Codex runs in the base repository's context holding `GITHUB_TOKEN`,
+        the `OPENAI_API_KEY`, and often `id-token: write`, with the attacker-controlled PR/issue
+        content as its input. An indirect prompt-injection payload can drive filesystem writes,
+        arbitrary command execution, or network exfiltration under those credentials.
+        `sandbox: read-only` (even with `approval_policy: never`) is not flagged, and without
+        `allow-users: "*"` / `allow-bots` the action already limits itself to users with
+        repository write access, so this rule fires only on the open-trigger plus write/exec
+        combination.
+    regex: "openai/codex-action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,3000}?(?:(?:allow[_-]?users\\s*:\\s*[\"']?\\*|allow[_-]?bots\\s*:\\s*[\"']?true)(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,1500}?(?:sandbox\\s*:\\s*[\"']?(?:danger-full-access|workspace-write|danger|unsafe)|--dangerously-bypass-approvals-and-sandbox|--full-auto|approval[_-]?policy\\s*:\\s*[\"']?never)|(?:sandbox\\s*:\\s*[\"']?(?:danger-full-access|workspace-write|danger|unsafe)|--dangerously-bypass-approvals-and-sandbox|--full-auto|approval[_-]?policy\\s*:\\s*[\"']?never)(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,1500}?(?:allow[_-]?users\\s*:\\s*[\"']?\\*|allow[_-]?bots\\s*:\\s*[\"']?true))|(?:npm\\s+i(?:nstall)?\\s+-g\\s+@openai/codex|@openai/codex\\b|\\bcodex\\s+exec\\b)(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,2000}?(?:--dangerously-bypass-approvals-and-sandbox|--full-auto|--yolo|--sandbox[=\\s]+(?:danger-full-access|workspace-write)|(?<!\\w)-s[=\\s]+(?:danger-full-access|workspace-write)|sandbox_mode\\s*=\\s*[\"'](?:danger-full-access|workspace-write))"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            - uses: openai/codex-action@v1
+              with:
+                openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                sandbox: danger-full-access
+                allow-users: "*"
+      - |2-
+            - uses: openai/codex-action@v1
+              with:
+                openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                allow-bots: true
+                sandbox: workspace-write
+      - |2-
+            - run: npm i -g @openai/codex
+            - env:
+                OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+              run: codex exec --full-auto "Address ${{ github.event.comment.body }}"
+      - |2-
+            - run: npm install -g @openai/codex
+            - run: codex exec --dangerously-bypass-approvals-and-sandbox -m gpt-5 "$PROMPT"
+    negative_examples:
+      - |2-
+            - uses: openai/codex-action@v1
+              with:
+                openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                allow-users: "*"
+                sandbox: read-only
+      - |2-
+            - run: npm i -g @openai/codex
+            - run: codex exec --sandbox read-only "$PROMPT"
+      - |2-
+            - run: npm i -g @openai/codex
+            - run: codex exec --sandbox read-only --ask-for-approval never "$PROMPT"
+      - |2-
+            - uses: openai/codex-action@v1
+              with:
+                openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                sandbox: danger-full-access
+                safety-strategy: drop-sudo
+    recommendation: >-
+        Do not open a Codex agent with a write or full-access sandbox to untrusted actors.
+        For the action, remove `allow-users: "*"` / `allow-bots: true` so the default
+        write-access gate applies, or list only trusted maintainers. For the `codex exec` CLI,
+        drop `--dangerously-bypass-approvals-and-sandbox`, `--full-auto`, and `--yolo`, and run
+        with `--sandbox read-only`. For any job that reads untrusted PR/issue content use a
+        read-only sandbox and keep `safety-strategy: drop-sudo` (or `unprivileged-user`) so the
+        `OPENAI_API_KEY` cannot be read from process memory. Split privilege: run Codex with
+        `permissions: { contents: read }` and no write credentials, then hand its output to a
+        separate non-AI job for any write. Never expose `id-token: write` or `OPENAI_API_KEY` to
+        a job that also runs fork content in a writable sandbox. Treat PR/issue title, body, and
+        comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_copilot_cli_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable GitHub Copilot CLI Agent Granted Shell / Write Tools In A Privileged CI Job"
+    description: >-
+        A CI job runs the GitHub Copilot CLI (`@github/copilot`, installed via
+        `npm i -g @github/copilot` or `gh.io/copilot-install`, or driven by a `gh aw` compiled
+        workflow with `GH_AW_ENGINE: copilot`) and grants it an arbitrary-command or file-write
+        tool - `copilot --allow-all-tools` or `copilot --allow-tool "shell"` / `"write"` /
+        `"edit"` / `"all"` - on a fork-reachable trigger, in a job that can mutate the repository
+        (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in
+        the same job). Copilot CLI reads the attacker-controlled PR diff, issue, or comment as
+        its prompt while holding `GITHUB_TOKEN` (or a `COPILOT_GITHUB_TOKEN` PAT), and
+        `--allow-all-tools` removes its per-command approval, so an indirect prompt-injection
+        payload becomes command execution and code push under CI credentials. This rule fires
+        only on the write-capable, ungated combination: an install-only or `--version` check,
+        review-only jobs (`contents: read`, comment-only scope), and jobs gated on repository
+        write access (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only
+        label gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])copilot\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[^\\n]|\\n){0,240}?(?:--allow-all-tools|--allow-tool[=\\s]+['\"]?(?:shell|write|edit|all)\\b)"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            permissions:
+              contents: write
+              pull-requests: write
+            jobs:
+              copilot:
+                steps:
+                  - run: npm install -g @github/copilot
+                  - env:
+                      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: |
+                      printf '%s' "${{ github.event.comment.body }}" | copilot --allow-all-tools -p -
+      - |2-
+            on:
+              pull_request_target:
+            permissions:
+              contents: write
+            jobs:
+              fix:
+                steps:
+                  - run: npm i -g @github/copilot
+                  - run: copilot --allow-tool "shell" -p "$PROMPT"
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              check:
+                permissions:
+                  contents: read
+                steps:
+                  - run: npm install -g @github/copilot
+                  - run: copilot --version
+      - |2-
+            on:
+              schedule:
+                - cron: "0 0 * * *"
+            jobs:
+              docs:
+                steps:
+                  - run: npm install -g @github/copilot
+                  - run: copilot --allow-tool "read" -p "$PROMPT"
+    recommendation: >-
+        Do not give a fork-triggerable Copilot CLI agent shell or write tools. Keep review jobs
+        at `permissions: contents: read` with only comment scope and never `git push` from them,
+        and drop `--allow-all-tools`. If the agent must make changes, gate the job on repository
+        write access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the
+        actor via `getCollaboratorPermissionLevel`, or use a maintainer-only label - and scope the
+        tool grant to the exact commands it needs rather than `--allow-all-tools`. Split
+        privilege: let Copilot propose changes in a read-only job and hand them to a separate
+        reviewed job for any commit. Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_cursor_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Cursor Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Cursor agent unattended and reads attacker-controlled PR/issue
+        content as its prompt. This covers the CLI (`cursor.com/install` / `CURSOR_API_KEY`
+        with `cursor-agent -p`, `cursor-agent --print`, or the `--force` auto-approve flag;
+        the binary is also aliased as `agent`) and the `@cursor/sdk` programmatic API
+        (`Agent.prompt` / `Agent.create` / `Agent.resume`, often invoked from a helper script
+        the workflow runs). It fires on a fork-reachable trigger, in a job that can mutate the
+        repository (`contents: write`, `permissions: write-all`, or a `git push` /
+        `gh pr create|merge` in the same job). The agent holds `GITHUB_TOKEN` and the runner's
+        credentials while executing the untrusted prompt, so an indirect prompt-injection
+        payload can run commands and push code under those credentials. This rule fires only on
+        the write-capable, ungated combination: review-only bots (`contents: read`, comment-only
+        `pull-requests: write`) and jobs gated on repository write access
+        (`getCollaboratorPermissionLevel`, an `author_association` check, or `allow_forks: false`)
+        are not flagged.
+    regex: "(?<![\\w-])(?:cursor-agent|agent)\\b[^\\n]{0,200}?(?:\\s(?:-p|--print|--force)\\b)|@cursor/sdk|Agent\\.(?:prompt|create|resume)\\s*\\("
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              cursor:
+                permissions:
+                  contents: write
+                steps:
+                  - run: curl https://cursor.com/install -fsS | bash
+                  - env:
+                      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+                    run: |
+                      cursor-agent -p "$(cat /tmp/prompt.md)" --model auto
+                      git push origin HEAD
+      - |2-
+            on:
+              issues:
+                types: [opened]
+            jobs:
+              agent:
+                permissions:
+                  contents: write
+                  issues: write
+                steps:
+                  - run: npm install @cursor/sdk
+                  - env:
+                      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+                    run: |
+                      node agent-dispatch.mjs
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                  pull-requests: write
+                steps:
+                  - run: curl https://cursor.com/install -fsS | bash
+                  - run: cursor-agent --version
+                  - run: command -v cursor-agent
+    recommendation: >-
+        Do not run a Cursor agent unattended on untrusted PR/issue content in a job that can
+        write to the repository. For review bots keep the job at `permissions: contents: read`
+        with only comment scope and never `git push` from the agent job. If the agent must
+        make changes, gate the job on repository write access - check
+        `github.event.comment.user`/`actor` via `getCollaboratorPermissionLevel`, or require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` - so untrusted contributors
+        cannot invoke it. Split privilege: run the agent with read-only permissions and no
+        write token, then hand its output to a separate reviewed job for any commit or push.
+        Treat PR/issue title, body, and comments as untrusted data. The same rules apply when
+        the agent is driven through the `@cursor/sdk` API from a helper script rather than the
+        CLI.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_opencode_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable OpenCode Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the OpenCode agent - the `sst/opencode/github` (or `anomalyco/opencode`)
+        action, or the `opencode run` CLI - on a fork-reachable trigger, in a job that can
+        mutate the repository (`contents: write`, `permissions: write-all`, or a `git push` /
+        `gh pr create|merge` in the same job). OpenCode executes the attacker-controlled
+        PR/issue comment as its instructions while holding `GITHUB_TOKEN`, so a
+        `/opencode`-style command from an untrusted contributor becomes command execution and
+        code push under CI credentials. This rule fires only on the write-capable, ungated
+        combination: review-only jobs (`contents: read`, comment-only scope) and jobs gated on
+        repository write access are not flagged.
+    regex: "(?:sst|anomalyco)/opencode/github@|(?<![\\w-])opencode\\s+run\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              opencode:
+                if: contains(github.event.comment.body, '/opencode')
+                permissions:
+                  contents: write
+                  issues: write
+                steps:
+                  - uses: sst/opencode/github@latest
+                    with:
+                      model: opencode/claude-sonnet-4-5
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                  pull-requests: write
+                steps:
+                  - run: npm install -g opencode-ai
+                  - run: opencode --version
+    recommendation: >-
+        Do not run OpenCode on untrusted PR/issue content in a job that can write to the
+        repository. For a `/opencode` review bot keep the job at `permissions: contents: read`
+        with only comment scope and never `git push` from it. If the agent must make changes,
+        gate the job on repository write access - check the commenter/actor via
+        `getCollaboratorPermissionLevel`, or require `author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR`. Split privilege: run the agent read-only and hand its
+        output to a separate reviewed job for any commit. Treat PR/issue title, body, and
+        comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_amp_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Amp Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Sourcegraph Amp non-interactively - the `sourcegraph/amp` action, or the
+        `@sourcegraph/amp` CLI executing a prompt (`amp -x`, `amp --execute`, or a prompt piped
+        into `amp`) - on a fork-reachable trigger, in a job that can mutate the repository
+        (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in
+        the same job). Amp runs the attacker-controlled PR/issue comment as its prompt while
+        holding `GITHUB_TOKEN` and `AMP_API_KEY`, so an untrusted contributor's comment becomes
+        command execution and code push under CI credentials. This rule fires only on the
+        write-capable, ungated combination: review-only jobs and jobs gated on repository write
+        access (including a hardcoded commenter/actor allowlist) are not flagged.
+    regex: "sourcegraph/amp[\\w./-]*@|(?<![\\w-])amp\\b[^\\n]{0,120}?(?:\\s-x\\b|--execute\\b|--dangerously)|\\|\\s*amp\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              amp:
+                permissions:
+                  contents: write
+                steps:
+                  - run: npm install -g @sourcegraph/amp
+                  - env:
+                      AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+                    run: |
+                      echo "${{ github.event.comment.body }}" | amp -x
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: npm install -g @sourcegraph/amp
+                  - run: amp --version
+    recommendation: >-
+        Do not run Amp on untrusted PR/issue content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If Amp must make changes, gate the job on repository write access
+        - check the commenter/actor via `getCollaboratorPermissionLevel`, or require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`. Split privilege: run Amp
+        read-only and hand its output to a separate reviewed job for any commit. Treat PR/issue
+        title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_goose_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Goose Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Block's Goose agent non-interactively - `goose run` or `goose session` with
+        a recipe, instructions file, or `-t`/`-i` prompt - on a fork-reachable trigger, in a job
+        that can mutate the repository (`contents: write`, `permissions: write-all`, or a
+        `git push` / `gh pr create|merge` in the same job). Goose reads the attacker-controlled
+        PR diff, issue, or comment as its instructions while holding `GITHUB_TOKEN` and the
+        model provider key, and its `developer`/`computercontroller` toolset executes shell and
+        edits files, so an indirect prompt-injection payload becomes command execution and code
+        push under CI credentials. This rule fires only on the write-capable, ungated
+        combination: review-only jobs (`contents: read`, comment-only scope) and jobs gated on
+        repository write access (`author_association`, `getCollaboratorPermissionLevel`, a label
+        gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])goose\\s+(?:run|session)\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened, synchronize]
+            permissions:
+              contents: write
+            jobs:
+              goose:
+                steps:
+                  - run: |
+                      curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+                  - env:
+                      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    run: |
+                      gh pr diff "$PR_NUMBER" > instructions.txt
+                      goose run --instructions instructions.txt
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: pipx install goose-vcs
+                  - run: goose version
+    recommendation: >-
+        Do not run Goose on untrusted PR/issue content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If Goose must make changes, gate the job on repository write access
+        - check the commenter/actor via `getCollaboratorPermissionLevel`, require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, or drive it from a maintainer-only
+        label. Split privilege: run Goose read-only and hand its output to a separate reviewed job
+        for any commit. Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_droid_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Factory Droid Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Factory's Droid agent non-interactively - the `Factory-AI/droid-action`
+        action or the `droid exec` CLI (installed from `app.factory.ai` or `@factory/cli`) - on a
+        fork-reachable trigger, in a job that can mutate the repository (`contents: write`,
+        `permissions: write-all`, or a `git push` / `gh pr create|merge` in the same job). Droid
+        reads the attacker-controlled PR diff, issue, or comment as its task while holding
+        `GITHUB_TOKEN` and `FACTORY_API_KEY`, and its execution mode (`--auto`,
+        `--skip-permissions-unsafe`) runs shell and edits files, so an indirect prompt-injection
+        payload becomes command execution and code push under CI credentials. This rule fires only
+        on the write-capable, ungated combination: review-only jobs (`contents: read`,
+        comment-only scope) and jobs gated on repository write access (`author_association`,
+        `getCollaboratorPermissionLevel`, a label gate, or a fork-exclusion check) are not flagged.
+    regex: "Factory-AI/droid[\\w./-]*@|(?<![\\w-])droid\\s+exec\\b|@factory/cli"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              droid:
+                if: contains(github.event.comment.body, '@droid')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v5
+                  - uses: Factory-AI/droid-action@v3
+                    with:
+                      factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: curl -fsSL https://app.factory.ai/cli | sh
+                  - run: droid --version
+    recommendation: >-
+        Do not run Droid on untrusted PR/issue content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If Droid must make changes, gate the job on repository write access
+        - check the commenter/actor via `getCollaboratorPermissionLevel`, or require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`. Split privilege: run Droid
+        read-only and hand its output to a separate reviewed job for any commit. Treat PR/issue
+        title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_aider_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Aider Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Aider non-interactively - `aider` with `--yes` / `--yes-always` and a
+        `--message` / `--message-file` / `-m` task (or `--auto-commits`) - on a fork-reachable
+        trigger, in a job that can mutate the repository (`contents: write`, `permissions:
+        write-all`, or a `git push` / `gh pr create|merge` in the same job). Aider edits files and
+        commits directly while holding `GITHUB_TOKEN` and the model provider key, so feeding it the
+        attacker-controlled PR diff, issue, or comment as its message turns an indirect
+        prompt-injection payload into code execution and a push under CI credentials. This rule
+        fires only on the write-capable, ungated combination: review-only jobs and jobs gated on
+        repository write access (`author_association`, `getCollaboratorPermissionLevel`, a label
+        gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])aider\\b[^\\n]{0,200}?(?:--yes\\b|--yes-always\\b|--message\\b|--message-file\\b|--auto-commits\\b|\\s-m\\b)"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, edited]
+            permissions:
+              contents: write
+            jobs:
+              aider:
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: pip install aider-chat
+                  - run: |
+                      echo "${{ github.event.issue.body }}" > message.txt
+                      aider --message-file message.txt --yes
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              lint:
+                permissions:
+                  contents: read
+                steps:
+                  - run: pip install aider-chat
+                  - run: aider --version
+    recommendation: >-
+        Do not run Aider on untrusted PR/issue content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If Aider must make changes, gate the job on repository write access
+        - check the commenter/actor via `getCollaboratorPermissionLevel`, or require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`. Split privilege: run Aider in a
+        dry-run and hand its output to a separate reviewed job for any commit. Treat PR/issue
+        title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_openhands_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable OpenHands Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the OpenHands resolver - the `All-Hands-AI/OpenHands` reusable
+        `openhands-resolver` workflow or the `openhands` CLI driven by an `@openhands-agent`
+        macro - on a fork-reachable trigger, in a job that can mutate the repository
+        (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in
+        the same job). OpenHands is an autonomous software agent that reads the
+        attacker-controlled issue, PR, or comment as its task while holding `GITHUB_TOKEN` (or a
+        `PAT_TOKEN`) and the model provider key, then edits files, runs shell, and opens or pushes
+        to branches, so an indirect prompt-injection payload becomes command execution and code
+        push under CI credentials. This rule fires only on the write-capable, ungated combination:
+        review-only jobs (`contents: read`, comment-only scope), jobs gated on repository write
+        access (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label
+        gate, or a fork-exclusion check), and caller stubs that delegate to the
+        `openhands-resolver.yml` reusable workflow (which gates on `author_association` in the
+        called repo) are not flagged.
+    regex: "All-Hands-AI/OpenHands[\\w./-]*|openhands-resolver\\.yml|@openhands-agent"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, labeled]
+              issue_comment:
+                types: [created]
+            permissions:
+              contents: write
+              pull-requests: write
+              issues: write
+            jobs:
+              resolve:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: pip install git+https://github.com/All-Hands-AI/OpenHands
+                  - env:
+                      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                    run: |
+                      echo "${{ github.event.issue.body }}" > task.txt
+                      python -m openhands.resolver.resolve_issue --task-file task.txt
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              build:
+                permissions:
+                  contents: read
+                steps:
+                  - run: docker build -t openhands-runtime .
+    recommendation: >-
+        Do not run OpenHands on untrusted issue/PR content in a job that can write to the
+        repository. Keep the resolver read-only or gate it on repository write access - drive it
+        from a maintainer-only label, require `author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR`, or check the actor via `getCollaboratorPermissionLevel`.
+        Split privilege: let OpenHands propose changes and hand them to a separate reviewed job for
+        any commit. Treat issue/PR title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_qwen_code_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Qwen Code Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Qwen Code agent - the `qwen-code-action`, a `@qwen-code` comment macro,
+        or the `qwen` CLI with `--yolo` - on a fork-reachable trigger, in a job that can mutate the
+        repository (`contents: write`, `permissions: write-all`, or a `git push` /
+        `gh pr create|merge` in the same job). Qwen Code is a Gemini-CLI-derived coding agent that
+        reads the attacker-controlled issue, PR, or comment as its instructions while holding
+        `GITHUB_TOKEN` and the model provider key; its shell tool and `--yolo` auto-approval run
+        commands and edit files, so an indirect prompt-injection payload becomes command execution
+        and code push under CI credentials. This rule fires only on the write-capable, ungated
+        combination: review-only jobs (`contents: read`, comment-only scope) and jobs gated on
+        repository write access (`author_association`, `getCollaboratorPermissionLevel`, a
+        maintainer-only label gate, or a fork-exclusion check) are not flagged.
+    regex: "qwen-code-action|@qwen-code(?![\\w/-])|(?<![\\w-])qwen\\b[^\\n]{0,80}?--yolo\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            permissions:
+              contents: write
+              pull-requests: write
+            jobs:
+              qwen:
+                steps:
+                  - run: npm install -g @qwen-code/qwen-code
+                  - env:
+                      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: |
+                      echo "${{ github.event.comment.body }}" > task.txt
+                      qwen --yolo --prompt-file task.txt
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              lint:
+                permissions:
+                  contents: read
+                steps:
+                  - run: npm install -g @qwen-code/qwen-code
+                  - run: qwen --version
+    recommendation: >-
+        Do not run Qwen Code on untrusted PR/issue content in a job that can write to the
+        repository, and avoid `--yolo` on fork-reachable triggers. Keep review jobs at
+        `permissions: contents: read` with only comment scope and never `git push` from them. If
+        the agent must make changes, gate the job on repository write access - require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or use a maintainer-only label. Treat PR/issue title,
+        body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_crush_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Crush Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Charm's Crush agent non-interactively - `crush run` (installed from
+        `charmbracelet/crush` or `repo.charm.sh`) - on a fork-reachable trigger, in a job that can
+        mutate the repository (`contents: write`, `permissions: write-all`, or a `git push` /
+        `gh pr create|merge` in the same job). Crush reads the attacker-controlled PR diff, issue,
+        or comment as its prompt while holding `GITHUB_TOKEN` and the model provider key, and its
+        tools run shell and edit files, so an indirect prompt-injection payload becomes command
+        execution and code push under CI credentials. This rule fires only on the write-capable,
+        ungated combination: review-only jobs (`contents: read`, comment-only scope) and jobs gated
+        on repository write access (`author_association`, `getCollaboratorPermissionLevel`, a
+        maintainer-only label gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])crush\\s+run\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            permissions:
+              contents: write
+              pull-requests: write
+            jobs:
+              crush:
+                steps:
+                  - run: |
+                      curl -fsSL https://repo.charm.sh/apt/gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/charm.gpg
+                      sudo apt install -y crush
+                  - env:
+                      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: crush run "Address the comment ${{ github.event.comment.body }} and push"
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              lint:
+                permissions:
+                  contents: read
+                steps:
+                  - run: sudo apt install -y crush
+                  - run: crush --version
+    recommendation: >-
+        Do not run Crush on untrusted PR/issue content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If Crush must make changes, gate the job on repository write access -
+        require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Treat PR/issue title, body, and comments as
+        untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_continue_cli_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Continue CLI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs Continue's headless CLI (`@continuedev/cli`, invoked as `cn`) in agent mode -
+        `cn -p --agent <agent>`, `cn --config <agent> --auto`, or `cn remote` - on a fork-reachable
+        trigger, in a job that can mutate the repository (`contents: write`, `permissions:
+        write-all`, or a `git push` / `gh pr create|merge` in the same job). The agent reads the
+        attacker-controlled PR diff, issue, or comment (or a repo-supplied agent file from the
+        checked-out fork branch) as its prompt while holding `GITHUB_TOKEN` and the model provider
+        key, and its tools run shell and edit files, so an indirect prompt-injection payload becomes
+        command execution and code push under CI credentials. This rule fires only on the
+        write-capable, ungated combination: an install-only step, a `cn --version` check, `cn review`
+        (read-only), review-only jobs (`contents: read`, comment-only scope), and jobs gated on
+        repository write access (`author_association`, `getCollaboratorPermissionLevel`, a
+        maintainer-only label gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])cn\\s+(?:remote\\b|(?:-\\S+\\s+)*(?:-p\\b|--print\\b|--agent\\b|--config\\b|--auto\\b))"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            permissions:
+              contents: write
+              pull-requests: write
+            jobs:
+              continue:
+                steps:
+                  - run: npm i -g @continuedev/cli
+                  - env:
+                      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: cn --config continuedev/fixer-agent -p "${{ github.event.comment.body }}" --auto
+      - |2-
+            on:
+              pull_request:
+                types: [opened, synchronize]
+            permissions:
+              contents: write
+            jobs:
+              agents:
+                steps:
+                  - run: npm install -g @continuedev/cli
+                  - run: cn -p --agent .continue/agents/fix.md
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: npm i -g @continuedev/cli
+                  - run: cn --version
+    recommendation: >-
+        Do not run the Continue CLI on untrusted PR/issue content in a job that can write to the
+        repository. Keep review jobs at `permissions: contents: read` with only comment scope and
+        never `git push` from them. If the agent must make changes, gate the job on repository write
+        access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Split privilege: let the agent propose changes
+        and hand them to a separate reviewed job for any commit. Treat PR/issue title, body,
+        comments, and repo-supplied agent files as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_gptme_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable gptme Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs gptme non-interactively - `gptme --non-interactive "<prompt>"` or the
+        `ErikBjare/gptme` bot action - on a fork-reachable trigger, in a job that can mutate the
+        repository (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr
+        create|merge` in the same job). gptme reads the attacker-controlled issue, comment, or PR
+        body as its prompt while holding `GITHUB_TOKEN` and the model provider key, and its default
+        tools run shell and Python and edit files, so an indirect prompt-injection payload becomes
+        command execution and code push under CI credentials. This rule fires only on the
+        write-capable, ungated combination: an install-only step, review-only jobs (`contents:
+        read`, comment-only scope), and jobs gated on repository write access (`author_association`,
+        `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a fork-exclusion check)
+        are not flagged.
+    regex: "(?<![\\w-])gptme\\s+(?:(?:-\\S+\\s+)*(?:--non-interactive|-n)\\b|[\"'])|uses\\s*:\\s*ErikBjare/gptme"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            permissions: write-all
+            jobs:
+              gptme:
+                steps:
+                  - run: pipx install gptme
+                  - env:
+                      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: |
+                      gptme --non-interactive "${{ github.event.comment.body }}"
+                      git push origin HEAD
+      - |2-
+            on:
+              issues:
+                types: [opened]
+            permissions:
+              contents: write
+            jobs:
+              bot:
+                steps:
+                  - uses: ErikBjare/gptme/.github/actions/bot@master
+                    with:
+                      command: ${{ github.event.issue.body }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              docs:
+                permissions:
+                  contents: read
+                steps:
+                  - run: pipx install gptme
+                  - run: gptme --version
+    recommendation: >-
+        Do not run gptme on untrusted issue/PR content in a job that can write to the repository.
+        Keep review jobs at `permissions: contents: read` with only comment scope and never
+        `git push` from them. If gptme must make changes, gate the job on repository write access -
+        require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Treat issue/PR title, body, and comments as
+        untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_warp_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Warp Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job installs the Warp CLI (`releases.warp.dev` / `WARP_API_KEY`) and runs the
+        Warp agent unattended - `warp-cli agent run` (also `warp agent run`) - on a
+        fork-reachable trigger, in a job that can mutate the repository (`contents: write`,
+        `permissions: write-all`, or a `git push` / `gh pr create|merge` in the same job).
+        The agent reads the attacker-controlled issue/PR body or comment as its `--prompt`
+        while holding `GITHUB_TOKEN` and the runner's credentials, and its tools run shell and
+        edit files, so an indirect prompt-injection payload becomes command execution and code
+        push under CI credentials. This rule fires only on the write-capable, ungated
+        combination: review-only jobs (`contents: read`, comment-only scope) and jobs gated on
+        repository write access (`author_association`, `getCollaboratorPermissionLevel`, a
+        maintainer-only label gate, or a fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])warp(?:-cli)?\\s+agent\\s+run\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              warp-fix:
+                if: contains(github.event.comment.body, '@warp-fix')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - run: sudo apt install warp-cli -y
+                  - env:
+                      WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+                    run: |
+                      warp-cli agent run --prompt "$(cat prompt.txt)"
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                  pull-requests: write
+                steps:
+                  - run: sudo apt install warp-cli -y
+                  - run: warp-cli --version
+    recommendation: >-
+        Do not run the Warp agent on untrusted issue/PR content in a job that can write to the
+        repository. Keep review jobs at `permissions: contents: read` with only comment scope
+        and never `git push` from them. If the agent must make changes, gate the job on
+        repository write access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`,
+        check the actor via `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Have the agent open a PR for human review
+        rather than pushing directly. Treat issue/PR title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_swe_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable SWE-agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs SWE-agent (`SWE-agent/SWE-agent`, invoked as `sweagent run` or
+        `python -m sweagent`) on a fork-reachable trigger, in a job that can mutate the repository
+        (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in the
+        same job). SWE-agent reads the attacker-controlled issue or PR
+        (`--problem_statement.github_url`) as its task while holding `GITHUB_TOKEN` and the model
+        provider key, and its tools run shell and edit files, so an indirect prompt-injection
+        payload becomes command execution and code push under CI credentials. This rule fires only
+        on the write-capable, ungated combination: an install-only step, review-only jobs
+        (`contents: read`, comment-only scope), and jobs gated on repository write access
+        (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a
+        fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])sweagent\\s+run\\b|python\\s+-m\\s+sweagent\\s+run\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, labeled]
+            permissions:
+              contents: write
+              pull-requests: write
+            jobs:
+              resolve:
+                steps:
+                  - run: pip install sweagent
+                  - env:
+                      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    run: |
+                      sweagent run \
+                        --problem_statement.github_url=${{ github.event.issue.html_url }}
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              resolve:
+                permissions:
+                  contents: read
+                steps:
+                  - run: pip install sweagent
+                  - run: sweagent --help
+    recommendation: >-
+        Do not run SWE-agent on untrusted issue/PR content in a job that can write to the
+        repository. Keep review jobs at `permissions: contents: read` with only comment scope and
+        never `git push` from them. If SWE-agent must make changes, gate the job on repository write
+        access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Have the agent open a PR for human review
+        rather than pushing directly. Treat issue/PR title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_claude_cli_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Claude CLI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Claude Code CLI unattended - `claude -p ...` with the auto-approve
+        flag `--dangerously-skip-permissions` or `--permission-mode bypassPermissions`
+        (`acceptEdits`) - on a fork-reachable trigger, in a job that can mutate the repository
+        (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in
+        the same job). This is the raw-CLI variant of the agent; the `anthropics/claude-code-action`
+        form is covered separately. The CLI reads the attacker-controlled issue/PR body or comment
+        as its prompt while holding `GITHUB_TOKEN`, the runner's credentials, and the Anthropic key,
+        and the auto-approve flag lets it run shell and edit files without confirmation, so an
+        indirect prompt-injection payload becomes command execution and code push under those
+        credentials. This rule fires only on the write-capable, ungated combination: review-only
+        jobs (`contents: read`, comment-only scope) and jobs gated on repository write access
+        (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a
+        fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])claude\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,3000}?(?:--dangerously-skip-permissions|--permission-mode[\\s=]+['\"]?(?:bypassPermissions|acceptEdits)\\b)"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              agent:
+                if: contains(github.event.comment.body, '@claude')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - env:
+                      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                      CLAUDE_TASK: ${{ github.event.comment.body }}
+                    run: |
+                      claude -p "Task: $CLAUDE_TASK" \
+                        --permission-mode bypassPermissions \
+                        --dangerously-skip-permissions
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                  pull-requests: write
+                steps:
+                  - run: npm install -g @anthropic-ai/claude-code
+                  - run: claude --version
+    recommendation: >-
+        Do not run the Claude CLI on untrusted issue/PR content in a job that can write to the
+        repository, and never pass `--dangerously-skip-permissions` /
+        `--permission-mode bypassPermissions` there. Keep review jobs at
+        `permissions: contents: read` with only comment scope and never `git push` from them. If
+        the agent must make changes, gate the job on repository write access - require
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs
+        (`head.repo.full_name == github.repository`). Have the agent open a PR for human review
+        rather than pushing directly. Treat issue/PR title, body, and comments as untrusted data.
     cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
     owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
     owasp_llm: ["LLM01", "LLM02", "LLM06"]

--- a/src/ansible_security_scanner/remediations/ai_ml_security.py
+++ b/src/ansible_security_scanner/remediations/ai_ml_security.py
@@ -59,6 +59,22 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
         "fork_triggerable_ai_agent_with_repo_mutating_gh_tools": "_fix_fork_triggerable_repo_mutating",
         "untrusted_event_content_interpolated_into_ai_agent_prompt": "_fix_event_prompt_injection",
         "fork_triggerable_gemini_or_copilot_agent_with_write_or_exec": "_fix_fork_triggerable_gemini",
+        "fork_triggerable_codex_agent_with_write_or_exec_sandbox": "_fix_fork_triggerable_codex",
+        "fork_triggerable_cursor_agent_with_repo_write": "_fix_fork_triggerable_cursor",
+        "fork_triggerable_opencode_agent_with_repo_write": "_fix_fork_triggerable_opencode",
+        "fork_triggerable_amp_agent_with_repo_write": "_fix_fork_triggerable_amp",
+        "fork_triggerable_goose_agent_with_repo_write": "_fix_fork_triggerable_goose",
+        "fork_triggerable_droid_agent_with_repo_write": "_fix_fork_triggerable_droid",
+        "fork_triggerable_aider_agent_with_repo_write": "_fix_fork_triggerable_aider",
+        "fork_triggerable_openhands_agent_with_repo_write": "_fix_fork_triggerable_openhands",
+        "fork_triggerable_qwen_code_agent_with_repo_write": "_fix_fork_triggerable_qwen_code",
+        "fork_triggerable_crush_agent_with_repo_write": "_fix_fork_triggerable_crush",
+        "fork_triggerable_copilot_cli_agent_with_repo_write": "_fix_fork_triggerable_copilot_cli",
+        "fork_triggerable_continue_cli_agent_with_repo_write": "_fix_fork_triggerable_continue_cli",
+        "fork_triggerable_gptme_agent_with_repo_write": "_fix_fork_triggerable_gptme",
+        "fork_triggerable_swe_agent_with_repo_write": "_fix_fork_triggerable_swe_agent",
+        "fork_triggerable_warp_agent_with_repo_write": "_fix_fork_triggerable_warp",
+        "fork_triggerable_claude_cli_agent_with_repo_write": "_fix_fork_triggerable_claude_cli",
     }
 
     def generate_ai_ml_security_fix(self, rule_id: str, code_snippet: str) -> str:
@@ -507,6 +523,445 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
             "A fork-triggerable Gemini/Copilot agent with the shell tool or "
             "YOLO mode turns a hostile PR into RCE/secret exfil via prompt "
             "injection - the same chain shown against the Gemini CLI Action.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_codex(self, rule_id: str, code_snippet: str) -> str:
+        action = _first(code_snippet, r"(openai/codex-action@[\w.-]+)") or "openai/codex-action@v1"
+        secure_fix = (
+            "# Drop allow-users/allow-bots so the action's default write-access\n"
+            "# gate applies, keep the sandbox read-only, and retain drop-sudo so\n"
+            "# the OPENAI_API_KEY cannot be read from process memory.\n"
+            "jobs:\n"
+            "  codex-review:\n"
+            "    permissions:\n"
+            "      contents: read          # no write token in the AI job\n"
+            "      pull-requests: read\n"
+            "      # no id-token: write - do not expose OIDC to a fork-reading job\n"
+            "    steps:\n"
+            f"      - uses: {action}\n"
+            "        with:\n"
+            "          openai-api-key: ${{ secrets.OPENAI_API_KEY }}\n"
+            "          sandbox: read-only\n"
+            "          safety-strategy: drop-sudo\n"
+            '          # no allow-users: "*" / allow-bots - only repo writers run this'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            'A fork-triggerable Codex agent opened with allow-users: "*" and a '
+            "write/full-access sandbox lets a hostile PR reach filesystem writes, "
+            "command execution, or secret exfil under GITHUB_TOKEN / OPENAI_API_KEY.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_cursor(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Keep the agent job read-only and comment-scoped; do not push from it.\n"
+            "# If the agent must write, gate the job on repository write access.\n"
+            "jobs:\n"
+            "  cursor-review:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.pull_request.author_association)\n"
+            "    permissions:\n"
+            "      contents: read          # no push from the agent job\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: curl https://cursor.com/install -fsS | bash\n"
+            "      - env:\n"
+            "          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}\n"
+            '        run: cursor-agent --print "Review only; post inline comments"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Cursor agent run unattended in a job that can push "
+            "code turns a hostile PR/issue into RCE and repo mutation via prompt "
+            "injection under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_opencode(self, rule_id: str, code_snippet: str) -> str:
+        action = (
+            _first(code_snippet, r"((?:sst|anomalyco)/opencode/github@[\w.-]+)")
+            or "sst/opencode/github@latest"
+        )
+        secure_fix = (
+            "# Gate the job on repository write access and keep it comment-scoped;\n"
+            "# do not push from the agent job.\n"
+            "jobs:\n"
+            "  opencode:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read          # no push from the agent job\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            f"      - uses: {action}\n"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable OpenCode agent with contents: write runs an "
+            "untrusted /opencode comment as instructions, reaching command "
+            "execution and code push under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_amp(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access, keep the job read-only, and never\n"
+            "# push from it. Amp reads the comment as its prompt, so untrusted\n"
+            "# input must not reach a write token.\n"
+            "jobs:\n"
+            "  amp:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: npm install -g @sourcegraph/amp\n"
+            "      - env:\n"
+            "          AMP_API_KEY: ${{ secrets.AMP_API_KEY }}\n"
+            '        run: echo "review only" | amp -x'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Amp agent with contents: write runs an untrusted "
+            "comment as its prompt, reaching command execution and code push under "
+            "GITHUB_TOKEN / AMP_API_KEY.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_goose(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only. Goose\n"
+            "# reads the PR/issue as its instructions, so untrusted input must not\n"
+            "# reach a write token; hand any change to a separate reviewed job.\n"
+            "jobs:\n"
+            "  goose:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.pull_request.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - env:\n"
+            "          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}\n"
+            "        run: goose run --instructions review-only.txt"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Goose agent with contents: write runs untrusted "
+            "PR/issue content as its instructions, reaching command execution and "
+            "code push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_droid(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only. Droid\n"
+            "# runs the PR/issue as its task, so untrusted input must not reach a\n"
+            "# write token; hand any change to a separate reviewed job.\n"
+            "jobs:\n"
+            "  droid:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - uses: Factory-AI/droid-action@v3\n"
+            "        with:\n"
+            "          factory_api_key: ${{ secrets.FACTORY_API_KEY }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Factory Droid agent with contents: write runs "
+            "untrusted PR/issue content as its task, reaching command execution and "
+            "code push under GITHUB_TOKEN / FACTORY_API_KEY.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_aider(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only. Aider\n"
+            "# edits and commits directly, so untrusted PR/issue text must not be\n"
+            "# fed as its message in a write-capable job.\n"
+            "jobs:\n"
+            "  aider:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.issue.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - run: pip install aider-chat\n"
+            "      - env:\n"
+            "          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}\n"
+            "        run: aider --message-file review-only.txt --dry-run"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Aider agent with contents: write runs untrusted "
+            "PR/issue content as its message, editing files and pushing under "
+            "GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_openhands(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate the resolver on repository write access. OpenHands runs the\n"
+            "# issue/PR as its task, so untrusted input must not reach a write\n"
+            "# token; a maintainer-only label is the usual gate.\n"
+            "on:\n"
+            "  issues:\n"
+            "    types: [labeled]    # only users with write access can label\n"
+            "jobs:\n"
+            "  resolve:\n"
+            "    if: github.event.label.name == 'openhands'\n"
+            "    uses: All-Hands-AI/OpenHands/.github/workflows/openhands-resolver.yml@main\n"
+            "    secrets:\n"
+            "      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable OpenHands resolver with contents: write runs "
+            "untrusted issue/PR content as its task, reaching command execution "
+            "and code push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_qwen_code(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only; drop\n"
+            "# --yolo on fork-reachable triggers. Qwen Code reads the comment as\n"
+            "# its instructions, so untrusted input must not reach a write token.\n"
+            "jobs:\n"
+            "  qwen:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: npm install -g @qwen-code/qwen-code\n"
+            "      - env:\n"
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            "        run: qwen --prompt-file review-only.txt"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Qwen Code agent with contents: write runs "
+            "untrusted PR/issue content as its instructions, reaching command "
+            "execution and code push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_crush(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Keep the job read-only and exclude fork PRs. Crush reads the PR as\n"
+            "# its prompt, so untrusted input must not reach a write token.\n"
+            "jobs:\n"
+            "  crush:\n"
+            "    if: >-\n"
+            "      github.event.workflow_run.head_repository.full_name ==\n"
+            "      github.event.workflow_run.repository.full_name\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - env:\n"
+            "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            '        run: crush run "Review the PR and post inline comments"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Crush agent with contents: write runs untrusted "
+            "PR/issue content as its prompt, reaching command execution and code "
+            "push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_copilot_cli(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only; drop\n"
+            "# --allow-all-tools. Copilot CLI reads the comment as its prompt, so\n"
+            "# untrusted input must not reach a write token.\n"
+            "jobs:\n"
+            "  copilot:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: npm install -g @github/copilot\n"
+            "      - env:\n"
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            '        run: copilot --allow-tool "shell(gh pr comment)" -p review-only.txt'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Copilot CLI agent with contents: write and "
+            "--allow-all-tools runs untrusted PR/issue content as its prompt, "
+            "reaching command execution and code push under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_continue_cli(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only. The\n"
+            "# Continue CLI reads the comment as its prompt, so untrusted input\n"
+            "# must not reach a write token; run review-only, never --auto.\n"
+            "jobs:\n"
+            "  continue:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: npm install -g @continuedev/cli\n"
+            "      - env:\n"
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            "        run: cn review --base ${{ github.event.pull_request.base.sha }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Continue CLI agent with contents: write runs "
+            "untrusted PR/issue content as its prompt, reaching command execution "
+            "and code push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_gptme(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and keep the job read-only. gptme\n"
+            "# reads the issue/comment as its prompt and its tools run shell, so\n"
+            "# untrusted input must not reach a write token.\n"
+            "jobs:\n"
+            "  gptme:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write    # comment only\n"
+            "    steps:\n"
+            "      - run: pipx install gptme\n"
+            "      - env:\n"
+            "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            '        run: gptme --non-interactive "Summarize the issue" issue.md'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable gptme agent with contents: write runs untrusted "
+            "issue/PR content as its prompt, reaching shell execution and code "
+            "push under GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_swe_agent(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and have the agent open a PR for\n"
+            "# human review instead of pushing. SWE-agent reads the issue as its\n"
+            "# task, so untrusted input must not reach a write token directly.\n"
+            "jobs:\n"
+            "  resolve:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.issue.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - run: pip install sweagent\n"
+            "      - env:\n"
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
+            "        run: sweagent run --problem_statement.github_url=$ISSUE_URL"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable SWE-agent with contents: write runs an untrusted "
+            "issue/PR as its task, reaching command execution and code push under "
+            "GITHUB_TOKEN and the model provider key.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_warp(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and have the agent open a PR for\n"
+            "# human review instead of pushing. The Warp agent reads the issue/PR\n"
+            "# comment as its prompt, so untrusted input must not reach a write\n"
+            "# token directly.\n"
+            "jobs:\n"
+            "  warp-fix:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - run: sudo apt install warp-cli -y\n"
+            "      - env:\n"
+            "          WARP_API_KEY: ${{ secrets.WARP_API_KEY }}\n"
+            '        run: warp-cli agent run --prompt "$(cat prompt.txt)"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Warp agent with contents: write runs an untrusted "
+            "issue/PR comment as its prompt, reaching command execution and code "
+            "push under GITHUB_TOKEN and the runner's credentials.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_claude_cli(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate on repository write access and have the agent open a PR for\n"
+            "# human review instead of pushing. Drop --dangerously-skip-permissions\n"
+            "# so tools cannot auto-run on untrusted input; keep the write token off\n"
+            "# review jobs.\n"
+            "jobs:\n"
+            "  agent:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - env:\n"
+            "          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}\n"
+            "          CLAUDE_TASK: ${{ github.event.comment.body }}\n"
+            '        run: claude -p "Review only. Task: $CLAUDE_TASK" --allowedTools Read,Grep,Glob'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Claude CLI run with --dangerously-skip-permissions and "
+            "contents: write reads an untrusted issue/PR comment as its prompt and "
+            "auto-approves shell and file-edit tools, reaching command execution and "
+            "code push under GITHUB_TOKEN and the runner's credentials.",
             secure_fix,
         )
 

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -34,7 +34,23 @@ rules_by_category:
     - cohere_api_key
     - fork_triggerable_ai_agent_with_repo_mutating_gh_tools
     - fork_triggerable_ai_agent_with_write_or_exec_tools
+    - fork_triggerable_aider_agent_with_repo_write
+    - fork_triggerable_amp_agent_with_repo_write
+    - fork_triggerable_claude_cli_agent_with_repo_write
+    - fork_triggerable_codex_agent_with_write_or_exec_sandbox
+    - fork_triggerable_continue_cli_agent_with_repo_write
+    - fork_triggerable_copilot_cli_agent_with_repo_write
+    - fork_triggerable_crush_agent_with_repo_write
+    - fork_triggerable_cursor_agent_with_repo_write
+    - fork_triggerable_droid_agent_with_repo_write
     - fork_triggerable_gemini_or_copilot_agent_with_write_or_exec
+    - fork_triggerable_goose_agent_with_repo_write
+    - fork_triggerable_gptme_agent_with_repo_write
+    - fork_triggerable_opencode_agent_with_repo_write
+    - fork_triggerable_openhands_agent_with_repo_write
+    - fork_triggerable_qwen_code_agent_with_repo_write
+    - fork_triggerable_swe_agent_with_repo_write
+    - fork_triggerable_warp_agent_with_repo_write
     - gcp_vertex_ai_access
     - generic_llm_api_key
     - google_ai_api_key

--- a/tests/playbooks/annotations/fork_triggerable_ai_nonreachable.yml
+++ b/tests/playbooks/annotations/fork_triggerable_ai_nonreachable.yml
@@ -1,0 +1,37 @@
+---
+# Test fixture: fork-triggerable AI-agent rules only fire when the workflow
+# can actually be reached by an untrusted contributor.
+#
+# The rules anchor on `allowed_non_write_users: "*"` plus a tool grant, but
+# that setting is inert when the workflow only runs on triggers a fork cannot
+# reach (`schedule`, `workflow_dispatch`, `workflow_run`). A finding here would
+# be a false positive, so the scanner drops it. This fixture covers the
+# non-reachable case; the reachable (fork-trigger present) counterpart lives in
+# fork_triggerable_ai_reachable.yml.
+#
+# All values are SYNTHETIC.
+
+- name: fixture play for fork-triggerable AI-agent reachability - non-reachable
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    # Scheduled maintenance agent - no fork-reachable trigger, so the
+    # open-user grant cannot be abused by an untrusted contributor.
+    - name: render a scheduled agent workflow with no fork-reachable trigger
+      ansible.builtin.copy:
+        dest: .github/workflows/nightly-agent.yml
+        content: |
+          on:
+            schedule:
+              - cron: "0 3 * * *"
+            workflow_dispatch:
+          jobs:
+            maintain:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: anthropics/claude-code-action@v1
+                  with:
+                    allowed_non_write_users: "*"
+                    claude_args: |
+                      --allowedTools Edit,Read,Write,Grep,Glob,Bash    # scanner-test: reject fork_triggerable_ai_agent_with_write_or_exec_tools

--- a/tests/playbooks/annotations/fork_triggerable_ai_reachable.yml
+++ b/tests/playbooks/annotations/fork_triggerable_ai_reachable.yml
@@ -1,0 +1,34 @@
+---
+# Test fixture: fork-triggerable AI-agent rules MUST still fire when the
+# workflow has a fork-reachable trigger (`pull_request_target`,
+# `issue_comment`, `issues`, `pull_request`, or `workflow_call`), the agent's
+# job can write to the repo, and no author gate is present. This is the
+# reachable, write-capable, ungated counterpart to
+# fork_triggerable_ai_nonreachable.yml and guards against the suppression
+# filter over-suppressing genuine findings.
+#
+# All values are SYNTHETIC.
+
+- name: fixture play for fork-triggerable AI-agent reachability - reachable
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+    - name: render a pull_request_target agent workflow with shell access
+      ansible.builtin.copy:
+        dest: .github/workflows/pr-agent.yml
+        content: |
+          on:
+            pull_request_target:
+              types: [opened, synchronize]
+          jobs:
+            review:
+              runs-on: ubuntu-latest
+              permissions:
+                contents: write
+              steps:
+                - uses: anthropics/claude-code-action@v1
+                  with:
+                    allowed_non_write_users: "*"
+                    claude_args: |
+                      --allowedTools Edit,Read,Write,Grep,Glob,Bash    # scanner-test: expect fork_triggerable_ai_agent_with_write_or_exec_tools

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -5614,8 +5614,13 @@
       ansible.builtin.copy:
         dest: .github/workflows/claude-review.yml
         content: |
+          on:
+            pull_request_target:
+              types: [opened, synchronize]
           jobs:
             review:
+              permissions:
+                contents: write
               steps:
                 - uses: anthropics/claude-code-action@v1
                   with:
@@ -5628,8 +5633,13 @@
       ansible.builtin.copy:
         dest: .github/workflows/claude-issue-triage.yml
         content: |
+          on:
+            issue_comment:
+              types: [created]
           jobs:
             triage:
+              permissions:
+                contents: write
               steps:
                 - uses: anthropics/claude-code-action@v1
                   with:
@@ -5654,14 +5664,371 @@
       ansible.builtin.copy:
         dest: .github/workflows/gemini.yml
         content: |
+          on:
+            issues:
+              types: [opened]
           jobs:
             gemini:
+              permissions:
+                contents: write
               steps:
-                - uses: google-github-actions/run-gemini-cli@v1
+                - uses: google-gemini/gemini-cli-action@v1
                   with:
-                    gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
-                    settings: |
-                      { "tools": { "run_shell_command": true } }
+                    GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                    settings_json: |
+                      { "coreTools": ["run_shell_command(gh issue edit)"] }
+
+    # --- ai_ml_security.yml: fork_triggerable_codex_agent_with_write_or_exec_sandbox ---
+    - name: trigger fork_triggerable_codex_agent_with_write_or_exec_sandbox
+      ansible.builtin.copy:
+        dest: .github/workflows/codex.yml
+        content: |
+          on:
+            issues:
+              types: [opened]
+          jobs:
+            codex:
+              permissions:
+                contents: write
+              steps:
+                - uses: openai/codex-action@v1
+                  with:
+                    openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+                    sandbox: danger-full-access
+                    allow-users: "*"
+
+    # --- ai_ml_security.yml: fork_triggerable_cursor_agent_with_repo_write ---
+    - name: trigger fork_triggerable_cursor_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/cursor.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            cursor:
+              permissions:
+                contents: write
+              steps:
+                - run: curl https://cursor.com/install -fsS | bash
+                - env:
+                    CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+                  run: |
+                    cursor-agent -p "$(cat /tmp/prompt.md)" --model auto
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_cursor_agent_with_repo_write (SDK shape) ---
+    - name: trigger fork_triggerable_cursor_agent_with_repo_write via sdk
+      ansible.builtin.copy:
+        dest: .github/workflows/cursor-sdk.yml
+        content: |
+          on:
+            issues:
+              types: [opened]
+          jobs:
+            agent:
+              permissions:
+                contents: write
+                issues: write
+              steps:
+                - run: npm install @cursor/sdk
+                - env:
+                    CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+                  run: |
+                    node agent-dispatch.mjs
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_opencode_agent_with_repo_write ---
+    - name: trigger fork_triggerable_opencode_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/opencode.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            opencode:
+              if: contains(github.event.comment.body, '/opencode')
+              permissions:
+                contents: write
+                issues: write
+              steps:
+                - uses: sst/opencode/github@latest
+                  with:
+                    model: opencode/claude-sonnet-4-5
+
+    # --- ai_ml_security.yml: fork_triggerable_amp_agent_with_repo_write ---
+    - name: trigger fork_triggerable_amp_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/amp.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            amp:
+              permissions:
+                contents: write
+              steps:
+                - run: npm install -g @sourcegraph/amp
+                - env:
+                    AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
+                  run: |
+                    echo "${{ github.event.comment.body }}" | amp -x
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_goose_agent_with_repo_write ---
+    - name: trigger fork_triggerable_goose_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/goose.yml
+        content: |
+          on:
+            pull_request:
+              types: [opened, synchronize]
+          permissions:
+            contents: write
+          jobs:
+            goose:
+              steps:
+                - run: curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+                - env:
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                  run: |
+                    gh pr diff "$PR_NUMBER" > instructions.txt
+                    goose run --instructions instructions.txt
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_droid_agent_with_repo_write ---
+    - name: trigger fork_triggerable_droid_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/droid.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            droid:
+              if: contains(github.event.comment.body, '@droid')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v5
+                - uses: Factory-AI/droid-action@v3
+                  with:
+                    factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+
+    # --- ai_ml_security.yml: fork_triggerable_aider_agent_with_repo_write ---
+    - name: trigger fork_triggerable_aider_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/aider.yml
+        content: |
+          on:
+            issues:
+              types: [opened, edited]
+          permissions:
+            contents: write
+          jobs:
+            aider:
+              steps:
+                - uses: actions/checkout@v4
+                - run: pip install aider-chat
+                - run: |
+                    echo "${{ github.event.issue.body }}" > message.txt
+                    aider --message-file message.txt --yes
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_openhands_agent_with_repo_write ---
+    - name: trigger fork_triggerable_openhands_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/openhands.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions:
+            contents: write
+            pull-requests: write
+            issues: write
+          jobs:
+            resolve:
+              runs-on: ubuntu-latest
+              steps:
+                - uses: actions/checkout@v4
+                - run: pip install git+https://github.com/All-Hands-AI/OpenHands
+                - env:
+                    LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                  run: |
+                    echo "${{ github.event.comment.body }}" > task.txt
+                    python -m openhands.resolver.resolve_issue --task-file task.txt
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_qwen_code_agent_with_repo_write ---
+    - name: trigger fork_triggerable_qwen_code_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/qwen.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions:
+            contents: write
+            pull-requests: write
+          jobs:
+            qwen:
+              steps:
+                - run: npm install -g @qwen-code/qwen-code
+                - env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: |
+                    echo "${{ github.event.comment.body }}" > task.txt
+                    qwen --yolo --prompt-file task.txt
+
+    # --- ai_ml_security.yml: fork_triggerable_crush_agent_with_repo_write ---
+    - name: trigger fork_triggerable_crush_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/crush.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions:
+            contents: write
+            pull-requests: write
+          jobs:
+            crush:
+              steps:
+                - run: sudo apt install -y crush
+                - env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: crush run "Address ${{ github.event.comment.body }} and push"
+
+    # --- ai_ml_security.yml: fork_triggerable_copilot_cli_agent_with_repo_write ---
+    - name: trigger fork_triggerable_copilot_cli_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/copilot.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions:
+            contents: write
+            pull-requests: write
+          jobs:
+            copilot:
+              steps:
+                - run: npm install -g @github/copilot
+                - env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: |
+                    printf '%s' "${{ github.event.comment.body }}" | copilot --allow-all-tools -p -
+
+    # --- ai_ml_security.yml: fork_triggerable_continue_cli_agent_with_repo_write ---
+    - name: trigger fork_triggerable_continue_cli_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/continue.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions:
+            contents: write
+            pull-requests: write
+          jobs:
+            continue:
+              steps:
+                - run: npm install -g @continuedev/cli
+                - env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: cn --config continuedev/fixer-agent -p "${{ github.event.comment.body }}" --auto
+
+    # --- ai_ml_security.yml: fork_triggerable_gptme_agent_with_repo_write ---
+    - name: trigger fork_triggerable_gptme_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/gptme.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          permissions: write-all
+          jobs:
+            gptme:
+              steps:
+                - run: pipx install gptme
+                - env:
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: |
+                    gptme --non-interactive "${{ github.event.comment.body }}"
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_swe_agent_with_repo_write ---
+    - name: trigger fork_triggerable_swe_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/swe-agent.yml
+        content: |
+          on:
+            issues:
+              types: [opened, labeled]
+          permissions:
+            contents: write
+            pull-requests: write
+          jobs:
+            resolve:
+              steps:
+                - run: pip install sweagent
+                - env:
+                    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  run: |
+                    sweagent run --problem_statement.github_url=${{ github.event.issue.html_url }}
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_warp_agent_with_repo_write ---
+    - name: trigger fork_triggerable_warp_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/warp-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            warp-fix:
+              if: contains(github.event.comment.body, '@warp-fix')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - run: sudo apt install warp-cli -y
+                - env:
+                    WARP_API_KEY: ${{ secrets.WARP_API_KEY }}
+                  run: |
+                    warp-cli agent run --prompt "$(cat prompt.txt)"
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_claude_cli_agent_with_repo_write ---
+    - name: trigger fork_triggerable_claude_cli_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/claude-cli-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            agent:
+              if: contains(github.event.comment.body, '@claude')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - env:
+                    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                    CLAUDE_TASK: ${{ github.event.comment.body }}
+                  run: |
+                    claude -p "Task: $CLAUDE_TASK" \
+                      --permission-mode bypassPermissions \
+                      --dangerously-skip-permissions
+                    git push origin HEAD
 
     # --- supply_chain.yml: mini_shai_hulud_poisoned_package_version_install ---
     - name: trigger mini_shai_hulud_poisoned_package_version_install


### PR DESCRIPTION
Adds detection for CI workflows that let an untrusted fork contributor drive an autonomous AI coding agent that can run shell commands or write to the repository.

## What it catches

A workflow is flagged only when three conditions hold together: a fork-reachable trigger (`pull_request_target`, `issue_comment`, `issues`, `pull_request`, `pull_request_review`, `pull_request_review_comment`, or `workflow_call`), an enclosing job that can mutate the repo (`contents: write`, `permissions: write-all`, or a `git push` / `gh pr create|merge` in the job), and no author or write-access gate. In that shape an indirect prompt-injection payload in the PR/issue body or a comment reaches command execution and code push under `GITHUB_TOKEN` and the runner's credentials.

## New rules

Sixteen CRITICAL rules under `ai_ml_security`, one per agent family:

- OpenAI Codex (`openai/codex-action` and the `codex exec` CLI)
- GitHub Copilot CLI
- Cursor (CLI and `@cursor/sdk`)
- OpenCode
- Sourcegraph Amp
- Block Goose
- Factory Droid
- Aider
- OpenHands
- Qwen Code
- Charm Crush
- Continue CLI
- gptme
- SWE-agent
- Warp
- Claude Code CLI (the raw-CLI counterpart to the existing `claude-code-action` rule)

The existing `claude-code-action` rules also now recognize the `allowed_bots: "*"` bypass and path-scoped write tools (`Edit(*)`, `Write(./**)`, `EditFile(...)`), and the Gemini rule now covers the `google-gemini/gemini-cli-action` slug and `coreTools` shell grants.

## How false positives are avoided

Two post-filters run after the line match. One scopes the write-capability check to the job that actually invokes the agent, so a write permission on an unrelated sibling job does not count, and honors a top-level `permissions:` default only when the job does not narrow it. The other drops findings on non-reachable triggers (`schedule`, `workflow_dispatch`, `workflow_run`), review-only jobs (`contents: read`, comment scope), and jobs gated by `author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label, a hardcoded actor allowlist, or a fork-exclusion check. Agents whose binary name collides with unrelated tooling require a whole-file family signal before firing.

Each rule ships a dynamic remediation that rewrites the workflow to a gated, read-only, split-privilege form, plus CWE, OWASP, MITRE ATT&CK, MITRE ATLAS, NIST, CIS, PCI DSS, and SOC 2 mappings.