### PR TITLE
Convert snap to strict confinement

### DIFF
--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -140,5 +140,10 @@ jobs:
           SNAP_FILE: ${{ steps.build.outputs.snap }}
         run: |
           set -euo pipefail
-          sudo snap install --dangerous --classic "$SNAP_FILE"
+          sudo snap install --dangerous "$SNAP_FILE"
           ansible-security-scanner --version
+          # Sideloaded snaps don't auto-connect home like store installs do.
+          sudo snap connect ansible-security-scanner:home
+          mkdir -p "$HOME/snap-smoke"
+          printf -- '- hosts: all\n  tasks:\n    - shell: echo hi\n' > "$HOME/snap-smoke/playbook.yml"
+          ansible-security-scanner --directory "$HOME/snap-smoke" || true

--- a/.hugo/static/llms.txt
+++ b/.hugo/static/llms.txt
@@ -9,7 +9,7 @@ Ansible Security Scanner is a static analyzer purpose-built for Ansible content.
 - [Installation](https://cpeoples.github.io/ansible-security-scanner/#installation): pip install ansible-security-scanner, or brew install cpeoples/tap/ansible-security-scanner
 - [PyPI package](https://pypi.org/project/ansible-security-scanner/): pip install ansible-security-scanner
 - [Homebrew tap](https://github.com/cpeoples/homebrew-tap): brew install cpeoples/tap/ansible-security-scanner
-- [Snap Store](https://snapcraft.io/ansible-security-scanner): snap install ansible-security-scanner --classic
+- [Snap Store](https://snapcraft.io/ansible-security-scanner): snap install ansible-security-scanner
 - [pre-commit hook](https://pre-commit.com/): add `repo: https://github.com/cpeoples/ansible-security-scanner` with hook id `ansible-security-scanner`
 - [Source code](https://github.com/cpeoples/ansible-security-scanner): GitHub repository (Apache-2.0)
 - [Documentation](https://cpeoples.github.io/ansible-security-scanner/): full docs site

--- a/README.md
+++ b/README.md
@@ -78,10 +78,16 @@ Available via the [`cpeoples/homebrew-tap`](https://github.com/cpeoples/homebrew
 ### Snap
 
 ```bash
-sudo snap install ansible-security-scanner --classic
+sudo snap install ansible-security-scanner
 ```
 
-Published to the [Snap Store](https://snapcraft.io/ansible-security-scanner). Classic confinement lets the scanner read playbooks anywhere on disk.
+Published to the [Snap Store](https://snapcraft.io/ansible-security-scanner). The snap is strictly confined: it scans content under your home directory out of the box. To scan a mounted drive under `/mnt` or `/media`, connect the removable-media interface once:
+
+```bash
+sudo snap connect ansible-security-scanner:removable-media
+```
+
+To scan system paths such as `/etc/ansible` or `/opt`, install via pip, pipx, or Homebrew instead.
 
 ### pre-commit
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,19 +28,18 @@ donation: https://github.com/sponsors/cpeoples
 website: https://cpeoples.github.io/ansible-security-scanner/
 grade: stable
 
-# The scanner reads and writes arbitrary paths the user points it at
-# (--directory /etc/ansible, /opt, mounted volumes), which strict
-# confinement would sandbox to $HOME. Requires a one-time store review.
-confinement: classic
+# Strict confinement sandboxes file access to the plugged interfaces: home
+# (auto-connected) for content under the user's home directory, removable-media
+# (connect manually) for mounted drives. System paths like /etc and /opt are
+# out of scope by design.
+confinement: strict
 
 apps:
   ansible-security-scanner:
     command: bin/ansible-security-scanner
-    # Classic confinement sets no library paths, so point the bundled launcher
-    # at the interpreter's stdlib and the venv's site-packages explicitly.
-    environment:
-      PYTHONPATH: $SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3.12
-      PATH: $SNAP/bin:$SNAP/usr/bin:$PATH
+    plugs:
+      - home
+      - removable-media
 
 parts:
   scanner:
@@ -50,9 +49,8 @@ parts:
     # the tag; the workflow stamps it into snap/.version instead.
     build-packages:
       - git
-    # classic confinement has no base runtime, so the interpreter ships in
-    # the payload; pyvenv.cfg is dropped so the venv doesn't resolve python
-    # to a build-time path at runtime.
+    # Bundle the interpreter and stdlib so the venv is self-contained; drop
+    # pyvenv.cfg so it doesn't resolve python to a build-time path at runtime.
     stage-packages:
       - python3-venv
       - python3.12-minimal

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,6 +37,10 @@ confinement: strict
 apps:
   ansible-security-scanner:
     command: bin/ansible-security-scanner
+    # The core24 python plugin doesn't add the venv's site-packages or the
+    # bundled stdlib to sys.path, so point the launcher at them explicitly.
+    environment:
+      PYTHONPATH: $SNAP/lib/python3.12/site-packages:$SNAP/usr/lib/python3.12
     plugs:
       - home
       - removable-media


### PR DESCRIPTION
The Snap Store rejected the classic confinement request: the tool does not fit the debug-tools category required for classic, and arbitrary path access is unsupported under classic. This switches to strict confinement using the standard interfaces.

- `confinement: strict` with `home` (auto-connected) and `removable-media` (connect manually) plugs
- Removed the classic only launcher environment, since core24 provides the runtime under strict
- Install docs note the home directory scope and how to reach mounted drives or system paths
- The snap smoke test now installs without `--classic` and scans a fixture under `$HOME`

The behavioral tradeoff is that the snap scans content under the user's home directory and connected removable media; system paths like `/etc/ansible` stay available through pip, pipx, or Homebrew.