### PR TITLE
Detect more fork-triggerable AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1144-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1161-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1144<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1161<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->442<!--/CRIT--> critical**, <!--HIGH-->548<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->456<!--/CRIT--> critical**, <!--HIGH-->551<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -158,7 +158,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1144<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1161<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -963,6 +963,24 @@ _FORK_TRIGGERABLE_AI_RULE_IDS: frozenset[str] = frozenset(
         "fork_triggerable_ai_agent_with_repo_mutating_gh_tools",
         "fork_triggerable_gemini_or_copilot_agent_with_write_or_exec",
         "fork_triggerable_codex_agent_with_write_or_exec_sandbox",
+        # Named-vendor agent actions (all ``uses:``-anchored). Each anchors on a
+        # specific action slug (plus, where the action self-gates by default, the
+        # documented bypass input - Junie's custom ``prompt:``, Letta's
+        # ``allowed_non_write_users: "*"``, the refactor action's ``mode:``,
+        # iFlow's ``prompt:``, Bonk's absence of a safe ``permissions:`` /
+        # ``token_permissions: NO_PUSH``). The regex cannot see the ``on:``
+        # trigger, the job's write scope, or an author gate, so the same
+        # fork-reachable + write-capable + ungated post-filter applies.
+        "fork_triggerable_junie_agent_with_prompt_bypass",
+        "fork_triggerable_bonk_agent_with_write_token",
+        "fork_triggerable_cogni_agent_with_repo_write",
+        "fork_triggerable_letta_agent_opened_to_forks",
+        "fork_triggerable_code_agent_with_repo_write",
+        "fork_triggerable_ai_github_action_with_repo_write",
+        "fork_triggerable_a5c_agent_with_repo_write",
+        "fork_triggerable_iflow_agent_with_prompt",
+        "fork_triggerable_sweep_agent_with_repo_write",
+        "fork_triggerable_pr_agent_with_repo_write",
     }
 )
 _FORK_REACHABLE_TRIGGERS: tuple[str, ...] = (
@@ -1085,7 +1103,54 @@ _INSTALLED_AGENT_PROOF: dict[str, re.Pattern[str]] = {
     # ``opencode run --dangerously-skip-permissions`` is not matched by the rule.
     "fork_triggerable_claude_cli_agent_with_repo_write": re.compile(
         r"@anthropic-ai/claude-code|ANTHROPIC_API_?KEY|CLAUDE_CODE|(?<![\w-])claude-code\b"
-        r"|--dangerously-skip-permissions|--permission-mode[\s=]+['\"]?(?:bypassPermissions|acceptEdits)\b",
+        r"|--dangerously-skip-permissions|--permission-mode[\s=]+['\"]?(?:bypassPermissions|acceptEdits|auto)\b",
+        re.IGNORECASE,
+    ),
+    # ``gemini`` collides with unrelated text, so require a Gemini CLI signal:
+    # the npm package, a ``GEMINI_*`` / ``GOOGLE_API_KEY`` credential, or the
+    # google-gemini org slug. The anchor already requires the ``--yolo`` /
+    # ``--approval-mode`` auto flag, and the ``run-gemini-cli`` action form is
+    # owned by a separate rule.
+    "fork_triggerable_gemini_cli_agent_with_repo_write": re.compile(
+        r"@google/gemini-cli|(?<![\w-])gemini-cli\b|google-gemini/gemini|GEMINI_API_?KEY"
+        r"|GOOGLE_API_?KEY|npm\s+install[^\n]*gemini",
+        re.IGNORECASE,
+    ),
+    # CodeMie's package/CLI is distinctive; require the npm package, the install
+    # invocation, a ``CODEMIE_*`` env var, or the vendor domain so a stray
+    # ``codemie`` token in prose does not count. The anchor already requires the
+    # ``codemie <subcommand>`` run form.
+    "fork_triggerable_codemie_agent_with_repo_write": re.compile(
+        r"@codemieai/code|codemie\s+install|CODEMIE_(?:API_KEY|TOKEN|MAX_TURNS)|codemie\.ai",
+        re.IGNORECASE,
+    ),
+    # Devin's action slug and credential/env names are distinctive; require one
+    # of them so the ``prompt-text`` / ``playbook-macro`` input anchor is
+    # attributed to the real agent and not an unrelated action input.
+    "fork_triggerable_devin_agent_with_repo_write": re.compile(
+        r"aaronsteers/devin-action|DEVIN_(?:AI_)?API_KEY|devin-token|app\.devin\.ai"
+        r"|cognition-ai/devin",
+        re.IGNORECASE,
+    ),
+    # Kilo Code's package/org and ``KILOCODE_*`` credential are distinctive;
+    # require one so the generic ``kilocode`` binary anchor (paired with an
+    # autonomous flag or ``run``/``code`` subcommand) is attributed to the real
+    # agent.
+    "fork_triggerable_kilocode_agent_with_repo_write": re.compile(
+        r"@kilocode/cli|KILOCODE_(?:API_KEY|TOKEN)|kilocode\.ai|Kilo-Org/kilocode"
+        r"|kilocodeModel",
+        re.IGNORECASE,
+    ),
+    # The bespoke-LLM rule anchors on a raw completions/messages endpoint, which
+    # a self-prompted workflow (release notes, changelog summaries) also hits.
+    # The proof demands an untrusted event payload in the file - an attacker's
+    # issue/PR title/body/comment - so a call over trusted repo content never
+    # matches even in a write-capable job. The fork-reachable + write-capable +
+    # ungated gating is then applied by ``_suppress_installed_agent_when_safe``
+    # exactly like the vendor CLIs.
+    "fork_triggerable_bespoke_llm_agent_with_repo_write": re.compile(
+        r"github\.event\.(?:comment\.body|issue\.body|issue\.title|pull_request\.body"
+        r"|pull_request\.title|review\.body|discussion\.body|discussion\.title)",
         re.IGNORECASE,
     ),
 }
@@ -1093,6 +1158,64 @@ _INSTALLED_AGENT_JOB_WRITE = re.compile(
     r"^\s*contents\s*:\s*write\b|permissions\s*:\s*write-all\b"
     r"|\bgit\s+push\b|\bgh\s+pr\s+(?:create|merge)\b",
     re.MULTILINE | re.IGNORECASE,
+)
+
+# ``fork_triggerable_agent_shell_exec_secret_exposure`` is the repo-write-less
+# complement of the per-vendor CRITICAL rules: it anchors on an agent handed an
+# arbitrary shell (``--dangerously-skip-permissions`` / ``--allowedTools
+# "...Bash..."`` / ``--yolo``), but fires only when the fork-reachable job cannot
+# be shown to write yet still carries a secret the shell could exfiltrate. The
+# proof keeps a bare tool mention from matching unless the file really drives one
+# of the shell-autonomy agents (its package/env, or the autonomy flag itself).
+_SHELL_EXEC_AGENT_RULE_ID = "fork_triggerable_agent_shell_exec_secret_exposure"
+_SHELL_EXEC_AGENT_PROOF = re.compile(
+    r"@anthropic-ai/claude-code|ANTHROPIC_API_?KEY|CLAUDE_CODE|(?<![\w-])claude-code\b|\.claude/"
+    r"|CLAUDE\.md|@google/gemini-cli|gemini-cli|GEMINI_API_?KEY|GOOGLE_API_?KEY"
+    r"|cursor\.com/install|CURSOR_API_?KEY|@cursor/sdk|sst/opencode|opencode\s+run|OPENCODE_API"
+    r"|aider-chat|(?<![\w-])aider\b|CODEX_API_?KEY|OPENAI_API_?KEY"
+    r"|--dangerously-skip-permissions|--dangerously-bypass-approvals-and-sandbox|--yolo\b"
+    r"|--allowed-?tools[\s=]+['\"][^'\"]*\b(?:Bash|Edit|Write|MultiEdit)\b",
+    re.IGNORECASE,
+)
+# A ``secrets.*`` reference in an ``env:`` value: a long-lived credential the
+# job carries into the agent's shell. ``GITHUB_TOKEN`` alone is excluded - it is
+# the ephemeral, scope-limited job token, not the exfiltration target this rule
+# is about (the CRITICAL write rules already cover token-scoped abuse).
+_JOB_SECRET_IN_ENV = re.compile(
+    r"\$\{\{\s*secrets\.(?!GITHUB_TOKEN\b)[A-Za-z0-9_]+\s*\}\}",
+    re.IGNORECASE,
+)
+
+# ``fork_reachable_gitlab_ci_agent_with_write_or_exec`` scans ``.gitlab-ci.yml``,
+# which has no GitHub ``on:`` block, so the GitHub-Actions fork-reachability and
+# author-gate helpers do not apply. The anchor already requires a write/exec
+# agent invocation; this family gates on the GitLab equivalents: the file must
+# drive a known agent (proof), the job must run on a merge-request pipeline
+# (where an untrusted contributor's MR reaches the parent's credentials), and no
+# fork guard (``$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_PROJECT_ID``) may be
+# present.
+_GITLAB_CI_AGENT_RULE_ID = "fork_reachable_gitlab_ci_agent_with_write_or_exec"
+_GITLAB_CI_AGENT_PROOF = re.compile(
+    r"@anthropic-ai/claude-code|claude\.ai/install|ANTHROPIC_API_?KEY|CLAUDE_CODE|claude\s+-p\b"
+    r"|@openai/codex|codex\s+exec|aider-chat|(?<![\w-])aider\b|cursor\.com/install|cursor-agent"
+    r"|CURSOR_API_?KEY|qwen-code|@qwen-code|opencode\s+run|block/goose|goose\s+run"
+    r"|@google/gemini-cli|gemini\s+--yolo|GEMINI_API_?KEY|--dangerously-skip-permissions"
+    r"|--dangerously-bypass-approvals-and-sandbox|--permission-mode[\s=]+['\"]?(?:bypassPermissions|acceptEdits|auto)",
+    re.IGNORECASE,
+)
+# A merge-request pipeline: the untrusted-contributor-reachable trigger in
+# GitLab CI (the analogue of a fork-reachable GitHub ``on:`` trigger).
+_GITLAB_MERGE_REQUEST_PIPELINE = re.compile(
+    r"CI_PIPELINE_SOURCE\s*==\s*[\"']?merge_request_event"
+    r"|CI_MERGE_REQUEST_(?:IID|TITLE|DESCRIPTION|SOURCE_BRANCH|TARGET_BRANCH)",
+    re.IGNORECASE,
+)
+# A fork guard: refuses (``when: never``) or restricts the job to same-project
+# merge requests by comparing the MR source project to the running project.
+_GITLAB_FORK_GUARD = re.compile(
+    r"CI_MERGE_REQUEST_SOURCE_PROJECT_ID\s*(?:!=|==)\s*\$?CI_PROJECT_ID"
+    r"|CI_PROJECT_ID\s*(?:!=|==)\s*\$?CI_MERGE_REQUEST_SOURCE_PROJECT_ID",
+    re.IGNORECASE,
 )
 # The OpenHands resolver ships as a reusable workflow
 # (``<owner>/OpenHands/.github/workflows/openhands-resolver.yml``) that gates
@@ -2067,6 +2190,22 @@ class FileScanner:
             # review-only jobs (``contents: read``), and jobs gated on repo
             # write access.
             line_findings = self._suppress_installed_agent_when_safe(line_findings, content)
+
+            # Post-filter: the shell-exec secret-exposure rule is the
+            # repo-write-less complement of the per-vendor CRITICAL rules. Keep a
+            # finding only when the fork-reachable, ungated job carries a
+            # ``secrets.*`` credential and cannot be shown to write (write-capable
+            # jobs are the CRITICAL rule's and are not double-reported).
+            line_findings = self._suppress_shell_exec_secret_exposure_when_safe(
+                line_findings, content
+            )
+
+            # Post-filter: the GitLab-CI agent rule anchors on a write/exec agent
+            # invocation in a ``.gitlab-ci.yml`` script but cannot see the
+            # pipeline trigger or a fork guard. Keep it only on a merge-request
+            # pipeline that drives a known agent with no
+            # ``CI_MERGE_REQUEST_SOURCE_PROJECT_ID`` fork guard.
+            line_findings = self._suppress_gitlab_ci_agent_when_safe(line_findings, content)
 
             # Post-filter: suppress ``crontab_modification`` when the
             # matching task is removing (not installing) a cron entry
@@ -7343,6 +7482,81 @@ class FileScanner:
             if job_can_write:
                 kept.append(f)
         return kept
+
+    def _suppress_shell_exec_secret_exposure_when_safe(
+        self, findings: list[SecurityFinding], content: str
+    ) -> list[SecurityFinding]:
+        """Drop ``fork_triggerable_agent_shell_exec_secret_exposure`` findings
+        that are not actually exploitable.
+
+        This rule is the repo-write-less complement of the per-vendor CRITICAL
+        agent rules. The anchor sees an agent handed an arbitrary shell but not
+        the trigger, the secret, an author gate, or whether the job can write.
+        A finding survives only when all of the following hold:
+
+        * the workflow has a fork-reachable trigger,
+        * no author / write-permission gate is present,
+        * the file drives one of the shell-autonomy agents (the family proof),
+        * the enclosing job carries a ``secrets.*`` credential (something for
+          the shell to exfiltrate; ``GITHUB_TOKEN`` alone does not count), and
+        * the job cannot be shown to write to the repo - a write-capable job is
+          owned by the CRITICAL per-vendor rule and is never double-reported
+          here.
+        """
+        if not findings or not any(f.rule_id == _SHELL_EXEC_AGENT_RULE_ID for f in findings):
+            return findings
+        if (
+            not _has_fork_reachable_trigger(content)
+            or _INSTALLED_AGENT_AUTHOR_GATE.search(content)
+            or not _SHELL_EXEC_AGENT_PROOF.search(content)
+        ):
+            return [f for f in findings if f.rule_id != _SHELL_EXEC_AGENT_RULE_ID]
+        lines = content.splitlines()
+        workflow_write = _workflow_level_write(content)
+        kept: list[SecurityFinding] = []
+        for f in findings:
+            if f.rule_id != _SHELL_EXEC_AGENT_RULE_ID:
+                kept.append(f)
+                continue
+            job_text = _enclosing_job_block(lines, max(f.line_number - 1, 0))
+            job_can_write = bool(_INSTALLED_AGENT_JOB_WRITE.search(job_text)) or (
+                workflow_write and not re.search(r"^\s+permissions\s*:", job_text, re.MULTILINE)
+            )
+            # The exfiltration premise requires a real secret and the *absence*
+            # of provable write (write-capable jobs are the CRITICAL rule's).
+            if not job_can_write and _JOB_SECRET_IN_ENV.search(job_text):
+                kept.append(f)
+        return kept
+
+    def _suppress_gitlab_ci_agent_when_safe(
+        self, findings: list[SecurityFinding], content: str
+    ) -> list[SecurityFinding]:
+        """Drop ``fork_reachable_gitlab_ci_agent_with_write_or_exec`` findings
+        that are not fork-reachable.
+
+        The anchor requires a write/exec agent invocation in a ``.gitlab-ci.yml``
+        ``script:`` but cannot see the pipeline trigger or a fork guard. GitLab
+        CI has no GitHub ``on:`` block, so this rule uses the GitLab-native
+        equivalents. A finding survives only when all hold:
+
+        * the file drives a known coding agent (the family proof),
+        * the pipeline is merge-request-triggered (``$CI_PIPELINE_SOURCE ==
+          "merge_request_event"`` / a ``CI_MERGE_REQUEST_*`` reference), the
+          untrusted-contributor-reachable trigger, and
+        * no fork guard (``$CI_MERGE_REQUEST_SOURCE_PROJECT_ID !=
+          $CI_PROJECT_ID``) is present that would refuse or restrict fork-sourced
+          merge requests.
+        """
+        if not findings or not any(f.rule_id == _GITLAB_CI_AGENT_RULE_ID for f in findings):
+            return findings
+        keep = (
+            bool(_GITLAB_CI_AGENT_PROOF.search(content))
+            and bool(_GITLAB_MERGE_REQUEST_PIPELINE.search(content))
+            and not _GITLAB_FORK_GUARD.search(content)
+        )
+        if keep:
+            return findings
+        return [f for f in findings if f.rule_id != _GITLAB_CI_AGENT_RULE_ID]
 
     def _suppress_crontab_cleanup(
         self, findings: list[SecurityFinding], lines: list[str]

--- a/src/ansible_security_scanner/patterns/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/ai_ml_security.yml
@@ -1110,7 +1110,7 @@ patterns:
         review-only jobs (`contents: read`, comment-only scope), and jobs gated on repository
         write access (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only
         label gate, or a fork-exclusion check) are not flagged.
-    regex: "(?<![\\w-])copilot\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[^\\n]|\\n){0,240}?(?:--allow-all-tools|--allow-tool[=\\s]+['\"]?(?:shell|write|edit|all)\\b)"
+    regex: "(?<![\\w-])copilot\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[^\\n]|\\n){0,240}?(?:--allow-all-tools|--allow-tool[=\\s]+['\"]?(?:shell|write|edit|all)\\b|--yolo\\b|--enable-all-github-mcp-tools\\b)"
     multiline: true
     window: 200
     positive_examples:
@@ -2118,7 +2118,7 @@ patterns:
         jobs (`contents: read`, comment-only scope) and jobs gated on repository write access
         (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a
         fork-exclusion check) are not flagged.
-    regex: "(?<![\\w-])claude\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,3000}?(?:--dangerously-skip-permissions|--permission-mode[\\s=]+['\"]?(?:bypassPermissions|acceptEdits)\\b)"
+    regex: "(?<![\\w-])claude\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,3000}?(?:--dangerously-skip-permissions|--permission-mode[\\s=]+['\"]?(?:bypassPermissions|acceptEdits|auto)\\b)"
     multiline: true
     window: 200
     positive_examples:
@@ -2164,6 +2164,1122 @@ patterns:
         `getCollaboratorPermissionLevel`, or exclude fork PRs
         (`head.repo.full_name == github.repository`). Have the agent open a PR for human review
         rather than pushing directly. Treat issue/PR title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_gemini_cli_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Gemini CLI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Google Gemini CLI unattended - `gemini` in `--yolo` mode, or with
+        `--approval-mode yolo`/`auto`/`always` - on a fork-reachable trigger, in a job that can
+        mutate the repository (`contents: write`, `permissions: write-all`, or a `git push` /
+        `gh pr create|merge` in the same job). This is the raw-CLI variant; the
+        `google-github-actions/run-gemini-cli` action form is covered separately. In `--yolo` /
+        auto-approval mode the CLI runs shell commands and edits files without confirmation while
+        holding `GITHUB_TOKEN`, the runner's credentials, and the `GEMINI_API_KEY`/`GOOGLE_API_KEY`,
+        so an indirect prompt-injection payload in the PR/issue body becomes command execution and
+        code push. This rule fires only on the write-capable, ungated combination: review-only jobs
+        (`contents: read`) and jobs gated on repository write access (`author_association`,
+        `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a fork-exclusion check)
+        are not flagged.
+    regex: "(?<![\\w./-])gemini\\b(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,3000}?(?:--yolo\\b|--approval-mode[\\s=]+['\"]?(?:yolo|auto|always)\\b)"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              agent:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - env:
+                      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                      TASK: ${{ github.event.comment.body }}
+                    run: |
+                      gemini --yolo --prompt "$TASK"
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - env:
+                      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                    run: gemini --version
+    recommendation: >-
+        Do not run the Gemini CLI in `--yolo` / auto-approval mode on untrusted issue/PR content in
+        a job that can write to the repository. Keep review jobs at `permissions: contents: read`
+        with only comment scope and never `git push` from them. If the agent must make changes, gate
+        the job on repository write access - require `author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via `getCollaboratorPermissionLevel`, or
+        exclude fork PRs (`head.repo.full_name == github.repository`) - and have it open a PR for
+        human review rather than pushing directly. Treat issue/PR title, body, and comments as
+        untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_codemie_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable CodeMie CLI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the CodeMie CLI (`@codemieai/code`) unattended - `codemie run`/`fix`/`code`/
+        `exec`, typically after `codemie install` wires it onto an underlying model - on a
+        fork-reachable trigger, in a job that can mutate the repository (`contents: write`,
+        `permissions: write-all`, or a `git push` / `gh pr create|merge` in the same job). CodeMie
+        reads attacker-controlled issue/PR content as its task while holding `GITHUB_TOKEN`, the
+        runner's credentials, and the `CODEMIE_API_KEY`, and it edits files and commits without
+        confirmation, so an indirect prompt-injection payload becomes command execution and code
+        push. This rule fires only on the write-capable, ungated combination: review-only jobs
+        (`contents: read`) and jobs gated on repository write access (`author_association`,
+        `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a fork-exclusion check)
+        are not flagged.
+    regex: "(?<![\\w./-])codemie[ \\t]+(?:install|run|fix|code|exec)\\b|npm[ \\t]+install[^\\n]*@codemieai/code"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              codemie:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: npm install -g @codemieai/code
+                  - env:
+                      CODEMIE_API_KEY: ${{ secrets.CODEMIE_API_KEY }}
+                      TASK: ${{ github.event.comment.body }}
+                    run: |
+                      codemie install claude
+                      codemie run "$TASK"
+                      git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: codemie --version
+    recommendation: >-
+        Do not run the CodeMie CLI on untrusted issue/PR content in a job that can write to the
+        repository. Keep review jobs at `permissions: contents: read` with only comment scope and
+        never `git push` from them. If the agent must make changes, gate the job on repository write
+        access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs - and have it open a PR for human
+        review rather than pushing directly. Treat issue/PR title, body, and comments as untrusted
+        data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_devin_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Devin Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Devin agent (`aaronsteers/devin-action`, or a step passing a
+        `devin-token` / `prompt-text` / `playbook-macro` input) on a fork-reachable trigger, in a job
+        that can mutate the repository (`contents: write`, `permissions: write-all`, or a `git push`
+        / `gh pr create|merge` in the same job). Devin reads attacker-controlled issue/PR content as
+        its prompt while holding `GITHUB_TOKEN` and the `DEVIN_API_KEY`, and it can edit files, run
+        commands, and open PRs, so an indirect prompt-injection payload becomes command execution and
+        code push. This rule fires only on the write-capable, ungated combination: review-only jobs
+        (`contents: read`) and jobs gated on repository write access (`author_association`,
+        `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a fork-exclusion check)
+        are not flagged.
+    regex: "uses\\s*:\\s*[^\\n]*?aaronsteers/devin-action|^\\s*(?:devin-token|prompt-text|playbook-macro)\\s*:"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              devin:
+                permissions:
+                  contents: write
+                  issues: write
+                steps:
+                  - uses: aaronsteers/devin-action@main
+                    with:
+                      devin-token: ${{ secrets.DEVIN_AI_API_KEY }}
+                      prompt-text: ${{ github.event.comment.body }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              notify:
+                permissions:
+                  contents: read
+                steps:
+                  - name: Ping Devin dashboard
+                    run: curl -sf https://app.devin.ai/health
+    recommendation: >-
+        Do not run the Devin agent on untrusted issue/PR content in a job that can write to the
+        repository. Keep review jobs at `permissions: contents: read` with only comment scope and
+        never `git push` from them. If the agent must make changes, gate the job on repository write
+        access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs - and have it open a PR for human
+        review rather than pushing directly. Treat issue/PR title, body, and comments as untrusted
+        data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_kilocode_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Kilo Code Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs the Kilo Code CLI (`@kilocode/cli`) unattended - `kilocode run`/`code`, or
+        `kilocode` with an autonomous flag (`--auto`, `--yolo`, `--headless`, `--auto-approve`) - on
+        a fork-reachable trigger, in a job that can mutate the repository (`contents: write`,
+        `permissions: write-all`, or a `git push` / `gh pr create|merge` in the same job). Kilo Code
+        reads attacker-controlled issue/PR content as its task while holding `GITHUB_TOKEN`, the
+        runner's credentials, and the `KILOCODE_API_KEY`, and in autonomous mode it edits files and
+        commits without confirmation, so an indirect prompt-injection payload becomes command
+        execution and code push. This rule fires only on the write-capable, ungated combination:
+        review-only jobs (`contents: read`) and jobs gated on repository write access
+        (`author_association`, `getCollaboratorPermissionLevel`, a maintainer-only label gate, or a
+        fork-exclusion check) are not flagged.
+    regex: "(?<![\\w-])kilocode\\b(?:[^\\n]){0,240}?(?:--auto\\b|--yolo\\b|--headless\\b|--auto-approve\\b)|(?<![\\w-])kilocode\\s+(?:run|code)\\b"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, labeled]
+            jobs:
+              kilo:
+                permissions:
+                  contents: write
+                steps:
+                  - run: npm install -g @kilocode/cli
+                  - env:
+                      KILOCODE_TOKEN: ${{ secrets.KILOCODE_API_KEY }}
+                    run: |
+                      kilocode --auto --yolo "Issue: ${{ github.event.issue.title }}"
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              review:
+                permissions:
+                  contents: read
+                steps:
+                  - run: npm install -g @kilocode/cli
+                  - run: kilocode --version
+    recommendation: >-
+        Do not run the Kilo Code CLI in an autonomous mode on untrusted issue/PR content in a job
+        that can write to the repository. Keep review jobs at `permissions: contents: read` with only
+        comment scope and never `git push` from them. If the agent must make changes, gate the job on
+        repository write access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`,
+        check the actor via `getCollaboratorPermissionLevel`, or exclude fork PRs - and have it open a
+        PR for human review rather than pushing directly. Treat issue/PR title, body, and comments as
+        untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_bespoke_llm_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Bespoke LLM Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI job runs a roll-your-own LLM agent - a `curl`/script that POSTs to a chat-completions /
+        messages endpoint (`/v1/chat/completions`, `/v1/messages`, `api.openai.com/v1`,
+        `api.anthropic.com/v1`, `generativelanguage.googleapis.com`, DashScope's `/compatible-mode/v1`,
+        Zhipu's `/api/paas/v4`) and applies the model's output - on a fork-reachable trigger, in a job
+        that can mutate the repository. Naming the API shape rather than a vendor is what lets an
+        unnamed, hand-built agent match. The rule fires only when the file also carries an untrusted
+        event payload (`github.event.issue.body`, `pull_request.title`, `comment.body`, etc.) flowing
+        into that call, the job is fork-reachable and write-capable (`contents: write`,
+        `permissions: write-all`, or a `git push` / `gh pr create|merge`), and no author gate is
+        present - so a self-prompted call over trusted repo content, a read-only review bot, or a
+        maintainer-gated job never matches.
+    regex: "(?:/v1/chat/completions|/v1/messages|/v1/completions|/chat/completions|api\\.openai\\.com/v1|api\\.anthropic\\.com/v1|generativelanguage\\.googleapis\\.com|/compatible-mode/v1|/api/paas/v4)"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened]
+            jobs:
+              agent:
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v4
+                  - env:
+                      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                      TASK: ${{ github.event.issue.body }}
+                    run: |
+                      RESP=$(curl -s https://api.openai.com/v1/chat/completions \
+                        -H "Authorization: Bearer $LLM_API_KEY" \
+                        -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$TASK\"}]}")
+                      echo "$RESP" | node apply-ops.js
+                      git add . && git commit -m fix && git push origin HEAD
+    negative_examples:
+      - |2-
+            on:
+              push:
+                branches: [main]
+            jobs:
+              notes:
+                permissions:
+                  contents: write
+                steps:
+                  - run: |
+                      curl -s https://api.example.com/summarize -d @changelog.json > notes.md
+                      git add notes.md && git commit -m notes && git push
+    recommendation: >-
+        Do not feed untrusted issue/PR content into a bespoke LLM call whose output is applied in a
+        job that can write to the repository. Keep review jobs at `permissions: contents: read` with
+        only comment scope and never `git push` from them. If the agent must make changes, gate the
+        job on repository write access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`,
+        check the actor via `getCollaboratorPermissionLevel`, or exclude fork PRs - and have it open a
+        PR for human review rather than pushing directly. Treat issue/PR title, body, and comments as
+        untrusted data and never interpolate them into a prompt whose response is executed or
+        committed.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_agent_shell_exec_secret_exposure"
+    category: "ai_ml_security"
+    severity: "HIGH"
+    title: "Fork-Triggerable Coding Agent Given An Arbitrary Shell On Untrusted PR Content In A Job That Exposes A Secret"
+    description: >-
+        A CI job hands an autonomous coding agent (`claude`, `gemini`, `cursor-agent`, `opencode`,
+        `aider`, `codex`) an arbitrary shell - via `--dangerously-skip-permissions`,
+        `--dangerously-bypass-approvals-and-sandbox`, `--yolo`, `--full-auto`, an autonomous
+        `--permission-mode`/`--approval-mode`, a `--allowedTools "...Bash/Edit/Write..."` grant, or
+        `--allow-all-tools` - while a fork PR's code is checked out and a secret (an API key/token in
+        `env:` referencing `secrets.*`) is present in the job. This is the repo-write-less complement
+        of the per-vendor CRITICAL rules: even without repository write, the shell runs
+        attacker-controlled content and can read and exfiltrate the secret. The rule fires only on a
+        fork-reachable, ungated job that carries a secret and cannot be shown to write (a write-capable
+        job is owned by the CRITICAL rule and is never double-reported here); a plain `pull_request`
+        that receives no secrets, a read-only tool grant, and author/merge-gated jobs are not flagged.
+    regex: "(?<![\\w./-])(?:claude|gemini|cursor-agent|opencode|aider|codex)(?![\\w./-])[ \\t]+(?:(?:exec|run)[ \\t]+)?(?:(?:--dangerously-skip-permissions|--dangerously-bypass-approvals-and-sandbox|--yolo\\b|--full-auto\\b|--permission-mode[\\s=]+['\"]?(?:bypassPermissions|acceptEdits|auto)\\b|--approval-mode[\\s=]+['\"]?(?:yolo|auto_edit|auto)\\b|--allowed-?tools[\\s=]+['\"][^'\"]*\\b(?:Bash|Edit|Write|MultiEdit)\\b|--allow-all-tools\\b)|[\"'$\\\\-](?:[^\\n]){0,600}?(?:--dangerously-skip-permissions|--dangerously-bypass-approvals-and-sandbox|--yolo\\b|--full-auto\\b|--permission-mode[\\s=]+['\"]?(?:bypassPermissions|acceptEdits|auto)\\b|--approval-mode[\\s=]+['\"]?(?:yolo|auto_edit|auto)\\b|--allowed-?tools[\\s=]+['\"][^'\"]*\\b(?:Bash|Edit|Write|MultiEdit)\\b|--allow-all-tools\\b))"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              pull_request_target:
+                types: [opened, synchronize]
+            jobs:
+              review:
+                runs-on: ubuntu-latest
+                steps:
+                  - uses: actions/checkout@v4
+                    with:
+                      ref: ${{ github.event.pull_request.head.sha }}
+                  - run: npm install -g @anthropic-ai/claude-code
+                  - env:
+                      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                    run: |
+                      claude -p "$(cat review-prompt.txt)" --allowedTools "Bash,Read,Grep"
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              review:
+                runs-on: ubuntu-latest
+                steps:
+                  - env:
+                      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                    run: claude --print "Summarize" --allowedTools "Read,Glob,Grep" > out.md
+    recommendation: >-
+        This job hands an autonomous coding agent an arbitrary shell
+        (`--dangerously-skip-permissions` / `--allowedTools "...Bash..."` / `--yolo`) while a fork
+        PR's code is checked out and a secret (API key, token) is in the job environment. Even without
+        repository write, that shell runs attacker-controlled content and can read and exfiltrate the
+        secret. Drop the shell/write tools for untrusted runs (grant only read-only tools such as
+        Read/Glob/Grep, or Gemini/Claude review-only modes), do not inject long-lived secrets into a
+        job that processes fork content, and gate any autonomous run on repository write access
+        (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or a collaborator-permission check).
+        Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-200", "CWE-522", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1567"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050", "AML.T0057"]
+
+  - id: "fork_triggerable_junie_agent_with_prompt_bypass"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable JetBrains Junie Agent With A Custom Prompt Bypassing Its Built-In Write-Access Gate"
+    description: >-
+        A CI workflow runs JetBrains Junie (`JetBrains/junie-github-action`) on a fork-reachable
+        trigger and passes a custom `prompt:` / `user_prompt:` / `custom_prompt:` input. Per
+        JetBrains' docs Junie self-gates by default - "only users with write access can trigger
+        Junie" and it blocks bot actors - so the common `@junie-agent` mention wiring is not
+        fork-exploitable and is not flagged. The decisive documented exception is that the built-in
+        permission validation "does NOT apply when a custom `prompt` input is provided". A workflow
+        that both runs Junie on a fork-reachable trigger and passes a custom prompt has intentionally
+        bypassed the self-gate; when that prompt carries untrusted PR/issue content into a
+        write-capable job it is the same fork-triggerable-agent class. This rule anchors only on the
+        action slug followed by a custom-prompt input in the same step, never the safe mention-only
+        default, and the fork-reachable + write-capable + ungated post-filter suppresses correctly
+        gated callers.
+    regex: "JetBrains/junie-github-action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,2000}?^\\s*(?:prompt|user_prompt|custom_prompt)\\s*:"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              junie:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: JetBrains/junie-github-action@v1
+                    with:
+                      junie_api_key: ${{ secrets.JUNIE_API_KEY }}
+                      prompt: ${{ github.event.comment.body }}
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              junie:
+                if: contains(github.event.comment.body, '@junie-agent')
+                permissions:
+                  contents: write
+                steps:
+                  - uses: JetBrains/junie-github-action@v1
+                    with:
+                      junie_api_key: ${{ secrets.JUNIE_API_KEY }}
+    recommendation: >-
+        Do not pass untrusted PR/issue content into Junie's custom `prompt:` input on a
+        fork-reachable trigger in a job that can write to the repository - the custom prompt disables
+        Junie's built-in write-access gate. Rely on the default `@junie-agent` mention flow (which
+        restricts triggers to users with write access), or gate the job explicitly on repository
+        write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or
+        `getCollaboratorPermissionLevel`) and have the agent open a PR for human review. Treat the PR
+        diff and issue/comment body as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_bonk_agent_with_write_token"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Bonk (OpenCode) Agent With A Writable Token And No Maintainer/CODEOWNERS Gate"
+    description: >-
+        A CI workflow runs Bonk (`ask-bonk/ask-bonk` / `ask-bonk/ask-bonk/github`), a code-review /
+        change agent built on OpenCode, on a fork-reachable trigger. Bonk's installation token
+        defaults to full write access and it responds to `/bonk` / `@ask-bonk` mentions in issues and
+        PRs. Bonk's own author gate is its `permissions:` input: setting it to `admin` / `write` /
+        `CODEOWNERS` restricts triggers to trusted actors, and `token_permissions: NO_PUSH` drops
+        repo write. The dangerous shape is a fork-reachable, write-capable Bonk step configured with
+        none of those safe inputs - i.e. mention-only (or `permissions: any`) with the default
+        writable token, which any fork contributor can trigger. This rule anchors on the action use
+        only when neither a safe `permissions:` value nor `token_permissions: NO_PUSH` appears in the
+        step, and the fork-reachable + write-capable + ungated post-filter handles the rest.
+    regex: "ask-bonk/ask-bonk(?:/github)?@(?![\\s\\S]{0,2500}?(?:permissions\\s*:\\s*[\"']?(?:admin|write|CODEOWNERS)|token_permissions\\s*:\\s*[\"']?NO_PUSH))(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,60}"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              bonk:
+                if: contains(github.event.comment.body, '/bonk')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: ask-bonk/ask-bonk/github@main
+                    with:
+                      model: opencode/claude-opus-4-5
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              bonk:
+                if: contains(github.event.comment.body, '/bonk')
+                permissions:
+                  contents: write
+                steps:
+                  - uses: ask-bonk/ask-bonk/github@main
+                    with:
+                      model: opencode/claude-opus-4-5
+                      permissions: CODEOWNERS
+    recommendation: >-
+        Do not run Bonk on a fork-reachable trigger with its default writable token and no
+        maintainer gate. Set the action's `permissions:` input to `admin` / `write` / `CODEOWNERS`
+        so only trusted actors can trigger it, or set `token_permissions: NO_PUSH` to drop repository
+        write. Otherwise gate the job on repository write access (`author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR` or `getCollaboratorPermissionLevel`). Treat PR/issue content
+        as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_cogni_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Cogni AI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs Cogni (`Cogni-AI-OU/cogni-ai-agent-action`), an autonomous agent that
+        takes a `prompt:` (typically the issue/PR/comment body piped straight in) and is granted
+        `contents: write` / `issues: write`, on a fork-reachable trigger. Cogni carries no built-in
+        author gate, so on a fork-reachable trigger with repository write it is directly exploitable:
+        an attacker's issue/PR/comment body becomes the agent's instructions and can drive commits
+        under `GITHUB_TOKEN`. This rule anchors on the action use, and the fork-reachable +
+        write-capable + ungated post-filter suppresses correctly gated callers (a read-only job or an
+        `author_association` / collaborator-permission gate).
+    regex: "Cogni-AI-OU/cogni-ai-agent-action@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              cogni:
+                permissions:
+                  contents: write
+                  issues: write
+                steps:
+                  - uses: Cogni-AI-OU/cogni-ai-agent-action@main
+                    with:
+                      prompt: ${{ github.event.comment.body }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              lint:
+                permissions:
+                  contents: read
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: echo "Cogni review is disabled for forks"
+    recommendation: >-
+        Do not run the Cogni agent on untrusted issue/PR content on a fork-reachable trigger in a job
+        that can write to the repository. Keep review jobs at `permissions: contents: read` with only
+        comment scope. If the agent must make changes, gate the job on repository write access -
+        require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via
+        `getCollaboratorPermissionLevel`, or exclude fork PRs - and have it open a PR for human
+        review. Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_letta_agent_opened_to_forks"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Letta Code Agent Opened To Non-Write Users With Shell / Commit Access"
+    description: >-
+        A CI workflow runs Letta Code (`letta-ai/letta-code-action`), a stateful autonomous coding
+        agent that can read files, run shell commands, commit and push, and open pull requests, and
+        opens it to non-write users. Per Letta's docs the action self-gates by default - "only
+        repository collaborators with write access can trigger the action" - using the same
+        `allowed_non_write_users` / `allowed_bots` input convention as the Claude action. The
+        documented, cautioned-against bypass is setting `allowed_non_write_users` (or `allowed_bots`)
+        to `*`, which lets any fork contributor drive a shell/commit-capable agent. This rule anchors
+        on the action use only when one of those inputs opens it to `*`; the default self-gated
+        wiring (no such input) never fires. The generic write/exec-tools rule does not cover this
+        because Letta does not use Claude's `allowed_tools: Bash,...` grant - it grants
+        shell/commit capability implicitly.
+    regex: "letta-ai/letta-code-action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,2500}?^\\s*allowed_(?:non_write_users|bots)\\s*:\\s*[\"']?\\*[\"']?"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              letta:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: letta-ai/letta-code-action@v0
+                    with:
+                      letta_api_key: ${{ secrets.LETTA_API_KEY }}
+                      allowed_non_write_users: "*"
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              letta:
+                permissions:
+                  contents: write
+                steps:
+                  - uses: letta-ai/letta-code-action@v0
+                    with:
+                      letta_api_key: ${{ secrets.LETTA_API_KEY }}
+    recommendation: >-
+        Do not set `allowed_non_write_users` / `allowed_bots` to `*` on the Letta Code action - that
+        disables its built-in write-access gate and lets any fork contributor drive a shell- and
+        commit-capable agent. Rely on the default self-gated wiring (only collaborators with write
+        access can trigger it), or gate the job explicitly on repository write access. Have the agent
+        open a PR for human review rather than committing directly. Treat the PR diff and issue/comment
+        content as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_code_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable code-agent (Claude Code / Codex Wrapper) With Repository Write Access"
+    description: >-
+        A CI workflow runs code-agent (`potproject/code-agent`), a GitHub Action that wraps Claude
+        Code / Codex, reads the issue/PR/comment body, and is granted `contents: write` +
+        `pull-requests: write`, on a fork-reachable trigger. code-agent carries no built-in author
+        gate - its only guard is `sender.type != 'Bot'`, which a fork contributor trivially satisfies
+        - so an attacker's issue/PR/comment body becomes the wrapped agent's instructions and can
+        drive commits under `GITHUB_TOKEN`. This rule anchors on the action use, and the
+        fork-reachable + write-capable + ungated post-filter suppresses correctly gated callers.
+    regex: "potproject/code-agent@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              code-agent:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: potproject/code-agent@main
+                    with:
+                      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              lint:
+                permissions:
+                  contents: read
+                steps:
+                  - uses: actions/checkout@v4
+                  - run: echo "no code-agent here"
+    recommendation: >-
+        Do not run code-agent on untrusted issue/PR content on a fork-reachable trigger in a job that
+        can write to the repository. Keep review jobs at `permissions: contents: read`. If the agent
+        must make changes, gate the job on repository write access - require `author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR`, check the actor via `getCollaboratorPermissionLevel`, or
+        exclude fork PRs (a `sender.type != 'Bot'` check is not sufficient) - and have it open a PR
+        for human review. Treat PR/issue title, body, and comments as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_ai_github_action_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable AI Refactor Agent (cognitivecomputations/ai-github-action) With Repository Write Access"
+    description: >-
+        A CI workflow runs the AI refactor agent (`cognitivecomputations/ai-github-action`) with a
+        `mode:` input (its autonomous refactor/edit modes, e.g. `mode: pr`) on a fork-reachable
+        trigger. In its edit modes the action rewrites files and pushes them, granted
+        `contents: write`. It has no built-in author gate, so on a fork-reachable trigger with
+        repository write it edits the checked-out fork branch directly under `GITHUB_TOKEN`. This
+        rule anchors on the action use followed by a `mode:` input, and the fork-reachable +
+        write-capable + ungated post-filter suppresses correctly gated callers.
+    regex: "cognitivecomputations/ai-github-action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,1500}?^\\s*mode\\s*:"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened, synchronize]
+            jobs:
+              ai-refactor:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: cognitivecomputations/ai-github-action@v1
+                    with:
+                      mode: "pr"
+                      instructions: "refactor"
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              ai-refactor:
+                permissions:
+                  contents: read
+                steps:
+                  - uses: cognitivecomputations/ai-github-action@v1
+                    with:
+                      instructions: "review only"
+    recommendation: >-
+        Do not run the AI refactor agent in an edit `mode:` (e.g. `pr`) on untrusted PR content on a
+        fork-reachable trigger in a job that can write to the repository. Keep review runs at
+        `permissions: contents: read`. If the agent must make changes, gate the job on repository
+        write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or
+        `getCollaboratorPermissionLevel`) and have it open a PR for human review rather than pushing
+        directly. Treat the PR diff and any in-tree agent policy files as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_a5c_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable a5c Agent Router With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs a5c (`a5c-ai/action`), an autonomous agent router that dispatches Claude
+        Code / Codex on a wide set of triggers (`pull_request`, `issue_comment`, `issues`, ...) and
+        is granted `contents` / `pull-requests` / `packages: write`, on a fork-reachable trigger. The
+        workflow itself carries no author gate - the vendor documents runtime routing/filtering the
+        static config does not express - so a fork-reachable + write-capable caller matches the
+        model: an attacker's PR/issue/comment content is routed to a coding agent that can commit
+        under `GITHUB_TOKEN`. This rule anchors on the action use, and the fork-reachable +
+        write-capable + ungated post-filter suppresses callers that add an explicit maintainer gate.
+    regex: "a5c-ai/action@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              a5c:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: a5c-ai/action@main
+                    with:
+                      anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+    negative_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened]
+            jobs:
+              a5c:
+                if: github.event.pull_request.author_association == 'MEMBER'
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v4
+    recommendation: >-
+        Do not run the a5c agent router on untrusted PR/issue content on a fork-reachable trigger in
+        a job that can write to the repository. Gate the job on repository write access -
+        `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, a `getCollaboratorPermissionLevel`
+        check, or a fork-exclusion check - and scope the dispatched agent's tools to read-only for
+        untrusted runs, handing any commit to a separate reviewed job. Treat PR/issue content as
+        untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_iflow_agent_with_prompt"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable iFlow CLI Coding Agent Driven By An Untrusted Prompt In A Privileged CI Job"
+    description: >-
+        A CI workflow runs the iFlow CLI action (`iflow-ai/iflow-cli-action`), an autonomous
+        coding-agent action that takes a `prompt:` (typically the issue/PR/comment body) and can
+        implement issues - i.e. commit and open PRs - on a fork-reachable trigger. It has no built-in
+        author gate, so a fork-reachable + write-capable caller that pipes untrusted content into
+        `prompt:` is exploitable: the attacker's content becomes the agent's instructions and can
+        drive commits under `GITHUB_TOKEN`. This rule anchors on the action use followed by a
+        `prompt:` input, and the fork-reachable + write-capable + ungated post-filter suppresses
+        callers that add an `author_association` / membership gate.
+    regex: "iflow-ai/iflow-cli-action@(?:(?!^\\s*-?\\s*(?:uses|name)\\s*:)[\\s\\S]){0,2000}?^\\s*prompt\\s*:"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              iflow:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: iflow-ai/iflow-cli-action@v2
+                    with:
+                      api_key: ${{ secrets.IFLOW_API_KEY }}
+                      prompt: ${{ github.event.comment.body }}
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              iflow:
+                if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+                permissions:
+                  contents: write
+                steps:
+                  - uses: iflow-ai/iflow-cli-action@v2
+                    with:
+                      api_key: ${{ secrets.IFLOW_API_KEY }}
+    recommendation: >-
+        Do not pipe untrusted issue/PR/comment content into the iFlow CLI action's `prompt:` input on
+        a fork-reachable trigger in a job that can write to the repository. Gate the job on repository
+        write access - require `author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`, check the
+        actor via `getCollaboratorPermissionLevel`, or exclude fork PRs - and have the agent open a PR
+        for human review. Treat the PR/issue/comment body as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_sweep_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Sweep AI Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs Sweep (`sweepai/sweep-action`, `sweep-ai/sweep`), an autonomous "junior
+        engineer" agent that reads an issue, edits the codebase, and opens a pull request, on a
+        fork-reachable trigger. Per Sweep's docs "any user with access to your repository can trigger
+        Sweep" and it acts with the GitHub App installation's permissions - it enforces no
+        author-write-access check of its own. The documented safe trigger is the maintainer-controlled
+        `Sweep` label (`github.event.label.name == 'sweep'`), which the author-gate post-filter treats
+        as sound. The dangerous shape is a fork-reachable trigger (an `issues` / `issue_comment`
+        `Sweep:` text prefix, which any outside author can set) with repository write and no
+        label/author gate. This rule anchors on the action use, and the fork-reachable +
+        write-capable + ungated post-filter suppresses label-gated callers.
+    regex: "(?:sweepai|sweep-ai)/sweep(?:-action)?@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, edited]
+            jobs:
+              sweep:
+                if: startsWith(github.event.issue.title, 'Sweep:')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: sweepai/sweep-action@v1
+                    with:
+                      github_token: ${{ secrets.GITHUB_TOKEN }}
+    negative_examples:
+      - |2-
+            on:
+              issues:
+                types: [labeled]
+            jobs:
+              sweep:
+                if: github.event.label.name == 'sweep'
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v4
+    recommendation: >-
+        Do not trigger Sweep from an outside-author-controllable signal (an `issues` / `issue_comment`
+        `Sweep:` title/body prefix) in a job that can write to the repository. Gate the agent on the
+        maintainer-controlled `Sweep` label (`github.event.label.name == 'sweep'`) - only users with
+        write access can label - or on repository write access (`author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR` or `getCollaboratorPermissionLevel`). Treat issue/PR content
+        as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_pr_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "HIGH"
+    title: "Fork-Triggerable PR-Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs PR-Agent (`qodo-ai/pr-agent`, formerly `Codium-ai/pr-agent`), which
+        reviews, describes, and - via `/improve` and its commitable code suggestions - edits pull
+        requests using the repository's `GITHUB_TOKEN`, on a fork-reachable trigger. Its GitHub
+        Action mode has no built-in author-permission check: the vendor's own examples gate only on
+        `github.event.sender.type != 'Bot'`, which an outside human PR author trivially satisfies.
+        Wired to `pull_request` / `issue_comment` with `contents: write` and no author gate, an
+        attacker's PR body or comment is read as the agent's instructions and can drive a push or PR
+        mutation through prompt injection. This rule anchors on the action use, and the fork-reachable
+        + write-capable + ungated post-filter suppresses the callers that add a real gate.
+    regex: "(?:Codium-ai|codiumai|qodo-ai)/pr-agent@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              pull_request:
+                types: [opened, reopened]
+              issue_comment:
+            jobs:
+              pr_agent_job:
+                if: ${{ github.event.sender.type != 'Bot' }}
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: qodo-ai/pr-agent@main
+                    env:
+                      OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+                      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              pr_agent_job:
+                if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v4
+    recommendation: >-
+        Do not run PR-Agent with repository-mutating tools (`/improve` commitable suggestions) on
+        untrusted PR/comment content on a fork-reachable trigger in a job that can write to the
+        repository - a `sender.type != 'Bot'` check does not gate outside human authors. Gate the job
+        on repository write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or
+        `getCollaboratorPermissionLevel`) and scope the agent to read-only review/describe tools.
+        Treat PR/issue content as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_reachable_gitlab_ci_agent_with_write_or_exec"
+    category: "ai_ml_security"
+    severity: "HIGH"
+    title: "Fork-Reachable GitLab CI Coding Agent With Write Or Execute Capability"
+    description: >-
+        A `.gitlab-ci.yml` job runs a coding agent (`claude -p`, `codex exec`, `aider`,
+        `cursor-agent`, `qwen ... -p`, `opencode run`, `goose run`, `gemini --yolo` /
+        `--approval-mode yolo|auto_edit`) with write / execute capability on a merge-request pipeline
+        (`$CI_PIPELINE_SOURCE == "merge_request_event"`) and with no fork guard. A merge-request
+        pipeline runs in the context that owns the agent's write credentials, so an untrusted diff,
+        title, or description can drive the agent via prompt injection. GitLab's fork-pipeline model
+        means the parent's protected variables are never injected into a fork merge-request pipeline,
+        so this is scored HIGH rather than CRITICAL - final exploitability also depends on project
+        settings (whether the token is Protected, branch protection, who may push a branch) that are
+        not visible in the file. The rule fires only when the file drives a known agent (the family
+        proof), the pipeline is merge-request-triggered, and no
+        `$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_PROJECT_ID` fork guard is present; read-only tool
+        grants (`--allowedTools "Read,Grep,Glob"`, `--permission-mode plan`) do not match the anchor.
+    regex: "(?:^|[\\s;&|])(?:claude\\s+(?:--\\S+\\s+)*-p\\b|codex\\s+exec\\b|aider\\b|cursor-agent\\b|qwen\\b[^\\n]*\\s-p\\b|opencode\\s+run\\b|goose\\s+run\\b|gemini\\b[^\\n]*--yolo\\b|gemini\\b[^\\n]*--approval-mode[\\s=]+[\"']?(?:yolo|auto_edit))"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            ai-review:
+              stage: review
+              image: node:22
+              rules:
+                - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+              script:
+                - npm install -g @anthropic-ai/claude-code
+                - |
+                  claude -p "Review MR !${CI_MERGE_REQUEST_IID} and post a note using PRIVATE-TOKEN $REVIEW_TOKEN" \
+                    --permission-mode acceptEdits \
+                    --allowedTools "Bash Read Edit Write"
+      - |2-
+            codex-fix:
+              rules:
+                - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+              script:
+                - npm i -g @openai/codex
+                - git diff origin/$CI_MERGE_REQUEST_TARGET_BRANCH_NAME...HEAD > diff.patch
+                - codex exec --full-auto "$(cat diff.patch)"
+                - git push origin HEAD
+    negative_examples:
+      - |2-
+            lint:
+              rules:
+                - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+              script:
+                - npm ci
+                - npm run lint
+      - |2-
+            claude-review:
+              rules:
+                - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+              script:
+                - npm install -g @anthropic-ai/claude-code
+                - claude --version
+    recommendation: >-
+        A merge-request pipeline runs in the context that owns the agent's write credentials, so an
+        untrusted diff can drive the agent via prompt injection. Gate the job against fork sources
+        (add a `rule: if $CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_PROJECT_ID` with `when: never`),
+        restrict the agent to read-only tools (for example `--allowedTools "Read,Grep,Glob"`) when it
+        only reviews, mark the API/personal access token as Protected so it is never exposed to fork
+        pipelines, and never embed the token in the agent prompt. Treat the merge-request diff, title,
+        and description as untrusted data.
     cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
     owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
     owasp_llm: ["LLM01", "LLM02", "LLM06"]

--- a/src/ansible_security_scanner/remediations/ai_ml_security.py
+++ b/src/ansible_security_scanner/remediations/ai_ml_security.py
@@ -75,6 +75,23 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
         "fork_triggerable_swe_agent_with_repo_write": "_fix_fork_triggerable_swe_agent",
         "fork_triggerable_warp_agent_with_repo_write": "_fix_fork_triggerable_warp",
         "fork_triggerable_claude_cli_agent_with_repo_write": "_fix_fork_triggerable_claude_cli",
+        "fork_triggerable_gemini_cli_agent_with_repo_write": "_fix_fork_triggerable_gemini_cli",
+        "fork_triggerable_codemie_agent_with_repo_write": "_fix_fork_triggerable_codemie",
+        "fork_triggerable_devin_agent_with_repo_write": "_fix_fork_triggerable_devin",
+        "fork_triggerable_kilocode_agent_with_repo_write": "_fix_fork_triggerable_kilocode",
+        "fork_triggerable_bespoke_llm_agent_with_repo_write": "_fix_fork_triggerable_bespoke_llm",
+        "fork_triggerable_agent_shell_exec_secret_exposure": "_fix_fork_triggerable_shell_exec",
+        "fork_triggerable_junie_agent_with_prompt_bypass": "_fix_fork_triggerable_junie",
+        "fork_triggerable_bonk_agent_with_write_token": "_fix_fork_triggerable_bonk",
+        "fork_triggerable_cogni_agent_with_repo_write": "_fix_fork_triggerable_cogni",
+        "fork_triggerable_letta_agent_opened_to_forks": "_fix_fork_triggerable_letta",
+        "fork_triggerable_code_agent_with_repo_write": "_fix_fork_triggerable_code_agent",
+        "fork_triggerable_ai_github_action_with_repo_write": "_fix_fork_triggerable_ai_refactor",
+        "fork_triggerable_a5c_agent_with_repo_write": "_fix_fork_triggerable_a5c",
+        "fork_triggerable_iflow_agent_with_prompt": "_fix_fork_triggerable_iflow",
+        "fork_triggerable_sweep_agent_with_repo_write": "_fix_fork_triggerable_sweep",
+        "fork_triggerable_pr_agent_with_repo_write": "_fix_fork_triggerable_pr_agent",
+        "fork_reachable_gitlab_ci_agent_with_write_or_exec": "_fix_fork_reachable_gitlab_ci_agent",
     }
 
     def generate_ai_ml_security_fix(self, rule_id: str, code_snippet: str) -> str:
@@ -962,6 +979,422 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
             "contents: write reads an untrusted issue/PR comment as its prompt and "
             "auto-approves shell and file-edit tools, reaching command execution and "
             "code push under GITHUB_TOKEN and the runner's credentials.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_gemini_cli(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Gate the Gemini CLI agent on repository write access, keep review\n"
+            "# jobs read-only, and drop --yolo / --approval-mode=yolo so tools never\n"
+            "# auto-run on untrusted issue/PR content.\n"
+            "jobs:\n"
+            "  gemini:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - env:\n"
+            "          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}\n"
+            '        run: gemini --approval-mode default -p "Review only."'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Gemini CLI run in --yolo / --approval-mode=yolo mode with "
+            "repository write reads untrusted issue/PR content as its prompt and can push "
+            "code under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_codemie(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# CodeMie has no built-in author gate. Gate the job on repository write\n"
+            "# access and keep it read-only unless a maintainer triggered it; have the\n"
+            "# agent open a PR for human review rather than pushing.\n"
+            "jobs:\n"
+            "  codemie:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.issue.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable CodeMie agent with contents: write reads an untrusted "
+            "issue/PR body as its instructions and can commit under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_devin(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Devin has no built-in author gate. Gate the job on repository write\n"
+            "# access, keep review jobs read-only, and have Devin open a PR for human\n"
+            "# review instead of pushing to the checked-out branch.\n"
+            "jobs:\n"
+            "  devin:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Devin agent with contents: write reads untrusted "
+            "issue/PR content as its task and can push under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_kilocode(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Kilo Code has no built-in author gate. Gate the job on repository write\n"
+            "# access and keep it read-only for untrusted runs; have it open a PR for\n"
+            "# human review rather than pushing.\n"
+            "jobs:\n"
+            "  kilocode:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Kilo Code agent with contents: write reads untrusted "
+            "issue/PR content as its instructions and can commit under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_bespoke_llm(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Do not feed untrusted issue/PR content into a hand-built LLM call whose\n"
+            "# output is applied in a write-capable job. Keep the job read-only and have\n"
+            "# it comment, or gate on repository write access and open a PR for review.\n"
+            "jobs:\n"
+            "  agent:\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write\n"
+            "    steps:\n"
+            "      - env:\n"
+            "          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}\n"
+            "        run: |\n"
+            "          # Summarise trusted repo content only; never execute or commit\n"
+            "          # the model output. Post a review comment for a human to act on.\n"
+            "          ./review-only.sh"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable bespoke LLM agent - a curl/script POSTing untrusted "
+            "event content to a chat-completions endpoint and applying the response - "
+            "in a write-capable job can drive commits under GITHUB_TOKEN via prompt "
+            "injection.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_shell_exec(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# An agent handed an arbitrary shell in a fork-reachable job that carries a\n"
+            "# long-lived secret can exfiltrate it. Remove --dangerously-skip-permissions\n"
+            "# / --yolo / broad --allowedTools, keep the long-lived secret off the job,\n"
+            "# and gate on repository write access.\n"
+            "jobs:\n"
+            "  agent:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            '      - run: agent --allowedTools Read,Grep,Glob "Review only."'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-reachable job that hands an agent an arbitrary shell while carrying a "
+            "secrets.* credential lets an injected prompt read and exfiltrate that "
+            "long-lived secret.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_junie(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Passing a custom prompt input to Junie disables its built-in write-access\n"
+            "# gate. Drop the custom prompt and rely on the default @junie-agent mention\n"
+            "# flow, or gate the job explicitly on repository write access.\n"
+            "jobs:\n"
+            "  junie:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "    steps:\n"
+            "      - uses: JetBrains/junie-github-action@v1\n"
+            "        with:\n"
+            "          junie_api_key: ${{ secrets.JUNIE_API_KEY }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A custom prompt input bypasses Junie's documented write-access self-gate, so "
+            "on a fork-reachable trigger untrusted PR/issue content drives a write-capable "
+            "agent.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_bonk(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Bonk's installation token defaults to full write. Restrict triggers to\n"
+            "# trusted actors with the action's permissions input, or drop repo write\n"
+            "# with token_permissions: NO_PUSH.\n"
+            "jobs:\n"
+            "  bonk:\n"
+            "    if: contains(github.event.comment.body, '/bonk')\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "    steps:\n"
+            "      - uses: ask-bonk/ask-bonk/github@main\n"
+            "        with:\n"
+            "          permissions: CODEOWNERS\n"
+            "          token_permissions: NO_PUSH"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-reachable Bonk step with its default writable token and no "
+            "maintainer/CODEOWNERS gate lets any fork contributor drive a write-capable "
+            "agent.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_cogni(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Cogni has no built-in author gate. Gate the job on repository write\n"
+            "# access, keep review runs read-only, and have it open a PR for human\n"
+            "# review rather than committing.\n"
+            "jobs:\n"
+            "  cogni:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Cogni agent with contents: write reads an untrusted "
+            "issue/PR/comment body as its prompt and can commit under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_letta(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Setting allowed_non_write_users/allowed_bots to '*' disables Letta's\n"
+            "# built-in write-access gate. Remove it and rely on the default self-gate\n"
+            "# (only collaborators with write access can trigger it).\n"
+            "jobs:\n"
+            "  letta:\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "    steps:\n"
+            "      - uses: letta-ai/letta-code-action@v0\n"
+            "        with:\n"
+            "          letta_api_key: ${{ secrets.LETTA_API_KEY }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "Opening the Letta Code agent to non-write users (allowed_non_write_users: "
+            "'*') lets any fork contributor drive a shell- and commit-capable agent.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_code_agent(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# code-agent's only guard is sender.type != 'Bot', which a fork contributor\n"
+            "# satisfies. Gate the job on repository write access and keep it read-only\n"
+            "# for untrusted runs; have it open a PR for human review.\n"
+            "jobs:\n"
+            "  code-agent:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable code-agent (Claude Code / Codex wrapper) with contents: "
+            "write reads untrusted issue/PR content as its instructions and can commit "
+            "under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_ai_refactor(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Do not run the AI refactor agent in an edit mode (mode: pr) on untrusted\n"
+            "# PR content in a write-capable job. Keep review runs read-only, or gate on\n"
+            "# repository write access and open a PR for human review rather than pushing.\n"
+            "jobs:\n"
+            "  ai-refactor:\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: cognitivecomputations/ai-github-action@v1\n"
+            "        with:\n"
+            '          instructions: "review only"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable AI refactor agent in an edit mode with contents: write "
+            "rewrites and pushes the checked-out fork branch under GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_a5c(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# a5c routes untrusted PR/issue content to a coding agent. Gate the job on\n"
+            "# repository write access and scope the dispatched agent to read-only for\n"
+            "# untrusted runs, handing any commit to a separate reviewed job.\n"
+            "jobs:\n"
+            "  a5c:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable a5c agent router with write permissions dispatches a "
+            "coding agent on untrusted PR/issue content that can commit under "
+            "GITHUB_TOKEN.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_iflow(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Do not pipe untrusted issue/PR/comment content into the iFlow CLI action's\n"
+            "# prompt input in a write-capable job. Gate on repository write access and\n"
+            "# have the agent open a PR for human review.\n"
+            "jobs:\n"
+            "  iflow:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: iflow-ai/iflow-cli-action@v2\n"
+            "        with:\n"
+            "          api_key: ${{ secrets.IFLOW_API_KEY }}\n"
+            '          prompt: "Review only."'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable iFlow CLI agent driven by an untrusted prompt in a "
+            "write-capable job can commit and open PRs under GITHUB_TOKEN via prompt "
+            "injection.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_sweep(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Trigger Sweep only from the maintainer-controlled Sweep label - only users\n"
+            "# with write access can label - not from an outside-author-controllable\n"
+            "# issue title/body prefix.\n"
+            "jobs:\n"
+            "  sweep:\n"
+            "    if: github.event.label.name == 'sweep'\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "      pull-requests: write\n"
+            "    steps:\n"
+            "      - uses: sweepai/sweep-action@v1"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Sweep agent triggered by an outside-author-controllable "
+            "issue prefix with repository write reads an untrusted issue as its task and "
+            "opens a PR under the app's permissions.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_pr_agent(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# A sender.type != 'Bot' check does not gate outside human PR authors. Gate\n"
+            "# the job on repository write access and scope PR-Agent to read-only\n"
+            "# review/describe tools for untrusted runs.\n"
+            "jobs:\n"
+            "  pr_agent_job:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      pull-requests: write\n"
+            "    steps:\n"
+            "      - uses: qodo-ai/pr-agent@main\n"
+            "        env:\n"
+            "          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable PR-Agent with repository-mutating tools (/improve "
+            "commitable suggestions) reads an untrusted PR body/comment as its "
+            "instructions and can mutate the PR via prompt injection.",
+            secure_fix,
+        )
+
+    def _fix_fork_reachable_gitlab_ci_agent(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# .gitlab-ci.yml -- refuse fork-sourced merge requests, restrict the agent\n"
+            "# to read-only tools when it only reviews, and mark the token as Protected\n"
+            "# so it is never exposed to fork pipelines.\n"
+            "claude-review:\n"
+            "  rules:\n"
+            '    - if: \'$CI_PIPELINE_SOURCE == "merge_request_event" && '
+            "$CI_MERGE_REQUEST_SOURCE_PROJECT_ID != $CI_PROJECT_ID'\n"
+            "      when: never\n"
+            "    - if: '$CI_PIPELINE_SOURCE == \"merge_request_event\"'\n"
+            "  script:\n"
+            "    - npm install -g @anthropic-ai/claude-code\n"
+            '    - claude -p "Review MR !${CI_MERGE_REQUEST_IID}" --allowedTools "Read,Grep,Glob"'
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A merge-request pipeline runs in the context that owns the agent's write "
+            "credentials, so an untrusted diff can drive a write/execute-capable agent "
+            "via prompt injection unless a fork guard refuses fork-sourced merge "
+            "requests.",
             secure_fix,
         )
 

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -32,24 +32,41 @@ rules_by_category:
     - azure_ml_access
     - azure_openai_key
     - cohere_api_key
+    - fork_reachable_gitlab_ci_agent_with_write_or_exec
+    - fork_triggerable_a5c_agent_with_repo_write
+    - fork_triggerable_agent_shell_exec_secret_exposure
     - fork_triggerable_ai_agent_with_repo_mutating_gh_tools
     - fork_triggerable_ai_agent_with_write_or_exec_tools
+    - fork_triggerable_ai_github_action_with_repo_write
     - fork_triggerable_aider_agent_with_repo_write
     - fork_triggerable_amp_agent_with_repo_write
+    - fork_triggerable_bespoke_llm_agent_with_repo_write
+    - fork_triggerable_bonk_agent_with_write_token
     - fork_triggerable_claude_cli_agent_with_repo_write
+    - fork_triggerable_code_agent_with_repo_write
+    - fork_triggerable_codemie_agent_with_repo_write
     - fork_triggerable_codex_agent_with_write_or_exec_sandbox
+    - fork_triggerable_cogni_agent_with_repo_write
     - fork_triggerable_continue_cli_agent_with_repo_write
     - fork_triggerable_copilot_cli_agent_with_repo_write
     - fork_triggerable_crush_agent_with_repo_write
     - fork_triggerable_cursor_agent_with_repo_write
+    - fork_triggerable_devin_agent_with_repo_write
     - fork_triggerable_droid_agent_with_repo_write
+    - fork_triggerable_gemini_cli_agent_with_repo_write
     - fork_triggerable_gemini_or_copilot_agent_with_write_or_exec
     - fork_triggerable_goose_agent_with_repo_write
     - fork_triggerable_gptme_agent_with_repo_write
+    - fork_triggerable_iflow_agent_with_prompt
+    - fork_triggerable_junie_agent_with_prompt_bypass
+    - fork_triggerable_kilocode_agent_with_repo_write
+    - fork_triggerable_letta_agent_opened_to_forks
     - fork_triggerable_opencode_agent_with_repo_write
     - fork_triggerable_openhands_agent_with_repo_write
+    - fork_triggerable_pr_agent_with_repo_write
     - fork_triggerable_qwen_code_agent_with_repo_write
     - fork_triggerable_swe_agent_with_repo_write
+    - fork_triggerable_sweep_agent_with_repo_write
     - fork_triggerable_warp_agent_with_repo_write
     - gcp_vertex_ai_access
     - generic_llm_api_key

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -6030,6 +6030,338 @@
                       --dangerously-skip-permissions
                     git push origin HEAD
 
+    # --- ai_ml_security.yml: fork_triggerable_gemini_cli_agent_with_repo_write ---
+    - name: trigger fork_triggerable_gemini_cli_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/gemini-cli-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            gemini:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - env:
+                    GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                    TASK: ${{ github.event.comment.body }}
+                  run: |
+                    gemini --yolo --prompt "$TASK"
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_codemie_agent_with_repo_write ---
+    - name: trigger fork_triggerable_codemie_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/codemie-agent.yml
+        content: |
+          on:
+            issues:
+              types: [opened]
+          jobs:
+            codemie:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - env:
+                    TASK: ${{ github.event.issue.body }}
+                  run: |
+                    npm install -g @codemieai/code
+                    codemie run "$TASK"
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_devin_agent_with_repo_write ---
+    - name: trigger fork_triggerable_devin_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/devin-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            devin:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: aaronsteers/devin-action@v1
+                  with:
+                    devin-token: ${{ secrets.DEVIN_TOKEN }}
+                    prompt-text: ${{ github.event.comment.body }}
+                - run: git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_kilocode_agent_with_repo_write ---
+    - name: trigger fork_triggerable_kilocode_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/kilocode-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            kilocode:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - env:
+                    TASK: ${{ github.event.comment.body }}
+                  run: |
+                    kilocode run --yolo "$TASK"
+                    git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_bespoke_llm_agent_with_repo_write ---
+    - name: trigger fork_triggerable_bespoke_llm_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/bespoke-llm-agent.yml
+        content: |
+          on:
+            issues:
+              types: [opened]
+          jobs:
+            agent:
+              permissions:
+                contents: write
+              steps:
+                - uses: actions/checkout@v4
+                - env:
+                    LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+                    TASK: ${{ github.event.issue.body }}
+                  run: |
+                    RESP=$(curl -s https://api.openai.com/v1/chat/completions \
+                      -H "Authorization: Bearer $LLM_API_KEY" \
+                      -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$TASK\"}]}")
+                    echo "$RESP" | node apply-ops.js
+                    git add . && git commit -m fix && git push origin HEAD
+
+    # --- ai_ml_security.yml: fork_triggerable_agent_shell_exec_secret_exposure ---
+    - name: trigger fork_triggerable_agent_shell_exec_secret_exposure
+      ansible.builtin.copy:
+        dest: .github/workflows/shell-exec-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            triage:
+              permissions:
+                contents: read
+              steps:
+                - env:
+                    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+                    DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+                    TASK: ${{ github.event.comment.body }}
+                  run: |
+                    claude -p "Triage: $TASK" --dangerously-skip-permissions
+
+    # --- ai_ml_security.yml: fork_triggerable_junie_agent_with_prompt_bypass ---
+    - name: trigger fork_triggerable_junie_agent_with_prompt_bypass
+      ansible.builtin.copy:
+        dest: .github/workflows/junie-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            junie:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: JetBrains/junie-github-action@v1
+                  with:
+                    junie_api_key: ${{ secrets.JUNIE_API_KEY }}
+                    prompt: ${{ github.event.comment.body }}
+
+    # --- ai_ml_security.yml: fork_triggerable_bonk_agent_with_write_token ---
+    - name: trigger fork_triggerable_bonk_agent_with_write_token
+      ansible.builtin.copy:
+        dest: .github/workflows/bonk-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            bonk:
+              if: contains(github.event.comment.body, '/bonk')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: ask-bonk/ask-bonk/github@main
+                  with:
+                    model: opencode/claude-opus-4-5
+
+    # --- ai_ml_security.yml: fork_triggerable_cogni_agent_with_repo_write ---
+    - name: trigger fork_triggerable_cogni_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/cogni-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            cogni:
+              permissions:
+                contents: write
+                issues: write
+              steps:
+                - uses: Cogni-AI-OU/cogni-ai-agent-action@main
+                  with:
+                    prompt: ${{ github.event.comment.body }}
+
+    # --- ai_ml_security.yml: fork_triggerable_letta_agent_opened_to_forks ---
+    - name: trigger fork_triggerable_letta_agent_opened_to_forks
+      ansible.builtin.copy:
+        dest: .github/workflows/letta-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            letta:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: letta-ai/letta-code-action@v0
+                  with:
+                    letta_api_key: ${{ secrets.LETTA_API_KEY }}
+                    allowed_non_write_users: "*"
+
+    # --- ai_ml_security.yml: fork_triggerable_code_agent_with_repo_write ---
+    - name: trigger fork_triggerable_code_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/code-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            code-agent:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: potproject/code-agent@main
+                  with:
+                    anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    # --- ai_ml_security.yml: fork_triggerable_ai_github_action_with_repo_write ---
+    - name: trigger fork_triggerable_ai_github_action_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/ai-refactor.yml
+        content: |
+          on:
+            pull_request:
+              types: [opened, synchronize]
+          jobs:
+            ai-refactor:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: cognitivecomputations/ai-github-action@v1
+                  with:
+                    mode: "pr"
+                    instructions: "refactor"
+
+    # --- ai_ml_security.yml: fork_triggerable_a5c_agent_with_repo_write ---
+    - name: trigger fork_triggerable_a5c_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/a5c-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            a5c:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: a5c-ai/action@main
+                  with:
+                    anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    # --- ai_ml_security.yml: fork_triggerable_iflow_agent_with_prompt ---
+    - name: trigger fork_triggerable_iflow_agent_with_prompt
+      ansible.builtin.copy:
+        dest: .github/workflows/iflow-agent.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            iflow:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: iflow-ai/iflow-cli-action@v2
+                  with:
+                    api_key: ${{ secrets.IFLOW_API_KEY }}
+                    prompt: ${{ github.event.comment.body }}
+
+    # --- ai_ml_security.yml: fork_triggerable_sweep_agent_with_repo_write ---
+    - name: trigger fork_triggerable_sweep_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/sweep-agent.yml
+        content: |
+          on:
+            issues:
+              types: [opened, edited]
+          jobs:
+            sweep:
+              if: startsWith(github.event.issue.title, 'Sweep:')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: sweepai/sweep-action@v1
+                  with:
+                    github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # --- ai_ml_security.yml: fork_triggerable_pr_agent_with_repo_write ---
+    - name: trigger fork_triggerable_pr_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/pr-agent.yml
+        content: |
+          on:
+            pull_request:
+              types: [opened, reopened]
+            issue_comment:
+          jobs:
+            pr_agent_job:
+              if: ${{ github.event.sender.type != 'Bot' }}
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: qodo-ai/pr-agent@main
+                  env:
+                    OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # --- ai_ml_security.yml: fork_reachable_gitlab_ci_agent_with_write_or_exec ---
+    - name: trigger fork_reachable_gitlab_ci_agent_with_write_or_exec
+      ansible.builtin.copy:
+        dest: gitlab-ci-agent.yml
+        content: |
+          ai-review:
+            stage: review
+            image: node:22
+            rules:
+              - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+            script:
+              - npm install -g @anthropic-ai/claude-code
+              - |
+                claude -p "Review MR !${CI_MERGE_REQUEST_IID} using PRIVATE-TOKEN $REVIEW_TOKEN" \
+                  --permission-mode acceptEdits \
+                  --allowedTools "Bash Read Edit Write"
+
     # --- supply_chain.yml: mini_shai_hulud_poisoned_package_version_install ---
     - name: trigger mini_shai_hulud_poisoned_package_version_install
       ansible.builtin.pip:


### PR DESCRIPTION
Adds 17 detection rules for fork-triggerable AI coding agents with repository write or shell access:

- Gemini CLI, CodeMie, Devin, Kilo Code, Junie, Bonk, Cogni, Letta, code-agent, AI refactor, a5c, iFlow, Sweep, PR-Agent
- Bespoke LLM agents (raw completions/messages endpoint fed untrusted event payloads)
- Shell-exec secret exposure (agent given an arbitrary shell in a secret-bearing job)
- GitLab CI agents on merge-request pipelines

Each rule has a tailored remediation and a triggering fixture in bad_example.yml. Existing copilot_cli regex widened for parity. Full test suite passes.