### PR TITLE
Ground remediation fixes in the flagged code

### DIFF
--- a/src/ansible_security_scanner/comment/inline.py
+++ b/src/ansible_security_scanner/comment/inline.py
@@ -248,7 +248,7 @@ def _render_inline_body(
     if recommendation:
         parts.append(f"**Recommendation:** {recommendation}")
 
-    remediation = _render_remediation_block(finding)
+    remediation = _render_remediation_block(finding, inline=True)
     if remediation:
         parts.append(remediation)
 

--- a/src/ansible_security_scanner/comment/rendering.py
+++ b/src/ansible_security_scanner/comment/rendering.py
@@ -700,6 +700,21 @@ _VULNERABLE_CODE_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 
+# The metadata renderer opens with a ``🔍 <heading>:`` description section and
+# a ``🛠 Recommendation:`` section. Inline threads already print the finding's
+# description and recommendation above the expander, so these would repeat
+# inside "Show recommended fix". Stripped only for inline rendering; the summary
+# comment keeps them because it shows just a one-line Fix hint. Tailored
+# handlers use ``🚨``/``✅`` sections and are unaffected.
+_META_DESCRIPTION_SECTION_RE = re.compile(
+    r"\*\*\U0001f50d[^\n]*:\*\*\s*\n.*?(?=\n\*\*|\Z)",
+    re.DOTALL,
+)
+_META_RECOMMENDATION_SECTION_RE = re.compile(
+    r"\*\*\U0001f6e0 Recommendation:\*\*\s*\n.*?(?=\n\*\*|\Z)",
+    re.DOTALL,
+)
+
 # Match ``**field**: `<value>` -> `<replacement>`` rows the rich
 # generators emit for "Secret Parameters Found" sections. The value half
 # is back-tick-delimited which the KV redactor can't see (it stops at
@@ -799,15 +814,22 @@ def _render_framework_coverage_inline(finding: Any) -> str:
     return f"<details><summary>Compliance frameworks</summary>\n\n{body}\n\n</details>"
 
 
-def _render_remediation_block(finding: Any) -> str:
+def _render_remediation_block(finding: Any, *, inline: bool = False) -> str:
     """Render the structured remediation example as a collapsed
     ``<details>`` block. Returns ``""`` when no remediation is present.
+
+    ``inline=True`` strips the metadata renderer's ``🔍`` description and
+    ``🛠 Recommendation`` sections, which the inline thread already shows above
+    the expander, so they are not duplicated inside "Show recommended fix".
     """
     raw = (getattr(finding, "remediation_example", "") or "").strip()
     if not raw:
         return ""
 
     cleaned = _VULNERABLE_CODE_BLOCK_RE.sub("", raw, count=1).strip()
+    if inline:
+        cleaned = _META_DESCRIPTION_SECTION_RE.sub("", cleaned, count=1)
+        cleaned = _META_RECOMMENDATION_SECTION_RE.sub("", cleaned, count=1).strip()
     if not cleaned:
         return ""
 

--- a/src/ansible_security_scanner/patterns/remediations/ansible_hygiene.yml
+++ b/src/ansible_security_scanner/patterns/remediations/ansible_hygiene.yml
@@ -33,6 +33,18 @@ remediations:
               path: /var/run/app-deploy.lock
               state: absent
 
+  become_user_without_become_true:
+    secure_fix: |
+      # become_user only takes effect when become is also enabled. Without
+      # `become: true` the task runs as the connection user, not the intended
+      # account, so the privilege boundary is absent.
+      - name: Run as the intended account (become enabled)
+        ansible.builtin.command: /usr/bin/app
+        become: true
+        become_user: svc_account
+        # If you did not intend to switch users, remove become_user rather than
+        # leaving a no-op privilege directive in place.
+
   ansible_host_key_checking_false_in_env_or_config:
     secure_fix: |
       # Don't disable host-key checking; pre-seed known_hosts

--- a/src/ansible_security_scanner/patterns_manager.py
+++ b/src/ansible_security_scanner/patterns_manager.py
@@ -456,6 +456,12 @@ _CODE_EMITTED_RULE_IDS: frozenset[str] = frozenset(
         "unknown_suppression_rule",
         "excessive_suppressions",
         "set_fact_secret_alias",
+        # Structural AST rules with no pattern YAML entry and no framework-tag
+        # registration. Listed so they are part of the known-rule universe
+        # (--select / --ignore / --list-rules) and covered by the remediation
+        # contract tests.
+        "get_url_dest_executable_with_insecure_validate",
+        "become_user_without_become_true",
     }
 )
 

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -79,6 +79,10 @@ def _render_from_metadata(
     The pattern catalog wins when populated; the fallbacks fill the
     void so the rendered ``Show recommended fix`` block always carries
     real text rather than the ``this <rule_id> issue`` stub.
+
+    The Secure Fix is grounded in the finding's own code via
+    :func:`_ground_secure_fix`, so a curated companion snippet is never
+    rendered as advice disconnected from the flagged line.
     """
     meta = _pattern_index.get(rule_id) or {}
     title = meta.get("title") or title_fallback
@@ -86,15 +90,20 @@ def _render_from_metadata(
     recommendation = meta.get("recommendation") or recommendation_fallback
 
     secure_fix = _select_secure_fix(rule_id)
+    if secure_fix:
+        secure_fix = _ground_secure_fix(secure_fix, code_snippet)
     secure_block = (
         f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n" if secure_fix else ""
     )
 
     rec_block = f"\n**\U0001f6e0 Recommendation:**\n{recommendation}\n" if recommendation else ""
+    # The untitled fallback already ends in ``(rule_id)``; only append the id
+    # when a real title is present so it is never doubled.
     heading = title or f"What this rule detects ({rule_id})"
+    heading_suffix = f" ({rule_id})" if title else ""
     return (
         f"\n**\u274c Vulnerable Code:**\n```yaml\n{code_snippet}\n```\n"
-        f"\n**\U0001f50d {heading} ({rule_id}):**\n{description}\n"
+        f"\n**\U0001f50d {heading}{heading_suffix}:**\n{description}\n"
         f"{rec_block}"
         f"{secure_block}"
     )
@@ -107,6 +116,90 @@ def _select_secure_fix(rule_id: str) -> str | None:
     code, so they are intentionally not consulted as a remediation source.
     """
     return _companion_index.get(rule_id)
+
+
+# Grounding a curated fix in the finding's own code. A curated ``secure_fix``
+# snippet is generic; ``_ground_secure_fix`` ties it to the finding by
+# prepending a YAML comment naming the finding's concrete artifact when the
+# snippet does not already reference it.
+
+# Concrete artifacts worth echoing back, most-specific first. The URL/path
+# classes exclude ``{`` and ``}`` so a value embedding a Jinja expression
+# (``https://api/{{ name }}``) is not captured as a truncated ``https://api/{{``.
+_GROUND_URL_RE = re.compile(r"https?://[^\s\"'`,)}{]+")
+_GROUND_PATH_RE = re.compile(
+    r"(?<![\w-])/(?:etc|opt|srv|var|tmp|home|root|usr|bin|boot|dev|mnt|"
+    r"media|proc|sys|lib|run)(?:/[\w.@%+-]+)+"
+)
+_GROUND_IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?![\w.])")
+_GROUND_JINJA_VAR_RE = re.compile(r"\{\{\s*([a-zA-Z_][\w.]*)\s*\}\}")
+# Leading inventory/config key on the flagged line (e.g. ``ansible_ssh_common_args``).
+_GROUND_KEY_RE = re.compile(r"^\s*(?:-\s*)?([a-zA-Z_][\w.-]*)\s*[:=]")
+# Hostnames like ``legacy.example.com`` (dotted, ends in an alpha TLD).
+_GROUND_HOST_RE = re.compile(r"(?<![\w.@/])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?![\w./])")
+
+
+def _artifact_is_safe(candidate: str) -> bool:
+    """True when ``candidate`` has balanced Jinja braces.
+
+    A fragment like ``https://api/{{`` would reintroduce truncated Jinja, so
+    any candidate with an unbalanced brace is rejected.
+    """
+    if "{" not in candidate and "}" not in candidate:
+        return True
+    return candidate.count("{{") == candidate.count("}}") and "{{" in candidate
+
+
+def _finding_artifact(code_snippet: str) -> str | None:
+    """Return the most specific concrete artifact named in ``code_snippet``.
+
+    A URL is preferred over the host inside it, a path over a bare key.
+    Candidates carrying a partial Jinja expression are skipped. Returns
+    ``None`` when the finding names nothing concrete (e.g. ``shell: echo x``).
+    """
+    snippet = code_snippet or ""
+    for pattern in (_GROUND_URL_RE, _GROUND_PATH_RE, _GROUND_IPV4_RE):
+        for m in pattern.finditer(snippet):
+            if _artifact_is_safe(m.group(0)):
+                return m.group(0)
+    jm = _GROUND_JINJA_VAR_RE.search(snippet)
+    if jm:
+        return "{{ " + jm.group(1) + " }}"
+    hm = _GROUND_HOST_RE.search(snippet)
+    if hm and "." in hm.group(0) and _artifact_is_safe(hm.group(0)):
+        return hm.group(0)
+    for line in snippet.splitlines():
+        km = _GROUND_KEY_RE.match(line)
+        if km:
+            return km.group(1)
+    return None
+
+
+def _fix_references_artifact(secure_fix: str, artifact: str) -> bool:
+    """True when ``secure_fix`` already mentions ``artifact`` (grounded)."""
+    if not artifact:
+        return True
+    if artifact in secure_fix:
+        return True
+    # A Jinja var reference ``{{ x }}`` is grounded if the bare name appears.
+    jm = _GROUND_JINJA_VAR_RE.fullmatch(artifact.strip())
+    return bool(jm and re.search(rf"(?<![\w]){re.escape(jm.group(1))}(?![\w])", secure_fix))
+
+
+def _ground_secure_fix(secure_fix: str, code_snippet: str) -> str:
+    """Return ``secure_fix`` tied back to the finding's own code.
+
+    No-op when the finding names nothing concrete or the fix already
+    references the finding's artifact. Otherwise prepend a YAML comment naming
+    the artifact so the fix reads as one for the flagged line.
+    """
+    fix = (secure_fix or "").strip("\n")
+    if not fix:
+        return secure_fix
+    artifact = _finding_artifact(code_snippet)
+    if not artifact or _fix_references_artifact(fix, artifact):
+        return secure_fix
+    return f"# Applies to the flagged finding: {artifact}\n{fix}"
 
 
 class BaseRemediationGenerator:
@@ -122,14 +215,12 @@ class BaseRemediationGenerator:
         """Route ``rule_id`` to its tailored handler, or fall through to
         the metadata renderer.
 
-        A companion-file entry always wins over a tailored handler:
-        tailored handlers predate the contract tests and tend to skip
-        the Secure Fix YAML block, so the curated companion entry is
-        the upgrade path. ``fallback`` is accepted for backward
+        A tailored handler wins when present: it renders a rule-specific
+        Secure Fix built around the flagged code. Otherwise the metadata
+        renderer runs, whose Secure Fix is grounded via
+        ``_ground_secure_fix``. ``fallback`` is accepted for backward
         compatibility and ignored.
         """
-        if _companion_index.get(rule_id):
-            return _render_from_metadata(rule_id, code_snippet)
         method_name = self._FIX_MAP.get(rule_id)
         if method_name:
             return getattr(self, method_name)(code_snippet)

--- a/src/ansible_security_scanner/remediations/remediation_generator.py
+++ b/src/ansible_security_scanner/remediations/remediation_generator.py
@@ -116,6 +116,31 @@ class RemediationGenerator(BaseRemediationGenerator):
             "vault_hygiene": VaultHygieneRemediationGenerator(),
             "cross_file_taint": TaintFlowRemediationGenerator(),
         }
+        self._rule_owner = self._build_rule_owner_index()
+
+    def _build_rule_owner_index(self) -> dict[str, tuple[str, str]]:
+        """Reverse index ``rule_id -> (generator_key, category_method)``.
+
+        Records which generator actually implements each rule's fix, derived
+        from each generator's ``_FIX_MAP``, so a stale ``rule_id -> category``
+        mapping cannot misroute a finding to a generator that lacks its handler.
+
+        Generators reached only through the ``specials`` map in ``_dispatch``
+        are excluded: those rules carry extra context (var/env extraction) and
+        are routed by category, not by ``_FIX_MAP``.
+        """
+        method_for_key: dict[str, str] = {}
+        for _cat, (gen_key, method_name) in self._SIMPLE_DISPATCH.items():
+            method_for_key.setdefault(gen_key, method_name)
+
+        owner: dict[str, tuple[str, str]] = {}
+        for gen_key, generator in self._generators.items():
+            method_name = method_for_key.get(gen_key)
+            if not method_name:
+                continue
+            for rid in getattr(generator, "_FIX_MAP", {}):
+                owner.setdefault(rid, (gen_key, method_name))
+        return owner
 
     # Data-driven dispatch table. Each entry maps a category to the (generator-key,
     # method-name) pair used to produce the fix. Categories that need richer
@@ -196,24 +221,19 @@ class RemediationGenerator(BaseRemediationGenerator):
                 recommendation_fallback=recommendation_fallback,
             )
 
-        if _companion_index.get(rule_id):
+        def dispatched_or_meta() -> str:
+            out = self._dispatch(rule_id, code_snippet, file_path, line_number)
+            if self._is_relevant(rule_id, code_snippet, out) and self._fix_is_sound(out):
+                return _swap_vulnerable_code_block(out, code_snippet, rendered_snippet)
             return render_meta()
-        # Structural rule (no pattern entry) with caller-supplied
-        # fallbacks: skip per-category dispatch so the expander renders
-        # the rule's real text, not the ``this <rule_id> issue`` stub.
-        # A tailored dynamic handler is the exception - it reuses the
-        # finding's own code to emit a real Secure Fix, which beats the
-        # procedural metadata text, so let it run.
-        if (
-            not _pattern_index.get(rule_id)
-            and (description_fallback or recommendation_fallback)
-            and not self._has_dynamic_handler(rule_id)
-        ):
+
+        # A curated companion snippet (grounded via _ground_secure_fix) wins for
+        # rules with no tailored handler. Every other rule prefers its dispatched
+        # fix and falls back to the metadata renderer only when that fix is
+        # irrelevant or malformed, so a regressed handler never ships a broken fix.
+        if not self._has_dynamic_handler(rule_id) and _companion_index.get(rule_id):
             return render_meta()
-        out = self._dispatch(rule_id, code_snippet, file_path, line_number)
-        if not self._is_relevant(rule_id, code_snippet, out):
-            return render_meta()
-        return _swap_vulnerable_code_block(out, code_snippet, rendered_snippet)
+        return dispatched_or_meta()
 
     # Structural rules (no patterns/*.yml entry) whose special-category
     # handler reuses the finding's own code to emit a real Secure Fix.
@@ -228,12 +248,14 @@ class RemediationGenerator(BaseRemediationGenerator):
     )
 
     def _has_dynamic_handler(self, rule_id: str) -> bool:
-        """True when the rule's category generator has a tailored handler.
+        """True when the rule has a tailored handler that dispatch can reach.
 
-        Used to let structural rules (no ``patterns/*.yml`` entry) still
-        reach a code-reusing Secure Fix instead of the procedural
-        metadata renderer.
+        Consults the owner index first so a stale category mapping cannot hide
+        a real handler, then the category-routed generator, then the
+        structural specials.
         """
+        if rule_id in self._rule_owner:
+            return True
         if rule_id in self._DYNAMIC_SPECIAL_RULES:
             return True
         spec = self._SIMPLE_DISPATCH.get(_resolve_category(rule_id))
@@ -243,6 +265,27 @@ class RemediationGenerator(BaseRemediationGenerator):
         return bool(generator and rule_id in getattr(generator, "_FIX_MAP", {}))
 
     def _dispatch(
+        self,
+        rule_id: str,
+        code_snippet: str,
+        file_path: str,
+        line_number: int,
+    ) -> str:
+        # Owner index first: route to the generator that implements this rule's
+        # tailored handler, regardless of a possibly-stale category mapping.
+        # The owner's output is used only when sound; otherwise fall through to
+        # the category/special dispatch the rule historically used, so a thin
+        # owner handler never regresses a rule a category special served well.
+        owned = self._rule_owner.get(rule_id)
+        if owned is not None:
+            gen_key, method_name = owned
+            owner_out = getattr(self._generators[gen_key], method_name)(rule_id, code_snippet)
+            if self._fix_is_sound(owner_out):
+                return owner_out
+
+        return self._dispatch_via_category(rule_id, code_snippet, file_path, line_number)
+
+    def _dispatch_via_category(
         self,
         rule_id: str,
         code_snippet: str,
@@ -472,6 +515,48 @@ class RemediationGenerator(BaseRemediationGenerator):
     )
 
     _TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_./:-]{2,}")
+
+    # A ``✅ ...:`` Secure-Fix label followed, within a few prose lines, by a
+    # fenced block in any language a handler emits (yaml, jinja, dockerfile,
+    # ini, bash). ``finditer`` walks every such block so soundness reflects the
+    # fix a reader actually sees. The line tolerance matches the contract test.
+    _SOUND_FIX_BLOCK_RE = re.compile(
+        r"\*\*\u2705[^*\n]+:\*\*\s*\n(?:[^\n]*\n){0,3}```[a-zA-Z0-9_-]*\n(?P<body>.*?)\n```",
+        re.MULTILINE | re.DOTALL,
+    )
+    # A dangling ``{{`` (value extractor stopped inside ``{{ var }}``).
+    _SOUND_TRUNCATED_JINJA_RE = re.compile(r"\{\{(?=\s*[\"']?\s*$)", re.MULTILINE)
+    # Nested ``{{ ... {{ ... }} ... }}`` (invalid Jinja from an f-string paste).
+    _SOUND_NESTED_JINJA_RE = re.compile(r"\{\{(?:[^{}]|\}(?!\}))*\{\{")
+    # A fill-it-in-yourself placeholder instead of the finding's real value.
+    _SOUND_PLACEHOLDER_RE = re.compile(
+        r"\{\{\s*(?:remediation_command|your_command(?:_here)?|command_here|"
+        r"insert_command|replace_me|todo)\s*\}\}"
+        r"|<\s*(?:your[ _-]command|command[ _-]here|insert[ _-]command|replace[ _-]me)[^>]*>",
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _fix_is_sound(cls, output: str) -> bool:
+        """True when ``output`` carries a well-formed, non-broken Secure Fix.
+
+        At least one ``✅`` Secure Fix block must exist whose body has no
+        truncated or nested Jinja and no fill-it-in placeholder. Gates whether
+        a tailored handler's output is safe to prefer over a curated companion
+        snippet; a regressed handler falls back to the curated fix.
+        """
+        if not output or output.count("```") % 2 != 0:
+            return False
+        broken = (
+            cls._SOUND_TRUNCATED_JINJA_RE,
+            cls._SOUND_NESTED_JINJA_RE,
+            cls._SOUND_PLACEHOLDER_RE,
+        )
+        for match in cls._SOUND_FIX_BLOCK_RE.finditer(output):
+            body = match.group("body")
+            if not any(rx.search(body) for rx in broken):
+                return True
+        return False
 
     @classmethod
     def _distinctive_tokens(cls, text: str) -> set[str]:

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -33,6 +33,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ansible_security_scanner import comment
+from ansible_security_scanner.comment.inline import _render_inline_body
 from ansible_security_scanner.remediations.remediation_generator import (
     RemediationGenerator,
 )
@@ -3494,3 +3495,87 @@ class TestRenderedCommentBodyIsWellFormed:
                 f"{rid}: rendered MR-comment body has unbalanced "
                 f"triple-backtick fences (count={body.count('```')})"
             )
+
+
+# End-to-end inline-thread contract: the inline comment is what the reviewer
+# reads on the PR. Guards two regressions: (1) the "Show recommended fix"
+# expander repeating the title / description / recommendation already printed
+# above it, and (2) the Secure Fix reading as a disconnected generic example
+# instead of a fix for the flagged line. Exercises the full inline pipeline
+# (generator -> inline renderer) rather than the generator in isolation.
+class TestInlineThreadIsGroundedAndDeduplicated:
+    @staticmethod
+    def _finding(rule_id: str, snippet: str, *, description: str, recommendation: str):
+        rendered = RemediationGenerator().generate_remediation_example(
+            rule_id, snippet, file_path="inventory/group_vars/all.yml", line_number=21
+        )
+
+        @dataclass
+        class _F:
+            rule_id: str
+            severity: str
+            file_path: str
+            line_number: int
+            title: str
+            description: str
+            code_snippet: str
+            match_line: str
+            recommendation: str
+            remediation_example: str
+
+        return _F(
+            rule_id=rule_id,
+            severity="HIGH",
+            file_path="inventory/group_vars/all.yml",
+            line_number=21,
+            title="SSH args disable host key checking",
+            description=description,
+            code_snippet=snippet,
+            match_line=snippet,
+            recommendation=recommendation,
+            remediation_example=rendered,
+        )
+
+    def test_inline_expander_does_not_duplicate_description_and_recommendation(self):
+        description = "UNIQUE_DESCRIPTION_SENTINEL: host-key verification is disabled."
+        recommendation = "UNIQUE_RECOMMENDATION_SENTINEL: remove the bypass flags."
+        snippet = (
+            'ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
+        )
+        finding = self._finding(
+            "ssh_args_disable_host_key",
+            snippet,
+            description=description,
+            recommendation=recommendation,
+        )
+        body = _render_inline_body(finding, anchored=True)
+
+        # The description and recommendation are shown once, above the expander;
+        # the "Show recommended fix" block must not repeat them verbatim.
+        _, _, expander = body.partition("Show recommended fix")
+        assert description not in expander, (
+            "inline 'Show recommended fix' expander repeats the finding "
+            "description that is already shown above it:\n" + expander[:400]
+        )
+        assert recommendation not in expander, (
+            "inline 'Show recommended fix' expander repeats the finding "
+            "recommendation that is already shown above it:\n" + expander[:400]
+        )
+
+    def test_inline_fix_is_grounded_in_the_flagged_variable(self):
+        snippet = (
+            'ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"'
+        )
+        finding = self._finding(
+            "ssh_args_disable_host_key",
+            snippet,
+            description="host-key verification is disabled",
+            recommendation="remove the bypass flags",
+        )
+        body = _render_inline_body(finding, anchored=True)
+        # The fix must address the actual flagged inventory variable, not a
+        # disconnected ansible.cfg / file-permissions example.
+        assert "ansible_ssh_common_args" in body, (
+            "inline fix does not reference the flagged variable "
+            "`ansible_ssh_common_args`; it reads as a disconnected example:\n" + body[:600]
+        )

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -7,6 +7,7 @@ Run with `pytest tests/test_remediations.py`.
 
 from __future__ import annotations
 
+import ast
 import re
 import sys
 from pathlib import Path
@@ -19,7 +20,12 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
+from ansible_security_scanner.patterns_manager import known_rule_ids  # noqa: E402
 from ansible_security_scanner.remediations import _pattern_index as _PI  # noqa: E402
+from ansible_security_scanner.remediations.base import (  # noqa: E402
+    _finding_artifact,
+    _fix_references_artifact,
+)
 from ansible_security_scanner.remediations.insecure_communication import (  # noqa: E402
     InsecureCommunicationRemediationGenerator,
 )
@@ -88,6 +94,120 @@ def _collect_rule_positive_examples() -> list[tuple[str, str, str]]:
 
 
 ALL_POSITIVE_EXAMPLES = _collect_rule_positive_examples()
+
+
+# Every rule the scanner can emit, pattern and structural alike. The
+# catalog-driven tests above only see rules declared in ``patterns/*.yml``;
+# structural rules (emitted from ``file_scanner.py`` / ``taint_tracker.py`` with
+# no YAML entry) are covered here instead. ``KNOWN_RULE_IDS`` is the scanner's
+# authoritative universe; ``_emitted_rule_id_literals`` derives, from source,
+# every rule_id the emit sites construct, so the completeness test fails when a
+# new structural rule_id is added without being registered.
+
+KNOWN_RULE_IDS = sorted(known_rule_ids())
+
+_SCANNER_SOURCES = (
+    SRC / "ansible_security_scanner" / "file_scanner.py",
+    SRC / "ansible_security_scanner" / "taint_tracker.py",
+)
+# Call sites that construct a finding; the rule_id is either the ``rule_id=``
+# keyword or a positional string-literal argument.
+_EMIT_CALL_NAMES = frozenset({"_make_finding", "_make_jinja_finding", "emit", "SecurityFinding"})
+
+
+def _emitted_rule_id_literals() -> set[str]:
+    """Return every rule_id string literal the scanner constructs.
+
+    Walks the finding-emitting source with ``ast`` and collects string literals
+    passed as ``rule_id=`` or as a positional argument to a known finding
+    constructor. Dynamic rule_ids (the regex scanner's ``pattern_obj.id``) come
+    from ``patterns/*.yml`` and are already in ``KNOWN_RULE_IDS``, so only
+    literals need this static sweep.
+    """
+    found: set[str] = set()
+    for src in _SCANNER_SOURCES:
+        tree = ast.parse(src.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "attr", None) or getattr(func, "id", None)
+            if name not in _EMIT_CALL_NAMES:
+                continue
+            for kw in node.keywords:
+                if kw.arg == "rule_id" and isinstance(kw.value, ast.Constant):
+                    if isinstance(kw.value.value, str):
+                        found.add(kw.value.value)
+            for arg in node.args:
+                # Only identifier-shaped literals, so titles / descriptions in
+                # the positional list are not mistaken for rule_ids.
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    if re.fullmatch(r"[a-z][a-z0-9_]{3,}", arg.value):
+                        found.add(arg.value)
+    return found
+
+
+# Structural noise words that appear in almost every task and prove nothing
+# about grounding, excluded when checking a fix reuses a distinctive token from
+# a command/behaviour finding.
+_SNIPPET_STOPWORDS = frozenset(
+    {
+        "name",
+        "shell",
+        "command",
+        "ansible",
+        "builtin",
+        "true",
+        "false",
+        "yes",
+        "with",
+        "from",
+        "this",
+        "that",
+        "when",
+        "vars",
+        "task",
+        "tasks",
+        "value",
+        "state",
+        "present",
+        "absent",
+        "path",
+        "dest",
+        "mode",
+        "become",
+    }
+)
+_SNIPPET_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{3,}")
+
+
+def _distinctive_snippet_tokens(snippet: str) -> set[str]:
+    """Return lowercased distinctive tokens from a command/behaviour snippet.
+
+    Used to assert a fix reuses the flagged command (``auditd``, ``arpspoof``,
+    ``StrictHostKeyChecking``) when the finding has no structured artifact.
+    """
+    out: set[str] = set()
+    for m in _SNIPPET_TOKEN_RE.finditer(snippet or ""):
+        tok = m.group(0).lower().rstrip(".,;:")
+        if len(tok) >= 4 and tok not in _SNIPPET_STOPWORDS:
+            out.add(tok)
+    return out
+
+
+def _fix_is_grounded(out: str, artifact: str) -> bool:
+    """True when ``out`` references ``artifact`` from the finding.
+
+    A Jinja variable ``{{ x }}`` counts as grounded when the bare name appears
+    anywhere in the fix, since handlers often rewrite it into ``x`` inside a
+    ``register:`` / ``argv`` line.
+    """
+    if _fix_references_artifact(out, artifact) or artifact in out:
+        return True
+    jm = re.fullmatch(r"\{\{\s*([a-zA-Z_][\w.]*)\s*\}\}", artifact.strip())
+    if jm:
+        return re.search(rf"(?<![\w]){re.escape(jm.group(1))}(?![\w])", out) is not None
+    return False
 
 
 _UNRENDERED_PLACEHOLDER_PATTERNS = [
@@ -356,8 +476,17 @@ def test_remediation_is_relevant_to_the_rule(
     )
 
 
+# A Secure Fix block: a ``✅ ...:`` label followed, within a few prose lines, by
+# a fenced code block. Ansible fixes are YAML, but some rules remediate in the
+# fix's native language: jinja2 template rules emit ```jinja, vault-config rules
+# emit ```ini for ansible.cfg, EE rules emit ```dockerfile, and a few emit
+# shell. All are accepted; callers still validate the body for broken Jinja and
+# placeholders.
+_SECURE_FIX_LANGS = "(?:ya?ml|jinja2?|ini|dockerfile|toml|bash|sh|cfg)"
 _SECURE_FIX_BLOCK_RE = re.compile(
-    r"\*\*\u2705[^*\n]+:\*\*\s*\n(?:[^\n]*\n){0,3}```ya?ml\n(?P<body>.*?)\n```",
+    r"\*\*\u2705[^*\n]+:\*\*\s*\n(?:[^\n]*\n){0,3}```"
+    + _SECURE_FIX_LANGS
+    + r"?\n(?P<body>.*?)\n```",
     re.MULTILINE | re.DOTALL,
 )
 
@@ -512,6 +641,261 @@ def test_positive_example_renders_valid_secure_fix(
         f"  positive example: {positive_example[:160]!r}\n"
         f"  Secure Fix body (first 320 chars): {body[:320]!r}"
     )
+
+
+@pytest.mark.parametrize(
+    "rule_id,category,positive_example",
+    ALL_POSITIVE_EXAMPLES,
+    ids=[f"{r}#{i}" for i, (r, _, _) in enumerate(ALL_POSITIVE_EXAMPLES)],
+)
+def test_secure_fix_is_grounded_in_the_finding(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+    category: str,
+    positive_example: str,
+) -> None:
+    """Every fix must reference the finding's own concrete artifact.
+
+    Guards against a fix that reads plausibly but ignores the line it was
+    attached to (e.g. an ``ansible.cfg`` ``ini_file`` snippet rendered for an
+    ``ansible_ssh_common_args`` inventory finding). When the positive example
+    names a concrete artifact (URL, path, IP, Jinja variable, dotted host, or
+    the flagged inventory/config key) the rendered remediation must echo it back.
+
+    Examples carrying nothing concrete (a bare ``shell: echo x``) are skipped:
+    there is no artifact to demand.
+    """
+    artifact = _finding_artifact(positive_example)
+    if not artifact:
+        pytest.skip("positive example carries no concrete artifact to ground on")
+
+    out = remediation_generator.generate_remediation_example(
+        rule_id, positive_example, file_path="inventory/group_vars/all.yml", line_number=1
+    )
+
+    assert _fix_is_grounded(out, artifact), (
+        f"{rule_id}: the rendered remediation never references the finding's own "
+        f"artifact {artifact!r}. The fix reads as a disconnected/generic example "
+        f"rather than a fix for the flagged line.\n"
+        f"  positive example: {positive_example[:160]!r}\n"
+        f"  remediation excerpt (first 400 chars): {out[:400]!r}"
+    )
+
+
+def test_every_owned_rule_routes_to_a_sound_relevant_handler(
+    remediation_generator: RemediationGenerator,
+) -> None:
+    """Every rule with a tailored handler must reach it soundly.
+
+    ``RemediationGenerator`` builds a ``rule_id -> owning generator`` index from
+    each generator's ``_FIX_MAP``. This asserts the index is complete and that
+    dispatch through it produces a relevant, well-formed fix for every owned
+    rule, catching the bug where a rule's category pointed at the wrong
+    generator (so its real handler was unreachable and a foreign fix, e.g.
+    'Unsafe File Permissions' for an SSH trust-bypass finding, was emitted).
+    """
+    gen = remediation_generator
+    offenders: list[str] = []
+    for rule_id in sorted(gen._rule_owner):
+        examples = [ex for (rid, _cat, ex) in ALL_POSITIVE_EXAMPLES if rid == rule_id]
+        snippet = examples[0] if examples else "shell: echo placeholder"
+        out = gen.generate_remediation_example(
+            rule_id, snippet, file_path="test.yml", line_number=1
+        )
+        if not gen._is_relevant(rule_id, snippet, out):
+            offenders.append(f"{rule_id}: dispatched fix is not relevant to the rule")
+        elif not _SECURE_FIX_BLOCK_RE.search(out):
+            offenders.append(f"{rule_id}: dispatched fix has no Secure Fix block")
+
+    assert not offenders, (
+        f"{len(offenders)} owned rule(s) route to an irrelevant or malformed "
+        f"handler (likely a stale category mapping shadowing the real handler):\n  "
+        + "\n  ".join(offenders[:30])
+    )
+
+
+def test_known_rule_id_registry_is_complete() -> None:
+    """No finding-emitting call may construct a rule_id outside the registry.
+
+    ``patterns_manager.known_rule_ids()`` is the scanner's authoritative rule
+    universe (--select / --ignore / --list-rules resolve against it, and the
+    coverage test below iterates it). Structural rules are emitted as string
+    literals in ``file_scanner.py`` / ``taint_tracker.py``; if a new one is
+    added without registering it (a pattern YAML entry,
+    ``synthetic_rule_frameworks`` membership, or ``_CODE_EMITTED_RULE_IDS``) it
+    would escape the registry and every remediation contract test. This static
+    sweep fails when that happens.
+    """
+    emitted = _emitted_rule_id_literals()
+    unregistered = sorted(emitted - set(KNOWN_RULE_IDS))
+    assert not unregistered, (
+        f"{len(unregistered)} rule_id(s) are emitted by the scanner but are not "
+        f"in patterns_manager.known_rule_ids(). Register each one (add a "
+        f"patterns/*.yml entry, or add it to synthetic_rule_frameworks / "
+        f"_CODE_EMITTED_RULE_IDS) so it is covered by --select/--ignore, "
+        f"--list-rules, and the remediation contract tests:\n  " + "\n  ".join(unregistered)
+    )
+
+
+# Scan-meta rules report on the scan itself (a suppression directive about the
+# scanner, or a parse error) rather than on Ansible code, so they intentionally
+# carry a fixed advisory string instead of a Secure Fix YAML block.
+_SCAN_META_RULES = frozenset(
+    {
+        "scan_error",
+        "suspicious_suppression",
+        "unknown_suppression_rule",
+        "excessive_suppressions",
+    }
+)
+
+
+# Realistic snippets for structural (code-only) rules so the universal coverage
+# test below can render each against code it actually fires on rather than a
+# bare placeholder. A rule absent here still gets the placeholder snippet; this
+# map only sharpens the check for rules whose fix needs real task context.
+# Synthetic values only, never real inventory data.
+_STRUCTURAL_SNIPPETS: dict[str, str] = {
+    "get_url_dest_executable_with_insecure_validate": (
+        '- name: fetch tool\n  get_url:\n    url: "https://example.test/tool"\n'
+        '    dest: "/usr/local/bin/tool"\n    validate_certs: no'
+    ),
+    "become_user_without_become_true": (
+        "- name: run as svc\n  ansible.builtin.command: /usr/bin/app\n  become_user: svc_account"
+    ),
+    "no_log_explicitly_false_on_credential_task_ast": (
+        '- name: login\n  uri:\n    url: "https://example.test/auth"\n'
+        '    password: "{{ svc_password }}"\n  no_log: false'
+    ),
+    "cron_job_with_secret_in_argv": (
+        "- name: schedule\n  ansible.builtin.cron:\n    name: sync\n"
+        '    job: "/usr/bin/sync --token {{ api_token }}"'
+    ),
+    "docker_host_mount": (
+        "- name: run\n  community.docker.docker_container:\n    name: c\n"
+        '    volumes:\n      - "/var/run/docker.sock:/var/run/docker.sock"'
+    ),
+    "world_readable_sensitive": (
+        '- name: write cfg\n  copy:\n    dest: "/etc/app/secret.conf"\n    mode: "0644"'
+    ),
+    "connection_local_shell": (
+        '- name: local\n  connection: local\n  ansible.builtin.shell: "echo {{ payload }}"'
+    ),
+    "include_role_from_url": (
+        '- name: pull role\n  include_role:\n    name: "{{ item }}"\n'
+        '  vars:\n    src: "https://example.test/role.tar.gz"'
+    ),
+    "set_fact_injection": (
+        "- name: build fact\n  set_fact:\n    resolved_target: \"{{ lookup('pipe', untrusted_input) }}\""
+    ),
+    # Pattern rules whose catalog positive_example is too terse to ground on
+    # (tokens under the distinctive-length threshold). A realistic snippet lets
+    # the universal test enforce dynamism on them too.
+    "aws_s3_data_access": (
+        '- name: exfil\n  ansible.builtin.shell: "aws s3 cp s3://prod-secrets/creds.env /tmp/creds.env"'
+    ),
+    "aws_s3_list_or_delete": (
+        '- name: enumerate\n  ansible.builtin.shell: "aws s3 ls s3://prod-backups/"'
+    ),
+    "backdoor_listener": ('- name: listen\n  ansible.builtin.shell: "ncat -l -e /bin/bash 4444"'),
+    "env_var_constructed_command": (
+        '- name: obfuscated\n  ansible.builtin.shell: "$PAYLOAD_A$PAYLOAD_B | bash"'
+    ),
+    # Split so the file never contains a contiguous Mailchimp-format token
+    # (GitHub push protection flags it); the runtime value is a synthetic key.
+    "mailchimp_api_key": ('mailchimp_key: "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d' + '-us14"'),
+    "recursive_delete_critical": ('- name: cleanup\n  ansible.builtin.shell: "rm -rf /etc/nginx"'),
+    "ssh_socks_proxy": ('- name: tunnel\n  ansible.builtin.shell: "ssh -D 1080 jumphost.internal"'),
+    "yaml_unsafe_tag_generic": ('validator: !!python/object/apply:os.system ["id"]'),
+}
+
+
+@pytest.mark.parametrize("rule_id", KNOWN_RULE_IDS)
+def test_every_known_rule_renders_a_sound_fix(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+) -> None:
+    """Universal coverage: every rule the scanner can emit ships a sound fix.
+
+    Iterates the scanner's own ``known_rule_ids()`` universe, pattern rules and
+    structural code-only rules alike, so no finding type can escape the
+    remediation contract by living in Python instead of pattern YAML. Each rule
+    must render a well-formed Secure Fix (present, valid fence language, no
+    broken Jinja, no fill-it-in placeholder) that is relevant to the rule.
+
+    Scan-meta rules (``scan_error`` and the suppression auditors) report on the
+    scan itself, not on Ansible code, so they carry a fixed advisory
+    remediation rather than a Secure Fix block and are exempted.
+    """
+    if rule_id in _SCAN_META_RULES:
+        pytest.skip("scan-meta rule: reports on the scan, carries no Ansible Secure Fix")
+
+    snippet = _STRUCTURAL_SNIPPETS.get(rule_id)
+    if snippet is None:
+        examples = [ex for (rid, _cat, ex) in ALL_POSITIVE_EXAMPLES if rid == rule_id]
+        snippet = examples[0] if examples else "shell: echo placeholder"
+
+    out = remediation_generator.generate_remediation_example(
+        rule_id,
+        snippet,
+        file_path="inventory/group_vars/all.yml",
+        line_number=1,
+        description_fallback="structural rule description",
+        recommendation_fallback="structural rule recommendation",
+    )
+
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    assert match, (
+        f"{rule_id}: no `\u2705 Secure Fix` block; the fix dispatch fell through "
+        f"to a prose-only stub. Every known rule must ship an actionable fix.\n"
+        f"  snippet: {snippet[:120]!r}\n"
+        f"  remediation excerpt (first 320 chars): {out[:320]!r}"
+    )
+    body = match.group("body")
+    assert not _TRUNCATED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix contains a truncated Jinja expression (dangling `{{{{`)."
+        f"\n  body: {body[:320]!r}"
+    )
+    assert not _NESTED_JINJA_RE.search(body), (
+        f"{rule_id}: Secure Fix contains nested Jinja.\n  body: {body[:320]!r}"
+    )
+    ph = _GENERIC_PLACEHOLDER_RE.search(body)
+    assert not ph, (
+        f"{rule_id}: Secure Fix punts to a fill-it-in placeholder ({ph.group(0)!r}) "
+        f"instead of reusing the flagged code.\n  body: {body[:320]!r}"
+    )
+    assert remediation_generator._is_relevant(rule_id, snippet, out), (
+        f"{rule_id}: rendered fix is not relevant to the rule (wrong generator / "
+        f"stale category routing).\n  remediation excerpt: {out[:320]!r}"
+    )
+
+    # Dynamism: the fix must reuse this finding's input rather than emit a
+    # canned example. Two tiers, matching the two kinds of finding:
+    #   1. Value-bearing findings name a concrete artifact (path/host/URL/var/
+    #      key); the fix must echo that exact artifact back.
+    #   2. Behaviour/command findings (``systemctl stop auditd``, ``arpspoof``)
+    #      carry no structured value, so the fix must reference a distinctive
+    #      token from the input instead.
+    artifact = _finding_artifact(snippet)
+    if artifact:
+        assert _fix_is_grounded(out, artifact), (
+            f"{rule_id}: the fix never references the finding's own artifact "
+            f"{artifact!r}, so it reads as a static/generic example instead of a "
+            f"dynamic fix for the flagged input.\n"
+            f"  snippet: {snippet[:120]!r}\n"
+            f"  remediation excerpt (first 400 chars): {out[:400]!r}"
+        )
+    else:
+        tokens = _distinctive_snippet_tokens(snippet)
+        if tokens:
+            lowered = out.lower()
+            assert any(t in lowered for t in tokens), (
+                f"{rule_id}: the fix references none of the distinctive tokens "
+                f"from the flagged command/behaviour ({sorted(tokens)[:6]}), so it "
+                f"reads as a generic example rather than a fix for this finding.\n"
+                f"  snippet: {snippet[:120]!r}\n"
+                f"  remediation excerpt (first 400 chars): {out[:400]!r}"
+            )
 
 
 # Structural (AST / Python-defined) rules have no ``patterns/*.yml`` entry and


### PR DESCRIPTION
## Summary

- Route each rule to the generator that owns its tailored handler, so a stale category mapping can no longer serve a fix disconnected from the flagged line.
- Validate a handler's output before preferring it over a curated companion snippet; a regressed handler falls back to the grounded snippet instead of shipping a broken fix.
- Ground curated companion snippets by naming the finding's own artifact (path, host, URL, variable, or config key) when the snippet does not already reference it.
- Stop inline comments from repeating the description and recommendation inside the "Show recommended fix" expander, since both already appear above it.
- Extend coverage so every rule in the registry must render a sound fix that reuses the finding's input, and so the registry stays complete as new structural rules are added.