### PR TITLE
Name credential findings from the rule that fired

### DIFF
--- a/src/ansible_security_scanner/cli.py
+++ b/src/ansible_security_scanner/cli.py
@@ -1012,6 +1012,7 @@ def _post_mr_comment(args, ctx, report, scanner) -> None:
         ignored_rule_ids=ignored_rule_ids,
         selected_rule_ids=selected_rule_ids,
         category_for_rule=category_for_rule,
+        suppression_warnings=list(getattr(report, "suppression_warnings", []) or []),
     )
     result = comment.post_or_update_comment(ctx, body)
 

--- a/src/ansible_security_scanner/comment/rendering.py
+++ b/src/ansible_security_scanner/comment/rendering.py
@@ -268,7 +268,7 @@ def _trim_to_head_and_tail(
 def _redact_snippet_line(line: str) -> str:
     """Single-line variant of ``_redact_snippet``.
 
-    ``_redact_snippet`` strips blank lines and dedents -- destructive
+    ``_redact_snippet`` strips blank lines and dedents - destructive
     when rendering a literal source-file window where indentation
     carries meaning. This helper applies just the secret-masking
     regexes and leaves whitespace untouched.
@@ -616,7 +616,7 @@ def _render_rule_disclosure(
 
     if len(rule_ids) > _IGNORE_HARD_CAP:
         top = ordered[:_IGNORE_TOP_CATEGORIES]
-        lines = [f"- **{_humanize_category(cat)}** \u2014 {len(rids)} rules" for cat, rids in top]
+        lines = [f"- **{_humanize_category(cat)}** - {len(rids)} rules" for cat, rids in top]
         tail = len(ordered) - len(top)
         if tail > 0:
             lines.append(f"- *...and {_pluralize(tail, 'more category', 'more categories')}*")
@@ -636,6 +636,55 @@ def _render_rule_disclosure(
 def _humanize_category(category_key: str) -> str:
     """Render a snake_case category key as a Title Cased label."""
     return category_key.replace("_", " ").title()
+
+
+# A scanner suppression-warning line has the shape
+# "WARN invalid suppression at <raw> -- <reason>". Split it back into its
+# two halves for the MR note so a reviewer sees the directive and why it
+# was ignored, not the internal log prefix.
+_SUPPRESSION_WARNING_PREFIX = "WARN invalid suppression at "
+_SUPPRESSION_WARNING_FLAT_LIMIT = 3
+
+
+def _split_suppression_warning(line: str) -> tuple[str, str]:
+    """Return the (directive, reason) pair from a scanner warning line.
+
+    The directive half is the raw source line and may carry a live secret,
+    so it is run through the same secret-masking pass as finding snippets
+    before it can reach the MR comment.
+    """
+    text = line.removeprefix(_SUPPRESSION_WARNING_PREFIX)
+    directive, _, reason = text.partition(" -- ")
+    return _redact_snippet_line(directive.strip()), reason.strip()
+
+
+def _render_suppression_warnings(warnings: list[str]) -> str:
+    """Render rejected ``# nosec`` / ``# noqa`` directives for the MR comment.
+
+    A rejected suppression means the author thought they silenced a finding
+    but their directive was ignored (no ``reason=``, no rule id, or an
+    unsuppressable rule). That decision is invisible unless it shows up next
+    to the findings they were trying to suppress, so it is rendered inline
+    rather than left in CI logs.
+    """
+    if not warnings:
+        return ""
+
+    head = f"{_pluralize(len(warnings), 'suppression directive')} ignored"
+    if len(warnings) <= _SUPPRESSION_WARNING_FLAT_LIMIT:
+        rows = []
+        for w in warnings:
+            directive, reason = _split_suppression_warning(w)
+            rows.append(f"`{directive}` - {reason}" if reason else f"`{directive}`")
+        listed = "; ".join(rows)
+        return f"> **Note:** {head}: {listed}."
+
+    summary = f"<summary><strong>Note:</strong> {head} (click to expand)</summary>"
+    lines = []
+    for w in warnings:
+        directive, reason = _split_suppression_warning(w)
+        lines.append(f"- `{directive}`" + (f": {reason}" if reason else ""))
+    return f"<details>\n{summary}\n\n" + "\n".join(lines) + "\n</details>"
 
 
 def _fence(body: str) -> str:
@@ -1186,6 +1235,7 @@ def render_comment_body(
     ignored_rule_ids: list[str] | None = None,
     selected_rule_ids: list[str] | None = None,
     category_for_rule: dict[str, str] | None = None,
+    suppression_warnings: list[str] | None = None,
 ) -> str:
     """Produce the final Markdown body for the MR/PR comment.
 
@@ -1217,6 +1267,8 @@ def render_comment_body(
         ignored_rule_ids=ignored_rule_ids,
         category_for_rule=category_for_rule,
     )
+    suppression_note = _render_suppression_warnings(suppression_warnings or [])
+    notes = "\n\n".join(n for n in (policy_note, suppression_note) if n)
 
     open_rule_ids = sorted(
         {getattr(f, "rule_id", "") for f in findings if getattr(f, "rule_id", "")}
@@ -1237,8 +1289,8 @@ def render_comment_body(
         footer = _render_footer(ctx, full_report_link)
         marker = _encode_marker(0, ctx.commit_sha, open_rule_ids)
         parts = [body, "---"]
-        if policy_note:
-            parts.extend([policy_note, "---"])
+        if notes:
+            parts.extend([notes, "---"])
         parts.extend([footer, marker])
         return "\n\n".join(parts) + "\n"
 
@@ -1273,7 +1325,7 @@ def render_comment_body(
         total,
         finding_fingerprints=finding_fingerprints,
         finding_rule_ids=finding_rule_ids,
-        policy_note=policy_note,
+        notes=notes,
     )
     if len(body.encode("utf-8")) <= _MAX_COMMENT_BYTES and total < _DASHBOARD_THRESHOLD:
         return body
@@ -1309,7 +1361,7 @@ def render_comment_body(
         trailing=tail_summary,
         finding_fingerprints=finding_fingerprints,
         finding_rule_ids=finding_rule_ids,
-        policy_note=policy_note,
+        notes=notes,
     )
     if len(body.encode("utf-8")) <= _MAX_COMMENT_BYTES:
         return body
@@ -1327,7 +1379,7 @@ def render_comment_body(
         trailing=tail_summary,
         finding_fingerprints=finding_fingerprints,
         finding_rule_ids=finding_rule_ids,
-        policy_note=policy_note,
+        notes=notes,
     )
 
 
@@ -1342,7 +1394,7 @@ def _render_drilldown(
     trailing: str = "",
     finding_fingerprints: list[str] | None = None,
     finding_rule_ids: list[str] | None = None,
-    policy_note: str = "",
+    notes: str = "",
 ) -> str:
     """Assemble header + rule blocks + footer + marker into the final
     comment body.
@@ -1361,9 +1413,9 @@ def _render_drilldown(
     parts.extend(blocks)
     if trailing:
         parts.append(trailing)
-    if policy_note:
+    if notes:
         parts.append("---")
-        parts.append(policy_note)
+        parts.append(notes)
     parts.append("---")
     parts.append(footer)
     parts.append(marker)

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -6,9 +6,25 @@ Base remediation generator for Ansible Security Scanner
 from __future__ import annotations
 
 import re
+from typing import TypedDict
 
 from ..variable_extractor import VariableExtractor
 from . import _companion_index, _pattern_index
+
+
+class CredentialInfo(TypedDict):
+    """Display name plus curated description and advice for a credential."""
+
+    name: str
+    description: str
+    security_advice: list[str]
+
+
+class _CredentialAdvice(TypedDict):
+    """Curated description and advice for a credential family."""
+
+    description: str
+    security_advice: list[str]
 
 
 def _first(snippet: str, *patterns: str) -> str | None:
@@ -116,6 +132,252 @@ def _select_secure_fix(rule_id: str) -> str | None:
     code, so they are intentionally not consulted as a remediation source.
     """
     return _companion_index.get(rule_id)
+
+
+# A JWT value is three base64url segments joined by dots, the first starting
+# with ``eyJ`` (the base64url of ``{"``). Matching the shape - not the word
+# ``token`` or ``jwt`` - keeps HEC/Vault/vendor API tokens from being
+# mislabelled as JWTs.
+_JWT_VALUE_RE = re.compile(r"\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*")
+
+# HEC context: an event-collector endpoint, an ``Authorization: Splunk`` header,
+# or an explicit HEC token key. Used to label a bare UUID token accurately.
+_SPLUNK_HEC_CONTEXT_RE = re.compile(
+    r"services/collector|authorization\s*:\s*[\"']?splunk\b|x-splunk|"
+    r"\bhec[_-]?(?:token|url|endpoint)\b|splunk_hec",
+    re.IGNORECASE,
+)
+
+
+def _is_jwt_value(code_snippet: str) -> bool:
+    """True when ``code_snippet`` contains an actual JWT (header.payload.sig)."""
+    return bool(_JWT_VALUE_RE.search(code_snippet or ""))
+
+
+def _is_splunk_hec_context(code_snippet: str) -> bool:
+    """True when the snippet is a Splunk HEC token in HEC context."""
+    return bool(_SPLUNK_HEC_CONTEXT_RE.search(code_snippet or ""))
+
+
+# Identity is humanised from the rule id, which already encodes the credential
+# (``okta_api_token_literal``). Peel these noise affixes before title-casing,
+# then apply the vendor casings.
+_RULE_ID_NOISE = (
+    "_literal",
+    "_credential",
+    "_credentials",
+    "_inline",
+    "_command",
+    "_on_disk",
+    "_in_playbook",
+    "_in_repo",
+    "_in_env_var",
+    "_default",
+    "_exposure",
+    "_leak",
+    "_pair",
+    "_auth",
+    "_var",
+    "_hardcoded",
+    "hardcoded_",
+)
+_IDENTITY_CASINGS = {
+    "api": "API",
+    "aws": "AWS",
+    "gcp": "GCP",
+    "jwt": "JWT",
+    "hec": "HEC",
+    "pat": "PAT",
+    "ssn": "SSN",
+    "pan": "PAN",
+    "oauth": "OAuth",
+    "url": "URL",
+    "ci": "CI",
+    "ipmi": "IPMI",
+    "sid": "SID",
+    "npm": "npm",
+    "pypi": "PyPI",
+    "oci": "OCI",
+    "gpp": "GPP",
+    "xml": "XML",
+    "mws": "MWS",
+    "id": "ID",
+    "sops": "SOPS",
+    "age": "age",
+    "mfa": "MFA",
+    "github": "GitHub",
+    "gitlab": "GitLab",
+    "us": "US",
+    "dockerhub": "DockerHub",
+}
+# Rule ids too generic to name a specific credential; fall back to the key.
+_GENERIC_CREDENTIAL_RULE_IDS = frozenset(
+    {
+        "hardcoded_credentials",
+        "hardcoded_token",
+        "hardcoded_secret",
+        "hardcoded_api_key",
+        "hardcoded_password",
+        "hardcoded_username",
+        "plaintext_credential_key_var",
+        "base64_like_secret",
+        "hex_secret",
+        "uuid_like_secret",
+    }
+)
+
+
+def _titleise_identifier(identifier: str) -> str:
+    """Render a snake/kebab identifier as a vendor-cased human name."""
+    words = [w for w in re.split(r"[_\-\s]+", identifier.strip()) if w]
+    return " ".join(_IDENTITY_CASINGS.get(w.lower(), w.capitalize()) for w in words)
+
+
+def _identity_from_rule_id(rule_id: str) -> str:
+    """Human credential name derived from the rule id (``okta_api_token``)."""
+    base = rule_id
+    for affix in _RULE_ID_NOISE:
+        if affix.endswith("_") and base.startswith(affix):
+            base = base[len(affix) :]
+        elif base.endswith(affix):
+            base = base[: -len(affix)]
+    return _titleise_identifier(base) or "Credential"
+
+
+def _identity_from_key(code_snippet: str) -> str | None:
+    """Human credential name derived from the flagged ``key:`` on the line."""
+    m = _GROUND_KEY_RE.search(code_snippet or "")
+    if not m:
+        return None
+    key = m.group(1)
+    if key.lower() in ("name", "line", "url", "src", "dest", "path"):
+        return None
+    return _titleise_identifier(key) or None
+
+
+def _credential_identity(rule_id: str, code_snippet: str) -> str:
+    """Resolve a credential's display name from the rule, then the key.
+
+    Never inferred from the value's shape: that guessing is exactly what
+    labelled every ``token:`` line a JWT. A specific rule names itself; a
+    generic rule (``hardcoded_token``) borrows the flagged key; only when
+    both are silent does a neutral, non-guessing default apply.
+    """
+    if rule_id and rule_id not in _GENERIC_CREDENTIAL_RULE_IDS:
+        return _identity_from_rule_id(rule_id)
+    return _identity_from_key(code_snippet) or "Hardcoded Credential"
+
+
+# Curated advice family per rule id, matched most-specific first on the rule
+# id (not the value). The family only selects security advice; the displayed
+# name always comes from _credential_identity.
+_CREDENTIAL_FAMILY_BY_RULE: tuple[tuple[str, str], ...] = (
+    ("stripe", "stripe"),
+    ("aws", "aws"),
+    ("github", "github"),
+    ("gitlab", "github"),
+    ("webhook", "webhook"),
+    ("slack", "webhook"),
+    ("splunk_hec", "splunk_hec"),
+    ("jwt", "jwt"),
+    ("password", "password"),
+    ("passwd", "password"),
+    ("api_key", "api_key"),
+    ("apikey", "api_key"),
+)
+
+_CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
+    "stripe": {
+        "description": "This Stripe key provides access to payment processing and financial data. Live keys handle real transactions.",
+        "security_advice": [
+            "Use separate keys for test and live environments",
+            "Implement webhook signature verification",
+            "Use restricted API keys with minimal permissions",
+            "Monitor transactions and set up fraud alerts",
+        ],
+    },
+    "aws": {
+        "description": "AWS access keys provide programmatic access to AWS services and should never be hardcoded.",
+        "security_advice": [
+            "Use IAM roles instead of access keys when possible",
+            "Implement least-privilege access policies",
+            "Enable AWS CloudTrail for API auditing",
+            "Store secrets in AWS Systems Manager Parameter Store or Secrets Manager",
+        ],
+    },
+    "github": {
+        "description": "This token provides access to repositories and platform APIs based on its configured scopes.",
+        "security_advice": [
+            "Use fine-grained tokens with minimal scopes",
+            "Set token expiration dates (90 days maximum recommended)",
+            "Use platform apps for organization-wide automation",
+            "Enable secret scanning in your repositories",
+        ],
+    },
+    "webhook": {
+        "description": "This webhook URL embeds an authentication token that grants access to an external service.",
+        "security_advice": [
+            "Use HTTPS webhooks only",
+            "Implement webhook signature verification",
+            "Restrict webhook endpoints by IP where possible",
+            "Use separate webhooks for different environments",
+        ],
+    },
+    "jwt": {
+        "description": "JSON Web Tokens carry encoded authentication and authorization claims and stay valid until they expire or their signing key is rotated.",
+        "security_advice": [
+            "Use strong signing keys and rotate them regularly",
+            "Set short token expiration times",
+            "Validate tokens on every request",
+            "Transmit tokens only over HTTPS",
+        ],
+    },
+    "splunk_hec": {
+        "description": "A Splunk HTTP Event Collector token authorizes event submission to the configured index. A leaked token lets an attacker forge or flood events and burn ingest quota until it is rotated.",
+        "security_advice": [
+            "Rotate the HEC token in Splunk immediately, then reference it from Vault at runtime",
+            "Scope each HEC token to a narrow Allowed Indexes list and a single sourcetype",
+            "Enable TLS on the collector endpoint and verify certificates",
+            "Monitor per-token ingest volume for anomalous spikes",
+        ],
+    },
+    "api_key": {
+        "description": "API keys provide programmatic access to a service and must be treated as live credentials.",
+        "security_advice": [
+            "Rotate the key at the issuing service immediately",
+            "Use different keys per environment",
+            "Monitor key usage and alert on unusual activity",
+            "Reference the key from Vault or a secrets manager, never a literal",
+        ],
+    },
+    "password": {
+        "description": "A plaintext password in source is a live credential the moment it is committed.",
+        "security_advice": [
+            "Rotate the password immediately",
+            "Reference it from Ansible Vault or a secrets manager",
+            "Use unique passwords per service account",
+            "Enable multi-factor authentication where the service supports it",
+        ],
+    },
+    "form_data": {
+        "description": "Form data containing authentication credentials must be secured like any other secret.",
+        "security_advice": [
+            "Use structured authentication instead of form encoding where possible",
+            "Reference credentials from Vault, never inline",
+            "Use HTTPS for all form submissions",
+            "Mark the task no_log: true so the value is not logged",
+        ],
+    },
+    "generic": {
+        "description": "This credential authenticates to a service and stays valid until it is rotated at the issuer. Committed to source, it is a live credential.",
+        "security_advice": [
+            "Rotate the credential at the issuing service immediately",
+            "Reference it from Ansible Vault or a secrets manager, never a literal",
+            "Scope the credential to the minimum permissions it needs",
+            "Transmit credentials only over HTTPS",
+        ],
+    },
+}
 
 
 # Grounding a curated fix in the finding's own code. A curated ``secure_fix``
@@ -237,123 +499,44 @@ class BaseRemediationGenerator:
 
         return f"vault_{var_name}"
 
-    def _detect_credential_type(self, code_snippet: str) -> str:
-        """Detect the type of credential based on patterns in the code"""
+    def _detect_credential_type(self, code_snippet: str, rule_id: str = "") -> str:
+        """Resolve the curated advice family for a credential finding.
+
+        The family drives *security advice*, not the displayed identity, and
+        is taken from the rule that fired, never guessed from the value. A
+        specific rule maps to its vendor family (``stripe_*`` -> ``stripe``);
+        a generic rule falls back to a key hint (a ``password:`` line ->
+        ``password``) and otherwise to sound, vendor-neutral advice.
+        """
+        rid = (rule_id or "").lower()
+        for needle, family in _CREDENTIAL_FAMILY_BY_RULE:
+            if needle in rid:
+                return family
+
         code_lower = code_snippet.lower()
-
-        if any(pattern in code_lower for pattern in ["stripe", "sk_live", "sk_test"]):
-            return "stripe_key"
-        if any(pattern in code_lower for pattern in ["aws", "akia", "secret_access"]):
-            return "aws_key"
-        if any(pattern in code_lower for pattern in ["github", "ghp_", "gho_"]):
-            return "github_token"
-        if any(pattern in code_lower for pattern in ["slack", "webhook", "hooks.slack.com"]):
-            return "webhook_url"
-        if any(pattern in code_lower for pattern in ["jwt", "bearer", "token"]):
-            return "jwt_token"
-        if any(pattern in code_lower for pattern in ["api_key", "apikey"]):
-            return "api_key"
-        if any(pattern in code_lower for pattern in ["password", "passwd", "pwd"]):
+        if _is_jwt_value(code_snippet):
+            return "jwt"
+        if _is_splunk_hec_context(code_snippet):
+            return "splunk_hec"
+        if any(p in code_lower for p in ["password", "passwd", "pwd"]):
             return "password"
-        if any(pattern in code_lower for pattern in ["secret", "key"]):
-            return "secret"
-        return "credential"
+        if any(p in code_lower for p in ["api_key", "apikey", "api-key"]):
+            return "api_key"
+        return "generic"
 
-    def _get_credential_type_info(self, credential_type: str) -> dict[str, str]:
-        """Get information about a specific credential type"""
-        credential_info = {
-            "stripe_key": {
-                "name": "Stripe API Key",
-                "description": "This Stripe key provides access to payment processing and financial data. Live keys handle real transactions.",
-                "security_advice": [
-                    "Use separate keys for test and live environments",
-                    "Implement webhook signature verification",
-                    "Use restricted API keys with minimal permissions",
-                    "Monitor transactions and set up fraud alerts",
-                ],
-            },
-            "aws_key": {
-                "name": "AWS Access Key",
-                "description": "This appears to be an AWS Access Key ID. These keys provide programmatic access to AWS services and should never be hardcoded.",
-                "security_advice": [
-                    "Use IAM roles instead of access keys when possible",
-                    "Implement least-privilege access policies",
-                    "Enable AWS CloudTrail for API auditing",
-                    "Consider using AWS Systems Manager Parameter Store for secrets",
-                ],
-            },
-            "github_token": {
-                "name": "GitHub Personal Access Token",
-                "description": "This GitHub token provides access to repositories and GitHub APIs based on configured permissions.",
-                "security_advice": [
-                    "Use fine-grained personal access tokens with minimal scopes",
-                    "Set token expiration dates (90 days maximum recommended)",
-                    "Use GitHub Apps for organization-wide automation",
-                    "Enable secret scanning in your repositories",
-                ],
-            },
-            "webhook_url": {
-                "name": "Webhook URL with Token",
-                "description": "This webhook URL contains embedded authentication tokens that grant access to external services.",
-                "security_advice": [
-                    "Use HTTPS webhooks only",
-                    "Implement webhook signature verification",
-                    "Consider IP whitelisting for webhook endpoints",
-                    "Use separate webhooks for different environments",
-                ],
-            },
-            "jwt_token": {
-                "name": "JWT Token",
-                "description": "JSON Web Tokens contain encoded authentication and authorization information.",
-                "security_advice": [
-                    "Use strong signing keys and rotate them regularly",
-                    "Implement proper token expiration times",
-                    "Validate tokens on every request",
-                    "Use HTTPS for all token transmission",
-                ],
-            },
-            "api_key": {
-                "name": "API Key",
-                "description": "API keys provide programmatic access to services and should be treated as sensitive credentials.",
-                "security_advice": [
-                    "Implement key rotation policies",
-                    "Use different keys for different environments",
-                    "Monitor API key usage and set up alerts for unusual activity",
-                    "Implement rate limiting and proper authentication",
-                ],
-            },
-            "password": {
-                "name": "Password",
-                "description": "Sensitive credentials should never be stored in plaintext in configuration files or code.",
-                "security_advice": [
-                    "Use strong, unique passwords (minimum 12 characters)",
-                    "Implement multi-factor authentication where possible",
-                    "Use password managers for generation and storage",
-                    "Rotate passwords regularly, especially for service accounts",
-                ],
-            },
-            "form_data": {
-                "name": "Form Data Authentication",
-                "description": "Form data containing authentication credentials should be properly secured.",
-                "security_advice": [
-                    "Use structured authentication instead of form encoding where possible",
-                    "Implement proper session management",
-                    "Use HTTPS for all form submissions",
-                    "Validate and sanitize all form inputs",
-                ],
-            },
-        }
+    def _get_credential_type_info(
+        self, credential_type: str, *, rule_id: str = "", code_snippet: str = ""
+    ) -> CredentialInfo:
+        """Advice for a credential family, named from the rule/key.
 
-        return credential_info.get(
-            credential_type,
-            {
-                "name": "Credential",
-                "description": "Sensitive credentials should never be stored in plaintext in configuration files or code.",
-                "security_advice": [
-                    "Use dedicated secret management systems (HashiCorp Vault, AWS Secrets Manager)",
-                    "Implement secret rotation policies",
-                    "Audit secret access and usage",
-                    "Never log or cache secrets",
-                ],
-            },
+        The ``name`` is always resolved by :func:`_credential_identity` from
+        the rule id (then the flagged key), so a finding is never labelled by
+        guessing at the value. Only the description and advice come from the
+        curated family map, with a sound vendor-neutral default.
+        """
+        family = _CREDENTIAL_ADVICE.get(credential_type, _CREDENTIAL_ADVICE["generic"])
+        return CredentialInfo(
+            name=_credential_identity(rule_id, code_snippet),
+            description=family["description"],
+            security_advice=list(family["security_advice"]),
         )

--- a/src/ansible_security_scanner/remediations/credentials.py
+++ b/src/ansible_security_scanner/remediations/credentials.py
@@ -13,12 +13,10 @@ class CredentialsRemediationGenerator(BaseRemediationGenerator):
     """Generates remediation for hardcoded credentials"""
 
     def generate_hardcoded_credentials_fix(
-        self, code_snippet: str, var_name: str, env_var: str
+        self, code_snippet: str, var_name: str, env_var: str, rule_id: str = ""
     ) -> str:
         """Generate fix for hardcoded credentials using actual code context"""
-
-        # Analyze the actual code to provide contextual fixes
-        return self._generate_contextual_credential_fix(code_snippet, var_name, env_var)
+        return self._generate_contextual_credential_fix(code_snippet, var_name, env_var, rule_id)
 
     def generate_webhook_exposure_fix(self, code_snippet: str, var_name: str, env_var: str) -> str:
         """Generate fix for webhook URL exposure"""
@@ -147,7 +145,7 @@ Webhook URLs often contain embedded tokens or secrets that should not be exposed
         if not secret_fields:
             return self.generate_hardcoded_credentials_fix(code_snippet, var_name, env_var)
 
-        credential_info = self._get_credential_type_info("form_data")
+        credential_info = self._get_credential_type_info("form_data", code_snippet=code_snippet)
 
         template = f"""
 **❌ Vulnerable Code:**
@@ -737,15 +735,15 @@ shell: >-
                 os.remove(temp_file)
 
     def _generate_contextual_credential_fix(
-        self, code_snippet: str, var_name: str, env_var: str
+        self, code_snippet: str, var_name: str, env_var: str, rule_id: str = ""
     ) -> str:
         """Generate contextual fix based on the actual code found"""
 
-        # Detect the specific pattern in the code
-        credential_type = self._detect_credential_type(code_snippet)
-        credential_info = self._get_credential_type_info(credential_type)
+        credential_type = self._detect_credential_type(code_snippet, rule_id)
+        credential_info = self._get_credential_type_info(
+            credential_type, rule_id=rule_id, code_snippet=code_snippet
+        )
 
-        # Extract actual values and variable names from the code
         extracted_info = self._extract_credential_info(code_snippet)
 
         template = f"""

--- a/src/ansible_security_scanner/remediations/remediation_generator.py
+++ b/src/ansible_security_scanner/remediations/remediation_generator.py
@@ -331,20 +331,28 @@ class RemediationGenerator(BaseRemediationGenerator):
         file_path: str,
         line_number: int,
     ) -> tuple:
-        """Pull the (var, env_var) pair the credential-style remediations need."""
+        """Pull the (var, env_var) pair the credential-style remediations need.
+
+        The extractors gate their credential logic on the literal rule_id
+        ``hardcoded_credentials``, so pass that for every rule in the
+        credentials category. Otherwise a specific rule
+        (``okta_api_token_literal``) falls through to the ``VARIABLE_NAME``
+        placeholder instead of the finding's real key.
+        """
+        extract_id = "hardcoded_credentials" if category == "hardcoded_credentials" else rule_id
         if category == "hardcoded_credentials" and file_path and line_number:
             var = self.variable_extractor.extract_variable_name_from_context(
-                file_path, line_number, rule_id
+                file_path, line_number, extract_id
             )
             env = self.variable_extractor.extract_env_var_name_from_context(
-                file_path, line_number, rule_id
+                file_path, line_number, extract_id
             )
             if var in ("variable_name", "credential", "secret"):
-                var = self.variable_extractor.extract_variable_name(code_snippet, rule_id)
-                env = self.variable_extractor.extract_env_var_name(code_snippet, rule_id)
+                var = self.variable_extractor.extract_variable_name(code_snippet, extract_id)
+                env = self.variable_extractor.extract_env_var_name(code_snippet, extract_id)
         else:
-            var = self.variable_extractor.extract_variable_name(code_snippet, rule_id)
-            env = self.variable_extractor.extract_env_var_name(code_snippet, rule_id)
+            var = self.variable_extractor.extract_variable_name(code_snippet, extract_id)
+            env = self.variable_extractor.extract_env_var_name(code_snippet, extract_id)
         return var, env
 
     # Category-specific handlers. Each accepts the same kwargs so they're safe
@@ -396,7 +404,7 @@ class RemediationGenerator(BaseRemediationGenerator):
             and len(re.findall(r'(\w+)=([^&"\']+)', code_snippet)) > 2
         ):
             return g.generate_form_data_fix(code_snippet, var_name, env_var_name)
-        return g.generate_hardcoded_credentials_fix(code_snippet, var_name, env_var_name)
+        return g.generate_hardcoded_credentials_fix(code_snippet, var_name, env_var_name, rule_id)
 
     def _gen_webhook(self, *, code_snippet, var_name, env_var_name, **_kw):
         return self._generators["webhook_exposure"].generate_webhook_exposure_fix(

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -3579,3 +3579,46 @@ class TestInlineThreadIsGroundedAndDeduplicated:
             "inline fix does not reference the flagged variable "
             "`ansible_ssh_common_args`; it reads as a disconnected example:\n" + body[:600]
         )
+
+
+class TestSuppressionWarningsInComment:
+    """A rejected ``# nosec`` / ``# noqa`` directive must surface in the MR
+    comment, not only in CI logs. If it stays in the logs the author sees
+    the finding still posted and assumes the tool is broken, never learning
+    their suppression was ignored and why.
+    """
+
+    _UUID = "e017639c" + "-db22-4933-936c-2950972a1e5c"
+
+    def _warning(self, reason: str = 'missing reason (write `reason="..."`)') -> str:
+        return (
+            f'WARN invalid suppression at site.yml:12: token: "{self._UUID}"  '
+            f"# nosec: hardcoded_token -- {reason}"
+        )
+
+    def test_rejected_suppression_appears_in_body(self):
+        findings = [StubFinding("hardcoded_token", "HIGH", "site.yml", 12, "t")]
+        body = comment.render_comment_body(
+            findings, _ctx("github"), suppression_warnings=[self._warning()]
+        )
+        assert "suppression directive ignored" in body
+        assert "hardcoded_token" in body
+        assert "missing reason" in body
+
+    def test_directive_secret_is_redacted_in_body(self):
+        findings = [StubFinding("hardcoded_token", "HIGH", "site.yml", 12, "t")]
+        body = comment.render_comment_body(
+            findings, _ctx("github"), suppression_warnings=[self._warning()]
+        )
+        assert self._UUID not in body, "suppression note leaked the raw credential value"
+
+    def test_appears_on_resolved_zero_finding_run(self):
+        body = comment.render_comment_body(
+            [], _ctx("github"), suppression_warnings=[self._warning()]
+        )
+        assert "suppression directive ignored" in body
+
+    def test_no_note_when_no_warnings(self):
+        findings = [StubFinding("hardcoded_token", "HIGH", "site.yml", 12, "t")]
+        body = comment.render_comment_body(findings, _ctx("github"))
+        assert "suppression directive ignored" not in body

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -23,6 +23,7 @@ if str(SRC) not in sys.path:
 from ansible_security_scanner.patterns_manager import known_rule_ids  # noqa: E402
 from ansible_security_scanner.remediations import _pattern_index as _PI  # noqa: E402
 from ansible_security_scanner.remediations.base import (  # noqa: E402
+    BaseRemediationGenerator,
     _finding_artifact,
     _fix_references_artifact,
 )
@@ -1646,3 +1647,123 @@ class TestDataDestructionDynamicFixes:
             assert _SECURE_FIX_BLOCK_RE.search(out), (
                 f"{rule_id}: no Secure Fix block - dispatch regressed"
             )
+
+
+class TestCredentialTypeLabelling:
+    """A credential finding is named from the rule that fired, then the
+    flagged key, never guessed from the value. That guessing is what
+    labelled every ``token:`` line a JWT and produced the vague "Access
+    Token" catch-all; both are gone. A specific rule names itself
+    (``splunk_hec_token_literal`` -> "Splunk HEC Token"); a generic rule
+    borrows the key (``okta_api_token:`` -> "Okta API Token").
+    """
+
+    _HEC_UUID = "e017639c" + "-db22-4933-936c-2950972a1e5c"
+    _REAL_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.c2ln"
+
+    @pytest.fixture(scope="class")
+    def base(self) -> BaseRemediationGenerator:
+        return BaseRemediationGenerator()
+
+    @pytest.mark.parametrize(
+        "rule_id,snippet,expected_name",
+        [
+            ("splunk_hec_token_literal", f'token: "{_HEC_UUID}"', "Splunk HEC Token"),
+            ("okta_api_token_literal", f'token: "{_HEC_UUID}"', "Okta API Token"),
+            ("aws_access_key", 'aws_access_key: "AKIA1234567890ABCD"', "AWS Access Key"),
+            ("stripe_live_secret_key_literal", 'k: "sk_live_x"', "Stripe Live Secret Key"),
+            ("github_personal_access_token_literal", 'k: "ghp_x"', "GitHub Personal Access Token"),
+            ("hardcoded_token", f'okta_api_token: "{_HEC_UUID}"', "Okta API Token"),
+            ("hardcoded_password", 'db_password: "hunter2hunter2"', "Db Password"),
+            ("jwt_token", f'token: "{_REAL_JWT}"', "JWT Token"),
+        ],
+    )
+    def test_identity_comes_from_rule_then_key(self, base, rule_id, snippet, expected_name):
+        family = base._detect_credential_type(snippet, rule_id)
+        info = base._get_credential_type_info(family, rule_id=rule_id, code_snippet=snippet)
+        assert info["name"] == expected_name, (
+            f"{rule_id} / {snippet!r} named {info['name']!r}, expected {expected_name!r}"
+        )
+
+    def test_bare_token_is_not_labelled_jwt(self, base):
+        """The exact regression: a UUID token value must not read as a JWT."""
+        family = base._detect_credential_type(f'token: "{self._HEC_UUID}"', "hardcoded_token")
+        info = base._get_credential_type_info(
+            family, rule_id="hardcoded_token", code_snippet=f'okta_api_token: "{self._HEC_UUID}"'
+        )
+        assert "JWT" not in info["name"], info
+
+    def test_every_credential_rule_labels_non_jwt_correctly(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """Semantic-label coverage across every credential-routed rule: a
+        finding whose value is not a JWT must never render 'JWT Token
+        Detected', and no rule may fall back to a generic guessed label.
+        This is the assertion that catches the whole class of mislabels,
+        not just the one rule that surfaced it.
+        """
+        from ansible_security_scanner.remediations._category_map import resolve_category
+
+        cred_ids = [
+            rid
+            for rid in sorted(known_rule_ids())
+            if resolve_category(rid) == "hardcoded_credentials"
+        ]
+        assert cred_ids, "no credential rules resolved; category map regressed"
+
+        mislabelled: list[str] = []
+        generic: list[str] = []
+        for rid in cred_ids:
+            snippet = f'{rid}: "{self._HEC_UUID}"'
+            out = remediation_generator.generate_remediation_example(rid, snippet) or ""
+            if "JWT Token Detected" in out and rid != "jwt_token":
+                mislabelled.append(rid)
+            # The retired catch-all rendered exactly this header. A real vendor
+            # name ("Facebook Access Token") is fine; the bare label is not.
+            if "\U0001f6a8 Access Token Detected:" in out:
+                generic.append(rid)
+
+        assert not mislabelled, (
+            "these credential rules render 'JWT Token Detected' for a non-JWT "
+            f"(UUID) value, which is wrong: {mislabelled}"
+        )
+        assert not generic, (
+            "these credential rules fall back to the retired bare 'Access Token' "
+            f"label instead of naming the credential from the rule/key: {generic}"
+        )
+
+    def test_every_credential_rule_generates_a_grounded_fix(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """Every credential rule must generate a fix built from the finding's
+        real key and value, never a placeholder. A leaked ``VARIABLE_NAME`` or
+        a ``vault_variable_name`` var means the extractor fell through to its
+        sentinel instead of reading the flagged line.
+        """
+        from ansible_security_scanner.remediations._category_map import resolve_category
+
+        cred_ids = [
+            rid
+            for rid in sorted(known_rule_ids())
+            if resolve_category(rid) == "hardcoded_credentials"
+        ]
+        assert cred_ids, "no credential rules resolved; category map regressed"
+
+        key = "okta_api_token"
+        ungrounded: list[str] = []
+        for rid in cred_ids:
+            snippet = f'    {key}: "{self._HEC_UUID}"'
+            out = remediation_generator.generate_remediation_example(rid, snippet) or ""
+            if (
+                "VARIABLE_NAME" in out
+                or "vault_variable_name" in out
+                or "your_actual_credential" in out
+                or key not in out
+                or self._HEC_UUID not in out
+            ):
+                ungrounded.append(rid)
+
+        assert not ungrounded, (
+            "these credential rules emit a placeholder or drop the finding's real "
+            f"key/value from the generated fix: {ungrounded}"
+        )


### PR DESCRIPTION
- Resolve a credential finding's display name from the rule id, then the flagged key, never by guessing at the value's shape. The value guessing labelled every token line a JWT and fell back to a vague Access Token catch-all; both are removed.
- Humanize the rule id into the credential name (okta_api_token_literal becomes Okta API Token) with vendor casing, so the name stays accurate as new rules are added without a hand-maintained table.
- Derive the credential's variable and env var for every rule in the credentials category, not only the literal hardcoded_credentials rule, so a specific rule's generated fix reuses the finding's real key instead of a VARIABLE_NAME placeholder.
- Surface rejected nosec and noqa directives in the merge request comment, redacted and with their reason, so an author who wrote an incomplete suppression learns why it was ignored instead of only seeing it in CI logs.