### PR TITLE
Detect more fork-triggerable AI agents and make SSM fixes specific

### DIFF
--- a/.hugo/scripts/build_docs.py
+++ b/.hugo/scripts/build_docs.py
@@ -275,7 +275,7 @@ _LEADING_HTML_H1_RE = re.compile(
     re.DOTALL | re.IGNORECASE,
 )
 _LEADING_HERO_BLOCK_RE = re.compile(
-    r"\A\s*<(p|div)\b[^>]*>\s*<picture\b.*?</picture>\s*</\1>\s*\n+",
+    r"\A\s*<(p|div)\b[^>]*>\s*(?:<a\b[^>]*>\s*)?(?:<picture\b.*?</picture>|<img\b[^>]*/?>)\s*(?:</a>\s*)?</\1>\s*\n+",
     re.DOTALL | re.IGNORECASE,
 )
 _LEADING_HR_RE = re.compile(r"\A\s*<hr\b[^>]*/?>\s*\n+", re.IGNORECASE)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <div align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/brand-mark.svg">
-    <img src="docs/assets/brand-mark-light.svg" alt="Ansible Security Scanner" width="560">
-  </picture>
+  <a href="https://github.com/cpeoples/ansible-security-scanner">
+    <img src="https://raw.githubusercontent.com/cpeoples/ansible-security-scanner/main/docs/assets/brand-mark-light.png" alt="Ansible Security Scanner" width="560">
+  </a>
 </div>
 <!-- BADGES_START - stripped from the Hugo docs build; see .hugo/scripts/build_docs.py -->
 <p align="center">
@@ -96,7 +95,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/cpeoples/ansible-security-scanner
-    rev: v0.1.37
+    rev: v0.1.38
     hooks:
       - id: ansible-security-scanner
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cpeoples/ansible-security-scanner@v0.1.36
+      - uses: cpeoples/ansible-security-scanner@v0.1.38
         with:
           path: ansible
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/cpeoples/ansible-security-scanner
-    rev: v0.1.34
+    rev: v0.1.37
     hooks:
       - id: ansible-security-scanner
 ```
@@ -105,6 +105,32 @@ Two hook IDs are exposed:
 
 - `ansible-security-scanner` — scans only the staged YAML / `*.j2` / `*.cfg` files. Runs on every commit.
 - `ansible-security-scanner-all` — scans the full repository tree. Wired to the `pre-push` and `manual` stages so it doesn't fire on every commit; trigger it with `pre-commit run --hook-stage pre-push ansible-security-scanner-all` or in CI.
+
+### GitHub Actions
+
+Scan on every push and pull request and surface findings inline in the Security
+tab and on the PR diff:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cpeoples/ansible-security-scanner@v0.1.36
+        with:
+          path: ansible
+```
+
+The action installs the pinned release, scans, and uploads SARIF to code
+scanning. Set `fail-on-findings: false` to report without failing the build, or
+`upload-sarif: false` with a `format:` of your choice to write another report
+type. See [CI/CD integration](docs/ci-cd.md) for the raw-CLI form and other
+platforms.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/cpeoples/ansible-security-scanner/actions/workflows/pip-audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/cpeoples/ansible-security-scanner/pip-audit.yml?branch=main&label=pip-audit&style=flat-square&logo=python&logoColor=white" alt="pip-audit" /></a>&nbsp;&nbsp;
   <a href="https://owasp.org/www-community/Source_Code_Analysis_Tools"><img src="https://img.shields.io/badge/OWASP-Listed-000000?style=flat-square&logo=owasp&logoColor=white" alt="OWASP Listed" /></a>&nbsp;&nbsp;
   <a href="https://github.com/ansible-community/awesome-ansible#tools"><img src="https://img.shields.io/badge/Awesome-Ansible-fc60a8?style=flat-square&logo=awesomelists&logoColor=white" alt="Listed on Awesome Ansible" /></a>&nbsp;&nbsp;
-  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1161-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
+  <a href="src/ansible_security_scanner/patterns"><img src="https://img.shields.io/badge/Rules-1165-blue?style=flat-square&logo=ansible&logoColor=white" alt="Rules" /></a>&nbsp;&nbsp;
   <a href="https://pypi.org/project/ansible-security-scanner/"><img src="https://img.shields.io/pypi/v/ansible-security-scanner?style=flat-square&logo=pypi&logoColor=white&label=PyPI" alt="PyPI" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SLSA-Level%203-success?style=flat-square&logo=slsa&logoColor=white" alt="SLSA Build Level 3" /></a>&nbsp;&nbsp;
   <a href="https://github.com/cpeoples/ansible-security-scanner/releases/latest"><img src="https://img.shields.io/badge/SBOM-CycloneDX-success?style=flat-square&logo=cyclonedx&logoColor=white" alt="CycloneDX SBOM" /></a>&nbsp;&nbsp;
@@ -23,9 +23,9 @@
 
 Static SAST scanner for Ansible playbooks, roles, collections, task files, vars, and inventories. Detects malicious code, RCE, command and template injection, hardcoded credentials, supply-chain risk, unauthorized cloud access, lateral movement, and reverse shells. Outputs SARIF, CycloneDX SBOM, GitLab SAST, JUnit, JSON, HTML, and Markdown reports with remediation guidance. Findings map to CWE, OWASP Top 10, OWASP ASVS, MITRE ATT&CK, NIST, and CIS. CI-native, autofix-capable, DevSecOps-ready.
 
-**<!--RULES-->1161<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
+**<!--RULES-->1165<!--/RULES--> rules** across **<!--CATS-->31<!--/CATS--> categories** -- all auto-discovered from YAML pattern plugins.
 
-**<!--CRIT-->456<!--/CRIT--> critical**, <!--HIGH-->551<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
+**<!--CRIT-->460<!--/CRIT--> critical**, <!--HIGH-->551<!--/HIGH--> high, <!--MED-->134<!--/MED--> medium, <!--LOW-->19<!--/LOW--> low. [Per-category breakdown on the dashboard.](https://cpeoples.github.io/ansible-security-scanner/dashboard/)
 
 > [!NOTE]
 > **Scope.** This is a *static, pattern-based* scanner - one layer in a defense-in-depth strategy. Pair it with the runtime controls you already trust (AAP/AWX approval gates, execution-environment lockdown, network egress policy, code review) for full coverage. See [Limitations](docs/limitations.md) for the specific classes of issue this layer cannot catch on its own.
@@ -158,7 +158,7 @@ installed CLI - it's a thin shim around the same entry point.
 
 ## What it detects
 
-The scanner ships <!--RULES-->1161<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
+The scanner ships <!--RULES-->1165<!--/RULES--> rules across <!--CATS-->31<!--/CATS--> auto-discovered categories. Highlights:
 
 **Malicious code and post-exploitation**
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,139 @@
+name: Ansible Security Scanner
+description: Scan Ansible playbooks, roles, and CI workflows for malicious code, injection, secrets, and supply-chain risk.
+author: cpeoples
+branding:
+  icon: shield
+  color: blue
+
+inputs:
+  path:
+    description: Directory to scan.
+    required: false
+    default: .
+  files:
+    description: Space-separated list of specific files to scan instead of a directory.
+    required: false
+    default: ""
+  version:
+    description: >-
+      ansible-security-scanner release to install (e.g. 0.1.36). Defaults to the
+      tag this action was called at, falling back to the latest PyPI release.
+    required: false
+    default: ""
+  format:
+    description: >-
+      Report format: sarif, json, markdown, html, junit, csv, xml, yaml,
+      gl-sast, cyclonedx. Forced to sarif when upload-sarif is true.
+    required: false
+    default: sarif
+  output:
+    description: Path to write the report to. Defaults to scan-results.<ext>.
+    required: false
+    default: ""
+  severity:
+    description: Only report findings at or above this severity (CRITICAL, HIGH, MEDIUM, LOW).
+    required: false
+    default: ""
+  select:
+    description: Comma-separated rule-id globs to scan for exclusively.
+    required: false
+    default: ""
+  ignore:
+    description: Comma-separated rule-id globs to suppress.
+    required: false
+    default: ""
+  upload-sarif:
+    description: >-
+      Upload the SARIF report to GitHub code scanning so findings appear inline
+      on pull requests. Requires security-events: write.
+    required: false
+    default: "true"
+  fail-on-findings:
+    description: Fail the step when the scanner reports a HIGH or CRITICAL finding.
+    required: false
+    default: "true"
+
+outputs:
+  exit-code:
+    description: Scanner exit code (0 clean, 1 HIGH findings, 2 CRITICAL findings).
+    value: ${{ steps.scan.outputs.exit-code }}
+  report:
+    description: Path to the written report.
+    value: ${{ steps.scan.outputs.report }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install ansible-security-scanner
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        set -euo pipefail
+
+        version="${INPUT_VERSION:-$ACTION_REF}"
+        case "$version" in
+          v[0-9]*) spec="ansible-security-scanner==${version#v}" ;;
+          [0-9]*)  spec="ansible-security-scanner==${version}" ;;
+          *)       spec="ansible-security-scanner" ;;
+        esac
+
+        python3 -m pip install --disable-pip-version-check "$spec"
+
+    - name: Scan
+      id: scan
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_FILES: ${{ inputs.files }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_SEVERITY: ${{ inputs.severity }}
+        INPUT_SELECT: ${{ inputs.select }}
+        INPUT_IGNORE: ${{ inputs.ignore }}
+        UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+        FAIL_ON_FINDINGS: ${{ inputs.fail-on-findings }}
+      run: |
+        set -uo pipefail
+
+        format="$INPUT_FORMAT"
+        [ "$UPLOAD_SARIF" = "true" ] && format=sarif
+
+        report="$INPUT_OUTPUT"
+        if [ -z "$report" ]; then
+          case "$format" in
+            sarif) ext=sarif ;;
+            gl-sast) ext=json ;;
+            cyclonedx) ext=cdx.json ;;
+            markdown) ext=md ;;
+            *) ext="$format" ;;
+          esac
+          report="scan-results.${ext}"
+        fi
+
+        args=(--directory "$INPUT_PATH" --format "$format" --output "$report")
+        [ -n "$INPUT_FILES" ] && args+=(--files $INPUT_FILES)
+        [ -n "$INPUT_SEVERITY" ] && args+=(--severity "$INPUT_SEVERITY")
+        [ -n "$INPUT_SELECT" ] && args+=(--select "$INPUT_SELECT")
+        [ -n "$INPUT_IGNORE" ] && args+=(--ignore "$INPUT_IGNORE")
+        [ "$FAIL_ON_FINDINGS" = "true" ] || args+=(--exit-zero)
+
+        ansible-security-scanner "${args[@]}"
+        code=$?
+
+        echo "exit-code=${code}" >> "$GITHUB_OUTPUT"
+        echo "report=${report}" >> "$GITHUB_OUTPUT"
+
+        if [ "$FAIL_ON_FINDINGS" = "true" ] && [ "$code" -ne 0 ]; then
+          echo "::error::ansible-security-scanner reported findings; see ${report}"
+          exit "$code"
+        fi
+        exit 0
+
+    - name: Upload SARIF to code scanning
+      if: always() && inputs.upload-sarif == 'true'
+      uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81  # v4.37.3
+      with:
+        sarif_file: ${{ steps.scan.outputs.report }}
+        category: ansible-security-scanner

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -22,6 +22,26 @@ ansible_security_scan:
 
 ## GitHub Actions
 
+The published action installs the pinned release, scans, and uploads SARIF to
+code scanning in one step:
+
+```yaml
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cpeoples/ansible-security-scanner@v0.1.37
+        with:
+          path: ansible
+```
+
+To run the CLI directly instead of the action:
+
 ```yaml
 - uses: actions/setup-python@v5
   with:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cpeoples/ansible-security-scanner@v0.1.37
+      - uses: cpeoples/ansible-security-scanner@v0.1.38
         with:
           path: ansible
 ```

--- a/src/ansible_security_scanner/comment/rendering.py
+++ b/src/ansible_security_scanner/comment/rendering.py
@@ -67,10 +67,14 @@ _AUTO_EXPAND_FINDING_THRESHOLD = 3
 # largest ignore list we render as a comma-separated blockquote; above
 # it we group by category. ``_IGNORE_HARD_CAP`` bounds the number of
 # rule names we'll print in the grouped form before collapsing the
-# tail into a top-categories summary - guards against pathologically
-# broad globs (``*`` against ~1k rules) blowing up the comment.
+# tail into a top-categories summary. The grouped form lives inside a
+# collapsed ``<details>``, so it costs no visible space until expanded;
+# the cap only exists to keep a pathologically broad glob (``*`` against
+# the full ~1.1k-rule set) from pushing the raw comment past the
+# platform's body-size limit. It is set well above any realistic
+# hand-authored ignore list so normal policies list every rule.
 _IGNORE_FLAT_LIMIT = 8
-_IGNORE_HARD_CAP = 60
+_IGNORE_HARD_CAP = 250
 _IGNORE_TOP_CATEGORIES = 5
 
 # Severity weights used when ranking "top rules". Matches the scanner's

--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -981,6 +981,12 @@ _FORK_TRIGGERABLE_AI_RULE_IDS: frozenset[str] = frozenset(
         "fork_triggerable_iflow_agent_with_prompt",
         "fork_triggerable_sweep_agent_with_repo_write",
         "fork_triggerable_pr_agent_with_repo_write",
+        # Skyramp Testbot, CodeScene's refactoring agent, and Tend all anchor on
+        # their action slug and self-gate only on a comment mention / an
+        # ungated ``pull_request_target``, which is not an authorization check.
+        "fork_triggerable_skyramp_testbot_with_repo_write",
+        "fork_triggerable_codescene_refactor_agent_with_repo_write",
+        "fork_triggerable_tend_agent_with_repo_write",
     }
 )
 _FORK_REACHABLE_TRIGGERS: tuple[str, ...] = (
@@ -1186,6 +1192,40 @@ _JOB_SECRET_IN_ENV = re.compile(
     re.IGNORECASE,
 )
 
+# ``fork_triggerable_ai_inference_agent_with_repo_write`` anchors on the neutral
+# ``actions/ai-inference`` step, which only returns model text - it holds no
+# tools and pushes nothing itself. The anchor alone over-fires: many deployments
+# hold ``contents: write`` yet only post the reply as a comment, set a label, or
+# PATCH a Release body, and some are trusted-input release-notes generators. So
+# the finding survives only when two whole-file proofs also hold on top of the
+# fork-reachable + write-capable + ungated gating: the reply is applied as repo
+# code / pushed (``_AI_INFERENCE_APPLY``) and untrusted event text reaches the
+# model (``_AI_INFERENCE_UNTRUSTED``).
+_AI_INFERENCE_RULE_ID = "fork_triggerable_ai_inference_agent_with_repo_write"
+# The model's reply is applied as repository code or pushed: written to a source
+# file, ``git apply``/``commit``/``push``-ed, or opened as a PR via a commit
+# action. A summarizer that only posts the reply as a comment, sets a label, or
+# PATCHes a Release body matches none of these.
+_AI_INFERENCE_APPLY = re.compile(
+    r"git\s+apply\b|git\s+(?:-c\s+\S+\s+)?commit\b|git\s+push\b|create-pull-request"
+    r"|peter-evans/create-pull-request|stefanzweifel/git-auto-commit|EndBug/add-and-commit"
+    r"|gh\s+pr\s+create\b"
+    r"|>\s*[^\n]*\.(?:patch|diff|py|js|ts|tsx|jsx|go|rs|java|kt|c|cc|cpp|h|hpp|rb|php|sh|bash|yml|yaml|json|toml|md)\b",
+    re.IGNORECASE,
+)
+# Untrusted input can reach the model: attacker-controlled event text is
+# interpolated somewhere in the file (issue/PR/comment/review body or title), or
+# the job checks out a fork-controlled ref (a ``workflow_run`` self-heal reads
+# the failed run's ``head_branch``/``head_sha``; a fork PR head checkout is the
+# same). A trusted-input release-notes generator matches none of these.
+_AI_INFERENCE_UNTRUSTED = re.compile(
+    r"github\.event\.(?:issue|comment|pull_request|review)\.(?:body|title)"
+    r"|github\.event\.pull_request\.head\.(?:ref|label|sha)"
+    r"|github\.event\.issue\.user\.login|github\.event\.comment\.user"
+    r"|github\.event\.workflow_run\.head_(?:branch|sha)|refs/pull/[^/\s]+/(?:head|merge)",
+    re.IGNORECASE,
+)
+
 # ``fork_reachable_gitlab_ci_agent_with_write_or_exec`` scans ``.gitlab-ci.yml``,
 # which has no GitHub ``on:`` block, so the GitHub-Actions fork-reachability and
 # author-gate helpers do not apply. The anchor already requires a write/exec
@@ -1269,7 +1309,12 @@ _INSTALLED_AGENT_AUTHOR_GATE = re.compile(
     r"|contains\(\s*github\.event\.label\.name"
     r"|github\.event\.label\.name\s*==|github\.event\.action\s*==\s*['\"]labeled"
     r"|head\.repo\.full_name\s*(?:==|!==|!=)\s*"
-    r"|head\.repo\.fork\b|is_fork\s*(?:==|!=)",
+    r"|head\.repo\.fork\b|is_fork\s*(?:==|!=)"
+    # A run gated to a tag ref cannot be reached by a fork PR head: a fork
+    # contributor cannot push a tag to the base repo. ``startsWith(github.ref,
+    # 'refs/tags/')`` and ``github.ref_type == 'tag'`` are release-style gates.
+    r"|startsWith\(\s*github\.ref\s*,\s*['\"]refs/tags/"
+    r"|github\.ref_type\s*==\s*['\"]tag['\"]",
     re.IGNORECASE,
 )
 
@@ -2199,6 +2244,12 @@ class FileScanner:
             line_findings = self._suppress_shell_exec_secret_exposure_when_safe(
                 line_findings, content
             )
+
+            # Post-filter: the ai-inference rule anchors on the neutral
+            # ``actions/ai-inference`` step. Keep a finding only when the
+            # fork-reachable, ungated, write-capable job both applies the model
+            # reply as code / pushes it and feeds it untrusted event text.
+            line_findings = self._suppress_ai_inference_when_safe(line_findings, content)
 
             # Post-filter: the GitLab-CI agent rule anchors on a write/exec agent
             # invocation in a ``.gitlab-ci.yml`` script but cannot see the
@@ -7525,6 +7576,46 @@ class FileScanner:
             # The exfiltration premise requires a real secret and the *absence*
             # of provable write (write-capable jobs are the CRITICAL rule's).
             if not job_can_write and _JOB_SECRET_IN_ENV.search(job_text):
+                kept.append(f)
+        return kept
+
+    def _suppress_ai_inference_when_safe(
+        self, findings: list[SecurityFinding], content: str
+    ) -> list[SecurityFinding]:
+        """Drop ``fork_triggerable_ai_inference_agent_with_repo_write`` findings
+        that are not actually exploitable.
+
+        ``actions/ai-inference`` is a neutral action - it only returns model
+        text. The anchor cannot see whether the workflow applies that text as
+        code, feeds it untrusted input, is fork-reachable, or is gated. A finding
+        survives only when all hold: the workflow is fork-reachable and ungated,
+        the agent's job can write to the repo, the reply is applied as repo code
+        / pushed (``_AI_INFERENCE_APPLY``), and untrusted event text reaches the
+        model (``_AI_INFERENCE_UNTRUSTED``). A read-only summarizer, a
+        comment/label/Release-body responder, and a trusted-input release-notes
+        generator each miss one of the two proofs and are dropped.
+        """
+        if not findings or not any(f.rule_id == _AI_INFERENCE_RULE_ID for f in findings):
+            return findings
+        if (
+            not _has_fork_reachable_trigger(content)
+            or _INSTALLED_AGENT_AUTHOR_GATE.search(content)
+            or not _AI_INFERENCE_APPLY.search(content)
+            or not _AI_INFERENCE_UNTRUSTED.search(content)
+        ):
+            return [f for f in findings if f.rule_id != _AI_INFERENCE_RULE_ID]
+        lines = content.splitlines()
+        workflow_write = _workflow_level_write(content)
+        kept: list[SecurityFinding] = []
+        for f in findings:
+            if f.rule_id != _AI_INFERENCE_RULE_ID:
+                kept.append(f)
+                continue
+            job_text = _enclosing_job_block(lines, max(f.line_number - 1, 0))
+            job_can_write = bool(_INSTALLED_AGENT_JOB_WRITE.search(job_text)) or (
+                workflow_write and not re.search(r"^\s+permissions\s*:", job_text, re.MULTILINE)
+            )
+            if job_can_write:
                 kept.append(f)
         return kept
 

--- a/src/ansible_security_scanner/patterns/ai_ml_security.yml
+++ b/src/ansible_security_scanner/patterns/ai_ml_security.yml
@@ -2448,18 +2448,22 @@ patterns:
     severity: "CRITICAL"
     title: "Fork-Triggerable Bespoke LLM Agent With Repository Write Access In A Privileged CI Job"
     description: >-
-        A CI job runs a roll-your-own LLM agent - a `curl`/script that POSTs to a chat-completions /
-        messages endpoint (`/v1/chat/completions`, `/v1/messages`, `api.openai.com/v1`,
-        `api.anthropic.com/v1`, `generativelanguage.googleapis.com`, DashScope's `/compatible-mode/v1`,
-        Zhipu's `/api/paas/v4`) and applies the model's output - on a fork-reachable trigger, in a job
-        that can mutate the repository. Naming the API shape rather than a vendor is what lets an
-        unnamed, hand-built agent match. The rule fires only when the file also carries an untrusted
-        event payload (`github.event.issue.body`, `pull_request.title`, `comment.body`, etc.) flowing
-        into that call, the job is fork-reachable and write-capable (`contents: write`,
-        `permissions: write-all`, or a `git push` / `gh pr create|merge`), and no author gate is
-        present - so a self-prompted call over trusted repo content, a read-only review bot, or a
-        maintainer-gated job never matches.
-    regex: "(?:/v1/chat/completions|/v1/messages|/v1/completions|/chat/completions|api\\.openai\\.com/v1|api\\.anthropic\\.com/v1|generativelanguage\\.googleapis\\.com|/compatible-mode/v1|/api/paas/v4)"
+        A CI job runs a roll-your-own LLM agent and applies the model's output on a fork-reachable
+        trigger, in a job that can mutate the repository. The agent takes one of two shapes: a
+        `curl`/script that POSTs to a chat-completions / messages endpoint (`/v1/chat/completions`,
+        `/v1/messages`, `api.openai.com/v1`, `api.anthropic.com/v1`,
+        `generativelanguage.googleapis.com`, DashScope's `/compatible-mode/v1`, Zhipu's
+        `/api/paas/v4`), or an inline `actions/github-script` / `python -c` step that calls the
+        provider SDK directly (`new OpenAI(...)`, `genai.GenerativeModel`, `.generate_content`,
+        `.chat.completions.create`, `.messages.create`, `@anthropic-ai/sdk`), which carries no URL
+        literal. Naming the API shape rather than a vendor is what lets an unnamed, hand-built agent
+        match. The rule fires only when the file also carries an untrusted event payload
+        (`github.event.issue.body`, `pull_request.title`, `comment.body`, etc.) flowing into that
+        call, the job is fork-reachable and write-capable (`contents: write`, `permissions:
+        write-all`, or a `git push` / `gh pr create|merge`), and no author gate is present - so a
+        self-prompted call over trusted repo content, a read-only review bot, or a maintainer-gated
+        job never matches.
+    regex: "(?:/v1/chat/completions|/v1/messages|/v1/completions|/chat/completions|api\\.openai\\.com/v1|api\\.anthropic\\.com/v1|generativelanguage\\.googleapis\\.com|/compatible-mode/v1|/api/paas/v4|new OpenAI\\(|genai\\.configure\\(|genai\\.GenerativeModel\\(|\\.getGenerativeModel\\(|\\.generateContent\\(|\\.generate_content\\(|\\.chat\\.completions\\.create\\(|\\.messages\\.create\\(|@anthropic-ai/sdk|@google/generative-ai)"
     multiline: true
     window: 200
     positive_examples:
@@ -2482,6 +2486,28 @@ patterns:
                         -d "{\"messages\":[{\"role\":\"user\",\"content\":\"$TASK\"}]}")
                       echo "$RESP" | node apply-ops.js
                       git add . && git commit -m fix && git push origin HEAD
+      - |2-
+            on:
+              issues:
+                types: [opened]
+            jobs:
+              coder:
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v4
+                  - env:
+                      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+                      ISSUE_BODY: ${{ github.event.issue.body }}
+                    run: |
+                      python - <<'PY'
+                      import os, google.generativeai as genai
+                      genai.configure(api_key=os.environ['GEMINI_API_KEY'])
+                      m = genai.GenerativeModel('gemini-1.5-flash')
+                      code = m.generate_content(os.environ['ISSUE_BODY']).text
+                      open('out.py','w').write(code)
+                      PY
+                      git add . && git commit -m auto && git push origin HEAD
     negative_examples:
       - |2-
             on:
@@ -3203,6 +3229,284 @@ patterns:
         on repository write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or
         `getCollaboratorPermissionLevel`) and scope the agent to read-only review/describe tools.
         Treat PR/issue content as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_skyramp_testbot_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Skyramp Testbot Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs Skyramp Testbot (`skyramp/testbot`), an Anthropic-backed test-generation
+        agent that checks out the repo and, with `autoCommit: 'true'`, commits and pushes generated
+        tests using a GitHub App token. It has no author-permission check of its own: the observed
+        deployments gate only on the comment body mentioning `@skyramp-testbot`, which any outside
+        commenter can type. On a secret-bearing fork-reachable trigger (`issue_comment`) with
+        `contents: write` and no author gate, an untrusted actor drives a push. This rule anchors on
+        the action use, and the fork-reachable + write-capable + ungated post-filter suppresses the
+        callers that add a real `author_association` / collaborator-permission gate.
+    regex: "skyramp/testbot@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              testbot:
+                if: contains(github.event.comment.body, '@skyramp-testbot')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v6
+                  - uses: skyramp/testbot@v0.10.0
+                    with:
+                      anthropicApiKey: ${{ secrets.SKYRAMP_TESTBOT_API_KEY }}
+                      githubToken: ${{ secrets.GITHUB_TOKEN }}
+                      autoCommit: 'true'
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              testbot:
+                if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v6
+    recommendation: >-
+        Do not run Skyramp Testbot with `autoCommit: 'true'` and repository write on a fork-reachable
+        trigger without an author gate - a `@skyramp-testbot` comment mention is not an authorization
+        check. Gate the job on repository write access (`author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR` or `getCollaboratorPermissionLevel`), or have the bot open a
+        PR for human review instead of pushing. Treat the PR diff and comment content as untrusted
+        data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_codescene_refactor_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable CodeScene Refactoring Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs the CodeScene refactoring agent (`codescene-oss/pr-refactoring-agent`),
+        which reads a PR, refactors the code with an LLM, and commits the result back. It has no
+        author-permission check of its own: the observed deployments gate only on a `/cs-agent`
+        mention in a PR comment, which any outside commenter can type. On the fork-reachable
+        `issue_comment` trigger with `contents: write` and no author gate, an untrusted actor drives
+        a push. This rule anchors on the action use, and the fork-reachable + write-capable + ungated
+        post-filter suppresses the callers that add a real `author_association` /
+        collaborator-permission gate.
+    regex: "codescene-oss/pr-refactoring-agent@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              refactor:
+                if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/cs-agent')
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v4
+                  - uses: codescene-oss/pr-refactoring-agent@bbc72fb
+                    env:
+                      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              refactor:
+                if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v4
+    recommendation: >-
+        Do not run the CodeScene refactoring agent with repository write on a fork-reachable trigger
+        without an author gate - a `/cs-agent` comment mention is not an authorization check. Gate
+        the job on repository write access (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR`
+        or `getCollaboratorPermissionLevel`) and have the agent open a PR for human review rather
+        than committing directly. Treat the PR diff and comment content as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050"]
+
+  - id: "fork_triggerable_tend_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable Tend Autonomous Maintainer Agent With Repository Write Access In A Privileged CI Job"
+    description: >-
+        A CI workflow runs Tend (`max-sixty/tend/claude`, or the PTY variant `.../claude-interactive`),
+        "an autonomous junior maintainer" that runs the `claude` binary headless with
+        `defaultMode: bypassPermissions` + `skipDangerousModePermissionPrompt` and a default tool
+        grant of `Bash,Edit,Write,...` - an autonomous shell and file writer that pushes commits with
+        the supplied `github_token`. It has no author-permission check of its own. The auto-review
+        flavor deploys on `pull_request_target`, which checks out and runs the untrusted fork PR head
+        with repo-write secrets in scope and no gate, so an outside contributor drives an autonomous
+        write. This rule anchors on the action use, and the fork-reachable + write-capable + ungated
+        post-filter suppresses the sibling workflows that add a real `author_association` /
+        collaborator-permission gate.
+    regex: "max-sixty/tend/claude(?:-interactive)?@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              pull_request_target:
+                types: [opened, synchronize]
+            jobs:
+              review:
+                permissions:
+                  contents: write
+                  pull-requests: write
+                steps:
+                  - uses: actions/checkout@v7
+                    with:
+                      ref: refs/pull/${{ github.event.pull_request.number }}/head
+                      allow-unsafe-pr-checkout: true
+                  - uses: max-sixty/tend/claude@0.1.12
+                    with:
+                      github_token: ${{ secrets.TEND_BOT_TOKEN }}
+                      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                      prompt: ${{ github.event.pull_request.title }}
+    negative_examples:
+      - |2-
+            on:
+              issue_comment:
+                types: [created]
+            jobs:
+              mention:
+                if: contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+                permissions:
+                  contents: write
+                steps:
+                  - uses: actions/checkout@v4
+    recommendation: >-
+        Do not run the Tend autonomous maintainer (headless `claude` with `bypassPermissions` and a
+        `Bash,Edit,Write` tool grant) on `pull_request_target` or any fork-reachable trigger with
+        repo-write secrets and no author gate. Gate the job on repository write access
+        (`author_association` in `OWNER`/`MEMBER`/`COLLABORATOR` or `getCollaboratorPermissionLevel`),
+        run the agent read-only on untrusted PR content, and hand any commit to a separate reviewed
+        job. Treat the PR diff, title, and body as untrusted data.
+    cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
+    owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
+    owasp_llm: ["LLM01", "LLM02", "LLM06"]
+    owasp_asvs: [V1.2.2, V6.2.1]
+    mitre_attack: ["T1059", "T1204.001", "T1552.001", "T1195.002"]
+    cis_controls: ["CIS-6.1", "CIS-16.11"]
+    nist_controls: ["AC-3", "AC-6", "CM-7", "SI-10"]
+    pci_dss: ["6.2.4", "7.2.1", "8.6.2"]
+    soc2: ["CC6.1", "CC6.3", "CC7.1"]
+    mitre_atlas: ["AML.T0051", "AML.T0051.001", "AML.T0053", "AML.T0050", "AML.T0057"]
+
+  - id: "fork_triggerable_ai_inference_agent_with_repo_write"
+    category: "ai_ml_security"
+    severity: "CRITICAL"
+    title: "Fork-Triggerable GitHub Models (actions/ai-inference) Agent Writing Model Output To The Repo In A Privileged CI Job"
+    description: >-
+        A CI workflow uses GitHub's first-party inference action (`actions/ai-inference`, GitHub
+        Models) and treats the model's reply as code. The action itself only returns model text - it
+        holds no tools and pushes nothing - so the exposure is the workflow around it: it feeds
+        untrusted event text (`github.event.issue.title`/`body`, the PR body, a comment) into the
+        `prompt`, then writes the returned diff to disk and `git apply`-s it, or commits the response,
+        and pushes it back with `contents: write`. Because it authenticates with the built-in `models:
+        read` permission plus `GITHUB_TOKEN`, there is no provider secret to grep, so it hides from
+        every provider-key / named-CLI signal. Since the action is neutral, this rule fires only when
+        two whole-file proofs also hold on top of the fork-reachable + write-capable + ungated
+        post-filter: the reply is applied as repo code / pushed (a `git apply`/`commit`/`push`, a
+        commit action, or the response written to a source file) AND untrusted event text reaches the
+        model. A summarizer that only posts the reply as a comment or PATCHes a Release body, and a
+        trusted-input release-notes generator, match none of these and stay silent.
+    regex: "^\\s*uses\\s*:\\s*actions/ai-inference@"
+    multiline: true
+    window: 200
+    positive_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened, labeled]
+            jobs:
+              fix:
+                permissions:
+                  contents: write
+                  issues: write
+                  models: read
+                steps:
+                  - uses: actions/checkout@v4
+                  - id: implement
+                    uses: actions/ai-inference@v1
+                    with:
+                      prompt: |
+                        Return a unified diff that fixes this issue.
+                        Title: ${{ github.event.issue.title }}
+                        Body: ${{ github.event.issue.body }}
+                  - name: Apply and push
+                    run: |
+                      printf '%s' "${{ steps.implement.outputs.response }}" > fix.patch
+                      git apply fix.patch
+                      git commit -am 'ai fix'
+                      git push
+    negative_examples:
+      - |2-
+            on:
+              issues:
+                types: [opened]
+            jobs:
+              summarize:
+                permissions:
+                  contents: write
+                  issues: write
+                steps:
+                  - uses: actions/ai-toolkit@v2
+                    with:
+                      prompt: |
+                        Summarize: ${{ github.event.issue.body }}
+                  - uses: peter-evans/create-or-update-comment@v4
+                    with:
+                      issue-number: ${{ github.event.issue.number }}
+                      body: ${{ steps.ai.outputs.response }}
+    recommendation: >-
+        Do not treat `actions/ai-inference` output as code in a fork-reachable, write-capable job
+        that also feeds untrusted event text into the prompt. Keep the inference job at `permissions:
+        contents: read` and post the reply as a comment for human review; if the reply must become
+        code, hand it to a separate reviewed job that opens a PR rather than `git apply`/`commit`/
+        `push`-ing directly, and gate that job on repository write access (`author_association` in
+        `OWNER`/`MEMBER`/`COLLABORATOR` or `getCollaboratorPermissionLevel`). Treat issue/PR title,
+        body, and comments as untrusted data and never apply a model response derived from them.
     cwe: ["CWE-77", "CWE-94", "CWE-269", "CWE-1427"]
     owasp_appsec: ["A01:2021", "A03:2021", "A08:2021"]
     owasp_llm: ["LLM01", "LLM02", "LLM06"]

--- a/src/ansible_security_scanner/remediations/ai_ml_security.py
+++ b/src/ansible_security_scanner/remediations/ai_ml_security.py
@@ -91,6 +91,10 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
         "fork_triggerable_iflow_agent_with_prompt": "_fix_fork_triggerable_iflow",
         "fork_triggerable_sweep_agent_with_repo_write": "_fix_fork_triggerable_sweep",
         "fork_triggerable_pr_agent_with_repo_write": "_fix_fork_triggerable_pr_agent",
+        "fork_triggerable_skyramp_testbot_with_repo_write": "_fix_fork_triggerable_skyramp",
+        "fork_triggerable_codescene_refactor_agent_with_repo_write": "_fix_fork_triggerable_codescene",
+        "fork_triggerable_tend_agent_with_repo_write": "_fix_fork_triggerable_tend",
+        "fork_triggerable_ai_inference_agent_with_repo_write": "_fix_fork_triggerable_ai_inference",
         "fork_reachable_gitlab_ci_agent_with_write_or_exec": "_fix_fork_reachable_gitlab_ci_agent",
     }
 
@@ -1370,6 +1374,120 @@ class AiMlSecurityRemediationGenerator(BaseRemediationGenerator):
             "A fork-triggerable PR-Agent with repository-mutating tools (/improve "
             "commitable suggestions) reads an untrusted PR body/comment as its "
             "instructions and can mutate the PR via prompt injection.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_skyramp(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# A '@skyramp-testbot' comment mention is not an authorization check. Gate\n"
+            "# the job on repository write access before letting the bot autoCommit and\n"
+            "# push, or have it open a PR for human review.\n"
+            "jobs:\n"
+            "  testbot:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: write\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v6\n"
+            "      - uses: skyramp/testbot@v0.10.0\n"
+            "        with:\n"
+            "          anthropicApiKey: ${{ secrets.SKYRAMP_TESTBOT_API_KEY }}\n"
+            "          githubToken: ${{ secrets.GITHUB_TOKEN }}\n"
+            "          autoCommit: 'true'"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Skyramp Testbot with autoCommit and repository write, "
+            "gated only on a '@skyramp-testbot' comment any outside commenter can type, "
+            "lets an untrusted actor drive a push under the bot's token.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_codescene(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# A '/cs-agent' comment mention is not an authorization check. Gate the job\n"
+            "# on repository write access and have the agent open a PR for human review\n"
+            "# rather than committing directly.\n"
+            "jobs:\n"
+            "  refactor:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "      - uses: codescene-oss/pr-refactoring-agent@bbc72fb\n"
+            "        env:\n"
+            "          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable CodeScene refactoring agent with repository write, gated "
+            "only on a '/cs-agent' comment any outside commenter can type, lets an "
+            "untrusted actor drive a commit through prompt injection.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_tend(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# Do not run the Tend autonomous maintainer (headless claude with\n"
+            "# bypassPermissions and a Bash/Edit/Write grant) on pull_request_target with\n"
+            "# repo-write secrets. Gate on repository write access and run it read-only on\n"
+            "# untrusted PR content, handing any commit to a separate reviewed job.\n"
+            "jobs:\n"
+            "  mention:\n"
+            "    if: >-\n"
+            '      contains(fromJSON(\'["OWNER", "MEMBER", "COLLABORATOR"]\'),\n'
+            "      github.event.comment.author_association)\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "    steps:\n"
+            "      - uses: max-sixty/tend/claude@0.1.12\n"
+            "        with:\n"
+            "          github_token: ${{ secrets.TEND_BOT_TOKEN }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable Tend agent runs headless claude with bypassPermissions "
+            "and a shell/write tool grant on an untrusted fork PR head with repo-write "
+            "secrets in scope, so an outside contributor drives an autonomous push.",
+            secure_fix,
+        )
+
+    def _fix_fork_triggerable_ai_inference(self, rule_id: str, code_snippet: str) -> str:
+        secure_fix = (
+            "# actions/ai-inference only returns model text - the risk is applying it as\n"
+            "# code. Keep the inference job read-only and post the reply for review; do\n"
+            "# not git apply/commit/push a response derived from untrusted issue/PR text.\n"
+            "jobs:\n"
+            "  suggest:\n"
+            "    permissions:\n"
+            "      contents: read\n"
+            "      issues: write\n"
+            "      models: read\n"
+            "    steps:\n"
+            "      - id: ai\n"
+            "        uses: actions/ai-inference@v1\n"
+            "        with:\n"
+            "          prompt: |\n"
+            "            Suggest a fix for: ${{ github.event.issue.title }}\n"
+            "      - uses: peter-evans/create-or-update-comment@v4\n"
+            "        with:\n"
+            "          issue-number: ${{ github.event.issue.number }}\n"
+            "          body: ${{ steps.ai.outputs.response }}"
+        )
+        return self._frame(
+            rule_id,
+            code_snippet,
+            "A fork-triggerable job feeds untrusted event text into actions/ai-inference "
+            "and applies the model's reply as repository code (git apply/commit/push) "
+            "with contents: write, so prompt injection becomes an arbitrary commit.",
             secure_fix,
         )
 

--- a/src/ansible_security_scanner/remediations/rule_id_categories.yml
+++ b/src/ansible_security_scanner/remediations/rule_id_categories.yml
@@ -38,6 +38,7 @@ rules_by_category:
     - fork_triggerable_ai_agent_with_repo_mutating_gh_tools
     - fork_triggerable_ai_agent_with_write_or_exec_tools
     - fork_triggerable_ai_github_action_with_repo_write
+    - fork_triggerable_ai_inference_agent_with_repo_write
     - fork_triggerable_aider_agent_with_repo_write
     - fork_triggerable_amp_agent_with_repo_write
     - fork_triggerable_bespoke_llm_agent_with_repo_write
@@ -45,6 +46,7 @@ rules_by_category:
     - fork_triggerable_claude_cli_agent_with_repo_write
     - fork_triggerable_code_agent_with_repo_write
     - fork_triggerable_codemie_agent_with_repo_write
+    - fork_triggerable_codescene_refactor_agent_with_repo_write
     - fork_triggerable_codex_agent_with_write_or_exec_sandbox
     - fork_triggerable_cogni_agent_with_repo_write
     - fork_triggerable_continue_cli_agent_with_repo_write
@@ -65,8 +67,10 @@ rules_by_category:
     - fork_triggerable_openhands_agent_with_repo_write
     - fork_triggerable_pr_agent_with_repo_write
     - fork_triggerable_qwen_code_agent_with_repo_write
+    - fork_triggerable_skyramp_testbot_with_repo_write
     - fork_triggerable_swe_agent_with_repo_write
     - fork_triggerable_sweep_agent_with_repo_write
+    - fork_triggerable_tend_agent_with_repo_write
     - fork_triggerable_warp_agent_with_repo_write
     - gcp_vertex_ai_access
     - generic_llm_api_key

--- a/src/ansible_security_scanner/remediations/unauthorized_cloud_procedural.py
+++ b/src/ansible_security_scanner/remediations/unauthorized_cloud_procedural.py
@@ -624,22 +624,74 @@ class UnauthorizedCloudProceduralRemediationGenerator(BaseRemediationGenerator):
     # ---- Remote exec -----------------------------------------------------
 
     def _fix_ssm(self, rule_id: str, code_snippet: str) -> str:
+        target = (
+            _first(
+                code_snippet,
+                r"--instance-ids?\s+[\"']?(\{\{[^}]+\}\})",
+                r"--instance-ids?\s+[\"']?(i-[0-9a-f]+)",
+                r"--targets\s+[\"'][^\"']*Values=([^,\"']+)",
+            )
+            or "{{ target_instance_id }}"
+        )
+        region = (
+            _first(
+                code_snippet,
+                r"--region\s+[\"']?(\{\{[^}]+\}\})",
+                r"--region\s+[\"']?([a-z]{2}-[a-z]+-\d)",
+            )
+            or "{{ aws_region }}"
+        )
+        remote_cmd = self._extract_ssm_command(code_snippet)
+        if not remote_cmd:
+            # Fall back to naming the SSM document (e.g. AWS-RunShellScript) so
+            # the fix still says what ran instead of a bare placeholder.
+            doc = _first(code_snippet, r"--document-name\s+[\"']?([\w.-]+)")
+            ran = f"the script your '{doc}' document invoked" if doc else "the send-command payload"
+            remote_cmd = f"# run {ran}, e.g.:\n    /usr/local/bin/your-provisioning-script.sh"
         why = (
             "`aws ssm send-command` runs code on instances outside Ansible's control "
-            "flow and audit trail. Add the hosts to inventory and run the task through "
-            "Ansible's own connection (SSH or the SSM connection plugin)."
+            "flow and audit trail: the shelled-out payload never shows up as a task, "
+            "its exit status is invisible to the play, and nothing is idempotent. Put "
+            "the target host in inventory behind the SSM connection plugin and run the "
+            "same command as a normal task, so it is logged, gated, and re-runnable."
         )
         fix = (
-            "# Target instances through inventory; the run is logged by Ansible itself.\n"
-            "- name: run command on managed hosts\n"
-            "  ansible.builtin.command:\n"
-            '    cmd: "{{ remediation_command }}"\n'
-            "  register: result\n"
+            "# 1. Reach the instance through inventory instead of send-command. The SSM\n"
+            "#    connection plugin needs no inbound SSH and keeps the run auditable.\n"
+            "#    inventory (host_vars or an aws_ec2 inventory plugin entry):\n"
+            "#      ssm_target:\n"
+            f'#        ansible_host: "{target}"\n'
+            "#        ansible_connection: community.aws.aws_ssm\n"
+            f'#        ansible_aws_ssm_region: "{region}"\n'
+            '#        ansible_aws_ssm_bucket_name: "{{ ssm_transfer_bucket }}"\n'
+            "\n"
+            "# 2. Run the real payload as a task against that host. Ansible now records\n"
+            "#    the command, its output, and its exit status.\n"
+            "- name: run provisioning command on the target host (audited)\n"
+            "  delegate_to: ssm_target\n"
+            "  ansible.builtin.shell: >-\n"
+            f"    {remote_cmd}\n"
+            "  register: ssm_task\n"
             "  changed_when: false\n"
-            "# Inventory uses the SSM connection plugin where SSH is unavailable:\n"
-            "#   ansible_connection: community.aws.aws_ssm\n"
         )
         return self._frame(rule_id, code_snippet, why, fix)
+
+    @staticmethod
+    def _extract_ssm_command(snippet: str) -> str | None:
+        """Pull the real shell payload out of an SSM ``--parameters`` arg.
+
+        ``send-command`` hides the command inside
+        ``--parameters 'commands=["<cmd>"]'`` (or ``commands=<cmd>``), so the
+        fix can run the operator's actual command as a task.
+        """
+        for pattern in (
+            r"commands\s*=\s*\[\s*[\"'](?P<cmd>.+?)[\"']\s*\]",
+            r"commands\s*=\s*[\"'](?P<cmd>.+?)[\"']",
+        ):
+            m = re.search(pattern, snippet, re.IGNORECASE | re.DOTALL)
+            if m:
+                return " ".join(m.group("cmd").split()).rstrip("\\").strip() or None
+        return None
 
     # ---- Audit-control destruction --------------------------------------
 

--- a/tests/playbooks/bad_example.yml
+++ b/tests/playbooks/bad_example.yml
@@ -6345,6 +6345,102 @@
                     OPENAI_KEY: ${{ secrets.OPENAI_KEY }}
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    # --- ai_ml_security.yml: fork_triggerable_skyramp_testbot_with_repo_write ---
+    - name: trigger fork_triggerable_skyramp_testbot_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/skyramp-testbot.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            testbot:
+              if: contains(github.event.comment.body, '@skyramp-testbot')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v6
+                - uses: skyramp/testbot@v0.10.0
+                  with:
+                    anthropicApiKey: ${{ secrets.SKYRAMP_TESTBOT_API_KEY }}
+                    githubToken: ${{ secrets.GITHUB_TOKEN }}
+                    autoCommit: 'true'
+
+    # --- ai_ml_security.yml: fork_triggerable_codescene_refactor_agent_with_repo_write ---
+    - name: trigger fork_triggerable_codescene_refactor_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/codescene-refactor.yml
+        content: |
+          on:
+            issue_comment:
+              types: [created]
+          jobs:
+            refactor:
+              if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/cs-agent')
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v4
+                - uses: codescene-oss/pr-refactoring-agent@bbc72fb
+                  env:
+                    CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+
+    # --- ai_ml_security.yml: fork_triggerable_tend_agent_with_repo_write ---
+    - name: trigger fork_triggerable_tend_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/tend-review.yml
+        content: |
+          on:
+            pull_request_target:
+              types: [opened, synchronize]
+          jobs:
+            review:
+              permissions:
+                contents: write
+                pull-requests: write
+              steps:
+                - uses: actions/checkout@v7
+                  with:
+                    ref: refs/pull/${{ github.event.pull_request.number }}/head
+                    allow-unsafe-pr-checkout: true
+                - uses: max-sixty/tend/claude@0.1.12
+                  with:
+                    github_token: ${{ secrets.TEND_BOT_TOKEN }}
+                    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+                    prompt: ${{ github.event.pull_request.title }}
+
+    # --- ai_ml_security.yml: fork_triggerable_ai_inference_agent_with_repo_write ---
+    - name: trigger fork_triggerable_ai_inference_agent_with_repo_write
+      ansible.builtin.copy:
+        dest: .github/workflows/ai-inference-fix.yml
+        content: |
+          on:
+            issues:
+              types: [opened, labeled]
+          jobs:
+            fix:
+              permissions:
+                contents: write
+                issues: write
+                models: read
+              steps:
+                - uses: actions/checkout@v4
+                - id: implement
+                  uses: actions/ai-inference@v1
+                  with:
+                    prompt: |
+                      Return a unified diff that fixes this issue.
+                      Title: ${{ github.event.issue.title }}
+                      Body: ${{ github.event.issue.body }}
+                - name: Apply and push
+                  run: |
+                    printf '%s' "${{ steps.implement.outputs.response }}" > fix.patch
+                    git apply fix.patch
+                    git commit -am 'ai fix'
+                    git push
+
     # --- ai_ml_security.yml: fork_reachable_gitlab_ci_agent_with_write_or_exec ---
     - name: trigger fork_reachable_gitlab_ci_agent_with_write_or_exec
       ansible.builtin.copy:

--- a/tests/test_policy_transparency.py
+++ b/tests/test_policy_transparency.py
@@ -19,7 +19,7 @@ from ansible_security_scanner.comment.inline import (
     _RESOLUTION_DISCLAIMER,
     _render_inline_body,
 )
-from ansible_security_scanner.comment.rendering import _render_policy_note
+from ansible_security_scanner.comment.rendering import _IGNORE_HARD_CAP, _render_policy_note
 
 
 def _ignore_note(ignored_rule_ids, category_for_rule):
@@ -96,14 +96,26 @@ def test_ignore_note_unknown_category_falls_into_other_bucket():
 
 
 def test_ignore_note_hard_cap_collapses_tail():
-    rules = [f"rule_{i:03d}" for i in range(80)]
+    rules = [f"rule_{i:03d}" for i in range(_IGNORE_HARD_CAP + 40)]
     cats: dict[str, str] = {}
     for i, r in enumerate(rules):
         cats[r] = f"cat_{i % 8}"
     note = _ignore_note(rules, cats)
-    assert "80 rules suppressed" in note
+    assert f"{len(rules)} rules suppressed" in note
     assert "Rule list capped for readability" in note
     assert "rule_000" not in note  # collapsed; not all listed
+
+
+def test_ignore_note_lists_every_rule_for_a_realistic_policy():
+    # A hand-authored ignore policy (61 rules across 18 categories, the size
+    # observed in the wild) must list every rule in the grouped form rather
+    # than collapse to a top-categories summary.
+    rules = [f"rule_{i:03d}" for i in range(61)]
+    cats = {r: f"cat_{i % 18}" for i, r in enumerate(rules)}
+    note = _ignore_note(rules, cats)
+    assert "Rule list capped for readability" not in note
+    assert "more categories" not in note
+    assert "rule_000" in note and "rule_060" in note
 
 
 # ---- render_comment_body integration ---------------------------------------

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -141,6 +141,17 @@ _TRUNCATED_JINJA_RE = re.compile(r"\{\{(?=\s*[\"']?\s*$)", re.MULTILINE)
 # already-interpolated expression.
 _NESTED_JINJA_RE = re.compile(r"\{\{(?:[^{}]|\}(?!\}))*\{\{")
 
+# A "fill-it-in-yourself" placeholder: a Secure Fix that punts the actual
+# remediation back to the operator via a fake variable instead of reusing the
+# finding's own code. Real fixes weave in the flagged command/path/host, so
+# none of these tokens should appear in a shipped Secure Fix body.
+_GENERIC_PLACEHOLDER_RE = re.compile(
+    r"\{\{\s*(?:remediation_command|your_command(?:_here)?|command_here|"
+    r"insert_command|replace_me|todo)\s*\}\}"
+    r"|<\s*(?:your[ _-]command|command[ _-]here|insert[ _-]command|replace[ _-]me)[^>]*>",
+    re.IGNORECASE,
+)
+
 
 def _unfenced_yaml_runs(output: str) -> list[list[str]]:
     """Return runs (>= 2 lines) of structural-YAML-shaped lines that
@@ -492,6 +503,15 @@ def test_positive_example_renders_valid_secure_fix(
         f"  positive example: {positive_example[:160]!r}\n"
         f"  Secure Fix body (first 320 chars): {body[:320]!r}"
     )
+    ph = _GENERIC_PLACEHOLDER_RE.search(body)
+    assert not ph, (
+        f"{rule_id}: Secure Fix rendered from the rule's own positive example "
+        f"contains a fill-it-in-yourself placeholder ({ph.group(0)!r}). The fix "
+        f"must reuse the flagged code (command/path/host/target), not punt the "
+        f"remediation back to the operator via a fake variable.\n"
+        f"  positive example: {positive_example[:160]!r}\n"
+        f"  Secure Fix body (first 320 chars): {body[:320]!r}"
+    )
 
 
 # Structural (AST / Python-defined) rules have no ``patterns/*.yml`` entry and
@@ -588,11 +608,97 @@ def test_structural_rule_renders_dynamic_secure_fix(
     assert not _NESTED_JINJA_RE.search(body), (
         f"{rule_id}: Secure Fix contains nested Jinja.\n  body: {body[:320]!r}"
     )
+    ph = _GENERIC_PLACEHOLDER_RE.search(body)
+    assert not ph, (
+        f"{rule_id}: Secure Fix contains a fill-it-in-yourself placeholder "
+        f"({ph.group(0)!r}) instead of reusing the finding's own code.\n"
+        f"  body: {body[:320]!r}"
+    )
     yaml.safe_load(body)  # raises if the Secure Fix isn't valid YAML
     assert must_contain in body, (
         f"{rule_id}: Secure Fix did not dynamically apply the expected hardening "
         f"({must_contain!r}) drawn from the finding's own code.\n"
         f"  body: {body[:320]!r}"
+    )
+
+
+# Handlers that extract a value from the finding (via `_first`/bespoke parsing)
+# and weave it into the fix. Unlike the static-by-design majority, these claim
+# to be dynamic, so a refactor that silently drops back to a hardcoded block
+# must fail. Each row is (rule_id, snippet, token_the_fix_must_echo): the token
+# is a distinctive value in the snippet that a genuinely dynamic fix reproduces.
+# Only rules whose handler is designed to echo belong here.
+DYNAMIC_EXTRACTION_EXAMPLES = [
+    (
+        "aws_ssm_send_command",
+        'shell: >\n  aws ssm send-command --instance-ids "{{ target_instance_id }}" '
+        '--region "{{ deploy_region }}" '
+        "--parameters 'commands=[\"bash /opt/scripts/bootstrap.sh\"]'",
+        "bash /opt/scripts/bootstrap.sh",
+    ),
+    (
+        "aws_ssm_send_command",
+        'shell: aws ssm send-command --instance-ids "{{ worker_instance_id }}" '
+        "--parameters 'commands=[\"python3 /opt/scripts/rotate_keys.py\"]'",
+        "{{ worker_instance_id }}",
+    ),
+    (
+        "aws_ec2_run_instances",
+        "shell: aws ec2 run-instances --image-id ami-0abc1234 --instance-type m5.large",
+        "m5.large",
+    ),
+    (
+        "aws_lambda_create",
+        "shell: aws lambda create-function --function-name order-worker --runtime python3.12",
+        "order-worker",
+    ),
+    (
+        "aws_s3_data_access",
+        "shell: aws s3 cp s3://example-artifacts-bucket/dump.tar.gz /tmp/x",
+        "example-artifacts-bucket",
+    ),
+    (
+        "aws_sts_assume_role",
+        "shell: aws sts assume-role --role-arn arn:aws:iam::123456789012:role/deployer",
+        "arn:aws:iam::123456789012:role/deployer",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "rule_id,snippet,must_echo",
+    DYNAMIC_EXTRACTION_EXAMPLES,
+    ids=[f"{r}#{i}" for i, (r, _, _) in enumerate(DYNAMIC_EXTRACTION_EXAMPLES)],
+)
+def test_dynamic_handler_echoes_extracted_value(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+    snippet: str,
+    must_echo: str,
+) -> None:
+    """Dynamic handlers must weave the finding's own value into the fix.
+
+    Guards the "generic fix" class: a handler that advertises extraction
+    (instance id, command, bucket, role ARN, ...) but silently renders a
+    hardcoded block that ignores the finding. Complements the placeholder
+    guard, which catches a fake token rather than a dropped real value.
+    """
+    out = remediation_generator.generate_remediation_example(
+        rule_id, snippet, file_path="test.yml", line_number=1
+    )
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    assert match, f"{rule_id}: no Secure Fix block rendered for {snippet[:80]!r}"
+    body = match.group("body")
+    yaml.safe_load(body)  # raises if invalid
+    assert not _GENERIC_PLACEHOLDER_RE.search(body), (
+        f"{rule_id}: dynamic handler emitted a fill-it-in placeholder for a "
+        f"snippet it should have extracted from.\n  snippet: {snippet[:120]!r}\n"
+        f"  body: {body[:320]!r}"
+    )
+    assert must_echo in body, (
+        f"{rule_id}: dynamic handler did NOT echo the extracted value "
+        f"({must_echo!r}) from the finding - it fell back to a generic block.\n"
+        f"  snippet: {snippet[:120]!r}\n  body: {body[:400]!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Add ai_ml_security detection rules for Skyramp Testbot, the CodeScene refactoring agent, Tend, and GitHub Models (`actions/ai-inference`).
- The three slug-anchored rules use the existing fork-reachable, write-capable, ungated post-filter. `actions/ai-inference` is a neutral action, so it fires only when the workflow both applies the model reply as repository code and feeds it untrusted event text.
- Extend the bespoke LLM anchor to cover provider SDK call shapes (`new OpenAI(`, `genai.GenerativeModel`, `.generate_content`, `.chat.completions.create`, `@anthropic-ai/sdk`), and treat a tag-ref gate (`refs/tags/`, `ref_type == 'tag'`) as non-fork-reachable.
- Make the SSM remediation reproduce the flagged instance, region, and command instead of a fill-in placeholder, and add a guard against the generic fix class.
- Raise the ignored-rule cap so a normal ignore policy lists every rule instead of collapsing to a category summary.
- Restore the malicious-activity remediation test class that had lost its class declaration.
- Add a composite `action.yml` so the scanner is usable as a one-line GitHub Actions step and listable on the Marketplace. It installs the pinned release, scans, and uploads SARIF, with inputs for format, output, severity, rule select/ignore, and a fail-on-findings toggle. Documented in the README and CI/CD guide.