### PR TITLE
bump pinned pip to 26.2.1 to clear PYSEC-2026-3721

### DIFF
--- a/.github/constraints.in
+++ b/.github/constraints.in
@@ -1,4 +1,4 @@
-pip
+pip>=26.2
 pip-tools
 pre-commit
 build

--- a/.github/constraints.txt
+++ b/.github/constraints.txt
@@ -964,9 +964,9 @@ wheel==0.47.0 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2 \
-    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
-    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
     # via
     #   -r constraints.in
     #   pip-tools

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,9 @@ jobs:
             pre-commit-${{ runner.os }}-
 
       - name: Install pre-commit
-        run: pip install --require-hashes -c .github/constraints.txt pip pre-commit
+        run: |
+          pip_pin=$(grep -m1 -oE '^pip==[0-9][0-9.]*' .github/constraints.txt)
+          pip install --require-hashes -c .github/constraints.txt "$pip_pin" pre-commit
 
       - name: Run pre-commit on all files
         run: pre-commit run --all-files --show-diff-on-failure --color=always

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -40,7 +40,8 @@ jobs:
 
       - name: Install package with dev extras
         run: |
-          pip install --require-hashes -c .github/constraints.txt pip
+          pip_pin=$(grep -m1 -oE '^pip==[0-9][0-9.]*' .github/constraints.txt)
+          pip install --require-hashes -c .github/constraints.txt "$pip_pin"
           pip install -e ".[dev]"
 
       - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266  # v1.1.0

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -33,7 +33,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install pip-tools
-        run: pip install --require-hashes -c .github/constraints.txt pip pip-tools
+        run: |
+          pip_pin=$(grep -m1 -oE '^pip==[0-9][0-9.]*' .github/constraints.txt)
+          pip install --require-hashes -c .github/constraints.txt "$pip_pin" pip-tools
 
       - name: Recompile lockfile
         run: |

--- a/.github/workflows/scanner-ci.yml
+++ b/.github/workflows/scanner-ci.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Install package (editable) + test deps
         run: |
-          pip install --require-hashes -c .github/constraints.txt pip
+          pip_pin=$(grep -m1 -oE '^pip==[0-9][0-9.]*' .github/constraints.txt)
+          pip install --require-hashes -c .github/constraints.txt "$pip_pin"
           pip install -e ".[dev]"
 
       - name: Run scanner unit + regression tests


### PR DESCRIPTION
The audit workflow flagged pip 26.1.2 for PYSEC-2026-3721 (fixed in pip 26.2), which was failing the pip-audit check.

Pin `pip>=26.2` in the build constraints and regenerate the hash-locked `constraints.txt` (resolves to pip 26.2.1). The install steps that upgrade pip now read the pin from `constraints.txt` and pass it explicitly, so the upgrade succeeds under `--require-hashes` even when the runner ships an older pip.