### PR TITLE
Ground credential remediations on the flagged line

### DIFF
--- a/src/ansible_security_scanner/file_scanner.py
+++ b/src/ansible_security_scanner/file_scanner.py
@@ -4401,6 +4401,23 @@ class FileScanner:
             cls._pattern_tag_index = idx
         return cls._pattern_tag_index.get(rule_id, {})
 
+    def _flagged_line(self, file_path, line_num: int) -> str:
+        """Return the redacted content of the flagged line, or ``""``.
+
+        Used to ground structural findings on their own line rather than on an
+        incidental URL/path elsewhere in the enclosing task window.
+        """
+        if not line_num or line_num < 1:
+            return ""
+        try:
+            with open(file_path, encoding="utf-8") as f:
+                lines = f.readlines()
+            if line_num <= len(lines):
+                return redact_secrets(lines[line_num - 1].strip())
+        except (OSError, UnicodeDecodeError) as e:
+            logger.debug("could not read flagged line %s:%d: %s", file_path, line_num, e)
+        return ""
+
     def _make_finding(
         self,
         file_path,
@@ -4449,6 +4466,7 @@ class FileScanner:
                 snippet,
                 str(file_path.absolute()),
                 line_num,
+                ground_snippet=self._flagged_line(file_path, line_num) or None,
                 title_fallback=title or "",
                 description_fallback=description or "",
                 recommendation_fallback=recommendation or "",
@@ -7154,8 +7172,10 @@ class FileScanner:
         ):
             return
 
-        snippet = self._task_window_snippet(all_lines, line_num) or _normalize_display_snippet(line)
-        snippet = redact_secrets(snippet)
+        raw_snippet = self._task_window_snippet(all_lines, line_num) or _normalize_display_snippet(
+            line
+        )
+        snippet = redact_secrets(raw_snippet)
 
         try:
             if pattern_obj.category in ["variable_injection", "unsafe_permissions"]:
@@ -7163,6 +7183,17 @@ class FileScanner:
                 remediation_example = self.remediation_generator.generate_remediation_example(
                     pattern_obj.id,
                     task_context,
+                    str(file_path.absolute()),
+                    line_num,
+                    display_snippet=snippet,
+                )
+            elif pattern_obj.category == "hardcoded_credentials":
+                # Feed the enclosing task (unredacted, so value extraction and
+                # context-based identity work) as the generation input, while
+                # the Vulnerable Code block still renders the redacted snippet.
+                remediation_example = self.remediation_generator.generate_remediation_example(
+                    pattern_obj.id,
+                    raw_snippet or line.strip(),
                     str(file_path.absolute()),
                     line_num,
                     display_snippet=snippet,

--- a/src/ansible_security_scanner/remediations/base.py
+++ b/src/ansible_security_scanner/remediations/base.py
@@ -8,8 +8,18 @@ from __future__ import annotations
 import re
 from typing import TypedDict
 
-from ..variable_extractor import VariableExtractor
+from ..variable_extractor import (
+    _NON_CREDENTIAL_KEYS,
+    VariableExtractor,
+    looks_like_credential_key,
+)
 from . import _companion_index, _pattern_index
+from ._category_map import resolve_category
+
+# The remediation layer historically referred to this predicate as
+# ``_key_is_credential``; it now lives in variable_extractor as the single
+# source of truth (base cannot own it without a circular import).
+_key_is_credential = looks_like_credential_key
 
 
 class CredentialInfo(TypedDict):
@@ -21,8 +31,15 @@ class CredentialInfo(TypedDict):
 
 
 class _CredentialAdvice(TypedDict):
-    """Curated description and advice for a credential family."""
+    """Curated description and advice for a credential family.
 
+    ``name`` is the family's canonical identity when the family itself names a
+    specific credential (Splunk HEC, Stripe). It is ``None`` for families that
+    only carry advice (``generic``, ``password``, ``api_key``, ``form_data``),
+    which defer their name to the rule id or the flagged key.
+    """
+
+    name: str | None
     description: str
     security_advice: list[str]
 
@@ -81,6 +98,7 @@ def _render_from_metadata(
     rule_id: str,
     code_snippet: str,
     *,
+    ground_snippet: str | None = None,
     title_fallback: str = "",
     description_fallback: str = "",
     recommendation_fallback: str = "",
@@ -90,15 +108,17 @@ def _render_from_metadata(
     Lives at module scope so per-category dispatchers can reach it
     without circular imports through ``RemediationGenerator``.
 
+    ``code_snippet`` is what renders inside the ``Vulnerable Code`` fence (the
+    enclosing task, for context). ``ground_snippet`` is what the Secure Fix is
+    grounded against and defaults to ``code_snippet``; callers pass the precise
+    flagged line here so grounding attaches to the finding's own artifact
+    rather than an incidental URL elsewhere in the task window.
+
     The ``*_fallback`` kwargs cover structural rules emitted from code
     (no ``patterns/*.yml`` entry, hence absent from ``_pattern_index``).
     The pattern catalog wins when populated; the fallbacks fill the
     void so the rendered ``Show recommended fix`` block always carries
     real text rather than the ``this <rule_id> issue`` stub.
-
-    The Secure Fix is grounded in the finding's own code via
-    :func:`_ground_secure_fix`, so a curated companion snippet is never
-    rendered as advice disconnected from the flagged line.
     """
     meta = _pattern_index.get(rule_id) or {}
     title = meta.get("title") or title_fallback
@@ -107,7 +127,12 @@ def _render_from_metadata(
 
     secure_fix = _select_secure_fix(rule_id)
     if secure_fix:
-        secure_fix = _ground_secure_fix(secure_fix, code_snippet)
+        prefer_credential_key = resolve_category(rule_id) == "hardcoded_credentials"
+        secure_fix = _ground_secure_fix(
+            secure_fix,
+            ground_snippet if ground_snippet is not None else code_snippet,
+            prefer_credential_key=prefer_credential_key,
+        )
     secure_block = (
         f"\n**\u2705 Secure Fix Example:**\n```yaml\n{secure_fix}\n```\n" if secure_fix else ""
     )
@@ -180,6 +205,14 @@ _RULE_ID_NOISE = (
     "_var",
     "_hardcoded",
     "hardcoded_",
+    # Value-format prefixes that leak into the name (a Databricks PAT starts
+    # ``dapi``, an Atlassian token ``atatt``); they identify the format, not a
+    # word a reader needs in the credential's name.
+    "_atatt",
+    "_dapi",
+    "_dckr",
+    "_asia",
+    "_glsa",
 )
 _IDENTITY_CASINGS = {
     "api": "API",
@@ -209,6 +242,17 @@ _IDENTITY_CASINGS = {
     "gitlab": "GitLab",
     "us": "US",
     "dockerhub": "DockerHub",
+    "openai": "OpenAI",
+    "mysql": "MySQL",
+    "postgresql": "PostgreSQL",
+    "postgres": "PostgreSQL",
+    "youtube": "YouTube",
+    "paypal": "PayPal",
+    "sshpass": "sshpass",
+    "hashicorp": "HashiCorp",
+    "apm": "APM",
+    "tfvars": "tfvars",
+    "cpassword": "cpassword",
 }
 # Rule ids too generic to name a specific credential; fall back to the key.
 _GENERIC_CREDENTIAL_RULE_IDS = frozenset(
@@ -236,41 +280,58 @@ def _titleise_identifier(identifier: str) -> str:
 def _identity_from_rule_id(rule_id: str) -> str:
     """Human credential name derived from the rule id (``okta_api_token``)."""
     base = rule_id
-    for affix in _RULE_ID_NOISE:
-        if affix.endswith("_") and base.startswith(affix):
-            base = base[len(affix) :]
-        elif base.endswith(affix):
-            base = base[: -len(affix)]
+    changed = True
+    while changed:
+        changed = False
+        for affix in _RULE_ID_NOISE:
+            if affix.endswith("_") and base.startswith(affix):
+                base, changed = base[len(affix) :], True
+            elif base.endswith(affix) and base != affix:
+                base, changed = base[: -len(affix)], True
     return _titleise_identifier(base) or "Credential"
 
 
 def _identity_from_key(code_snippet: str) -> str | None:
-    """Human credential name derived from the flagged ``key:`` on the line."""
-    m = _GROUND_KEY_RE.search(code_snippet or "")
-    if not m:
-        return None
-    key = m.group(1)
-    if key.lower() in ("name", "line", "url", "src", "dest", "path"):
-        return None
-    return _titleise_identifier(key) or None
+    """Human credential name from the credential-bearing ``key:`` in the snippet.
+
+    Scans every ``key: value`` / ``KEY=value`` line and prefers a key that
+    reads like a credential (``token``, ``secret``, ``password``, ...) so a
+    multi-line task names the flagged secret, not the first ``url:`` or
+    ``name:`` line above it. Falls back to the first non-structural key.
+    """
+    fallback: str | None = None
+    for m in _GROUND_KEY_RE.finditer(code_snippet or ""):
+        key = m.group(1)
+        if key.lower() in _NON_CREDENTIAL_KEYS:
+            continue
+        if _key_is_credential(key):
+            return _titleise_identifier(key) or None
+        if fallback is None:
+            fallback = _titleise_identifier(key) or None
+    return fallback
 
 
-def _credential_identity(rule_id: str, code_snippet: str) -> str:
-    """Resolve a credential's display name from the rule, then the key.
+def _credential_identity(rule_id: str, code_snippet: str, family: str = "") -> str:
+    """Resolve a credential's display name from the strongest evidence.
 
-    Never inferred from the value's shape: that guessing is exactly what
-    labelled every ``token:`` line a JWT. A specific rule names itself; a
-    generic rule (``hardcoded_token``) borrows the flagged key; only when
-    both are silent does a neutral, non-guessing default apply.
+    Order, all evidence-based, never a guess from the value's shape:
+    a specific rule names itself; a family identified from explicit context
+    (a Splunk HEC endpoint, a real JWT) names itself; otherwise the flagged
+    credential key names it; and only when all are silent does a neutral
+    default apply.
     """
     if rule_id and rule_id not in _GENERIC_CREDENTIAL_RULE_IDS:
         return _identity_from_rule_id(rule_id)
+    family_name = _CREDENTIAL_ADVICE.get(family, _CREDENTIAL_ADVICE["generic"])["name"]
+    if family_name:
+        return family_name
     return _identity_from_key(code_snippet) or "Hardcoded Credential"
 
 
 # Curated advice family per rule id, matched most-specific first on the rule
-# id (not the value). The family only selects security advice; the displayed
-# name always comes from _credential_identity.
+# id (not the value). The family selects security advice; it also names the
+# credential when the family is context-detected (splunk_hec, jwt). Every other
+# name comes from _credential_identity via the rule id or the flagged key.
 _CREDENTIAL_FAMILY_BY_RULE: tuple[tuple[str, str], ...] = (
     ("stripe", "stripe"),
     ("aws", "aws"),
@@ -288,6 +349,7 @@ _CREDENTIAL_FAMILY_BY_RULE: tuple[tuple[str, str], ...] = (
 
 _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
     "stripe": {
+        "name": None,
         "description": "This Stripe key provides access to payment processing and financial data. Live keys handle real transactions.",
         "security_advice": [
             "Use separate keys for test and live environments",
@@ -297,6 +359,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "aws": {
+        "name": None,
         "description": "AWS access keys provide programmatic access to AWS services and should never be hardcoded.",
         "security_advice": [
             "Use IAM roles instead of access keys when possible",
@@ -306,6 +369,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "github": {
+        "name": None,
         "description": "This token provides access to repositories and platform APIs based on its configured scopes.",
         "security_advice": [
             "Use fine-grained tokens with minimal scopes",
@@ -315,6 +379,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "webhook": {
+        "name": None,
         "description": "This webhook URL embeds an authentication token that grants access to an external service.",
         "security_advice": [
             "Use HTTPS webhooks only",
@@ -324,6 +389,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "jwt": {
+        "name": "JWT Token",
         "description": "JSON Web Tokens carry encoded authentication and authorization claims and stay valid until they expire or their signing key is rotated.",
         "security_advice": [
             "Use strong signing keys and rotate them regularly",
@@ -333,6 +399,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "splunk_hec": {
+        "name": "Splunk HEC Token",
         "description": "A Splunk HTTP Event Collector token authorizes event submission to the configured index. A leaked token lets an attacker forge or flood events and burn ingest quota until it is rotated.",
         "security_advice": [
             "Rotate the HEC token in Splunk immediately, then reference it from Vault at runtime",
@@ -342,6 +409,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "api_key": {
+        "name": None,
         "description": "API keys provide programmatic access to a service and must be treated as live credentials.",
         "security_advice": [
             "Rotate the key at the issuing service immediately",
@@ -351,6 +419,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "password": {
+        "name": None,
         "description": "A plaintext password in source is a live credential the moment it is committed.",
         "security_advice": [
             "Rotate the password immediately",
@@ -360,6 +429,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "form_data": {
+        "name": None,
         "description": "Form data containing authentication credentials must be secured like any other secret.",
         "security_advice": [
             "Use structured authentication instead of form encoding where possible",
@@ -369,6 +439,7 @@ _CREDENTIAL_ADVICE: dict[str, _CredentialAdvice] = {
         ],
     },
     "generic": {
+        "name": None,
         "description": "This credential authenticates to a service and stays valid until it is rotated at the issuer. Committed to source, it is a live credential.",
         "security_advice": [
             "Rotate the credential at the issuing service immediately",
@@ -396,7 +467,7 @@ _GROUND_PATH_RE = re.compile(
 _GROUND_IPV4_RE = re.compile(r"(?<![\w.])(?:\d{1,3}\.){3}\d{1,3}(?::\d+)?(?![\w.])")
 _GROUND_JINJA_VAR_RE = re.compile(r"\{\{\s*([a-zA-Z_][\w.]*)\s*\}\}")
 # Leading inventory/config key on the flagged line (e.g. ``ansible_ssh_common_args``).
-_GROUND_KEY_RE = re.compile(r"^\s*(?:-\s*)?([a-zA-Z_][\w.-]*)\s*[:=]")
+_GROUND_KEY_RE = re.compile(r"^\s*(?:-\s*)?([a-zA-Z_][\w.-]*)\s*[:=]", re.MULTILINE)
 # Hostnames like ``legacy.example.com`` (dotted, ends in an alpha TLD).
 _GROUND_HOST_RE = re.compile(r"(?<![\w.@/])(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?![\w./])")
 
@@ -412,14 +483,34 @@ def _artifact_is_safe(candidate: str) -> bool:
     return candidate.count("{{") == candidate.count("}}") and "{{" in candidate
 
 
-def _finding_artifact(code_snippet: str) -> str | None:
+def _credential_key_artifact(code_snippet: str) -> str | None:
+    """Return the credential-bearing ``key:`` in the snippet, if any.
+
+    For a credential finding the flagged secret's key is the most specific
+    artifact, more so than an incidental ``url:`` on another line of the task.
+    """
+    for line in (code_snippet or "").splitlines():
+        km = _GROUND_KEY_RE.match(line)
+        if km and _key_is_credential(km.group(1)):
+            return km.group(1)
+    return None
+
+
+def _finding_artifact(code_snippet: str, *, prefer_credential_key: bool = False) -> str | None:
     """Return the most specific concrete artifact named in ``code_snippet``.
 
     A URL is preferred over the host inside it, a path over a bare key.
     Candidates carrying a partial Jinja expression are skipped. Returns
     ``None`` when the finding names nothing concrete (e.g. ``shell: echo x``).
+
+    ``prefer_credential_key`` puts the flagged credential's key first, so a
+    credential finding grounds on the secret rather than an incidental URL.
     """
     snippet = code_snippet or ""
+    if prefer_credential_key:
+        cred_key = _credential_key_artifact(snippet)
+        if cred_key:
+            return cred_key
     for pattern in (_GROUND_URL_RE, _GROUND_PATH_RE, _GROUND_IPV4_RE):
         for m in pattern.finditer(snippet):
             if _artifact_is_safe(m.group(0)):
@@ -448,7 +539,9 @@ def _fix_references_artifact(secure_fix: str, artifact: str) -> bool:
     return bool(jm and re.search(rf"(?<![\w]){re.escape(jm.group(1))}(?![\w])", secure_fix))
 
 
-def _ground_secure_fix(secure_fix: str, code_snippet: str) -> str:
+def _ground_secure_fix(
+    secure_fix: str, code_snippet: str, *, prefer_credential_key: bool = False
+) -> str:
     """Return ``secure_fix`` tied back to the finding's own code.
 
     No-op when the finding names nothing concrete or the fix already
@@ -458,7 +551,7 @@ def _ground_secure_fix(secure_fix: str, code_snippet: str) -> str:
     fix = (secure_fix or "").strip("\n")
     if not fix:
         return secure_fix
-    artifact = _finding_artifact(code_snippet)
+    artifact = _finding_artifact(code_snippet, prefer_credential_key=prefer_credential_key)
     if not artifact or _fix_references_artifact(fix, artifact):
         return secure_fix
     return f"# Applies to the flagged finding: {artifact}\n{fix}"
@@ -536,7 +629,7 @@ class BaseRemediationGenerator:
         """
         family = _CREDENTIAL_ADVICE.get(credential_type, _CREDENTIAL_ADVICE["generic"])
         return CredentialInfo(
-            name=_credential_identity(rule_id, code_snippet),
+            name=_credential_identity(rule_id, code_snippet, credential_type),
             description=family["description"],
             security_advice=list(family["security_advice"]),
         )

--- a/src/ansible_security_scanner/remediations/credentials.py
+++ b/src/ansible_security_scanner/remediations/credentials.py
@@ -6,7 +6,7 @@ Credentials remediation generator for Ansible Security Scanner
 import os
 import re
 
-from .base import BaseRemediationGenerator
+from .base import BaseRemediationGenerator, _key_is_credential
 
 
 class CredentialsRemediationGenerator(BaseRemediationGenerator):
@@ -774,62 +774,86 @@ shell: >-
         return template
 
     def _extract_credential_info(self, code_snippet: str) -> dict:
-        """Extract credential information from the code"""
-        # Annotated explicitly so static analysis doesn't infer
-        # `dict[str, None]` from the initializer and then complain about
-        # every later `str` assignment. All four slots are populated later
-        # with either a captured regex group (str) or stay None.
+        """Extract the flagged credential's key, value, and assignment shape.
+
+        ``kind`` records which assignment form matched (``echo``, ``export``,
+        ``yaml``, ``env``) so the replacement generators branch on the actual
+        credential, not on whether a word like ``export`` happens to appear on
+        an unrelated line of a multi-line task.
+        """
         info: dict[str, str | None] = {
             "variable_name": None,
             "credential_value": None,
             "file_path": None,
-            "command": None,
+            "kind": None,
         }
 
-        # Extract from echo statements like: echo "API_KEY=value" > /path/file
-        echo_pattern = r'echo\s+"([^"]+)"\s*>\s*([^\s]+)'
-        echo_match = re.search(echo_pattern, code_snippet)
-        if echo_match:
-            assignment = echo_match.group(1)
+        # echo "API_KEY=value" > /path/file
+        echo_match = re.search(r'echo\s+"([^"]+)"\s*>\s*([^\s]+)', code_snippet)
+        if echo_match and "=" in echo_match.group(1):
+            key, value = echo_match.group(1).split("=", 1)
             info["file_path"] = echo_match.group(2)
-            if "=" in assignment:
-                key, value = assignment.split("=", 1)
-                info["variable_name"] = key.strip()
-                info["credential_value"] = value.strip()
+            info["variable_name"] = key.strip()
+            info["credential_value"] = value.strip()
+            info["kind"] = "echo"
+            return info
 
-        # Extract from export statements like: export VAR=value
-        export_pattern = r"export\s+([^=]+)=(.+)"
-        export_match = re.search(export_pattern, code_snippet)
+        # A YAML credential assignment (token:/secret:/...) wins over a bare
+        # ``VAR=value`` match: in a multi-line task the latter can appear on an
+        # unrelated line, so the flagged credential must not be clobbered.
+        yaml_key, yaml_value = self._match_yaml_credential(code_snippet)
+        if yaml_key is not None:
+            info["variable_name"] = yaml_key
+            info["credential_value"] = yaml_value
+            info["kind"] = "yaml"
+            return info
+
+        # export VAR=value
+        export_match = re.search(r"export\s+([^=]+)=(.+)", code_snippet)
         if export_match:
             info["variable_name"] = export_match.group(1).strip()
             info["credential_value"] = export_match.group(2).strip().strip("\"'")
+            info["kind"] = "export"
+            return info
 
-        # Extract from YAML assignments like: api_key: "value"
-        yaml_pattern = r'([^:]+):\s*["\']([^"\']+)["\']'
-        yaml_match = re.search(yaml_pattern, code_snippet)
-        if yaml_match:
-            info["variable_name"] = yaml_match.group(1).strip()
-            info["credential_value"] = yaml_match.group(2).strip()
-
-        # Extract from variable assignments like: VAR=value
-        var_pattern = r"([A-Z_][A-Z0-9_]*)=([^\s]+)"
-        var_match = re.search(var_pattern, code_snippet)
+        # Bare VAR=value assignment.
+        var_match = re.search(r"([A-Z_][A-Z0-9_]*)=([^\s]+)", code_snippet)
         if var_match:
             info["variable_name"] = var_match.group(1).strip()
             info["credential_value"] = var_match.group(2).strip()
+            info["kind"] = "env"
 
         return info
+
+    @staticmethod
+    def _match_yaml_credential(code_snippet: str) -> tuple[str | None, str | None]:
+        """Return the (key, value) of the credential-bearing YAML assignment.
+
+        Scans every ``key: "value"`` line and prefers a credential-looking key
+        (token/secret/password/...) so a multi-line task selects the flagged
+        secret, not an earlier ``url:``/``name:`` line. Falls back to the first
+        assignment, and to ``(None, None)`` when the snippet has none.
+        """
+        matches = re.findall(r'([A-Za-z_][\w.-]*)\s*:\s*["\']([^"\']+)["\']', code_snippet)
+        if not matches:
+            return None, None
+        key, value = next((kv for kv in matches if _key_is_credential(kv[0])), matches[0])
+        return key.strip(), value.strip()
 
     def _generate_secure_replacement(
         self, code_snippet: str, extracted_info: dict, var_name: str, env_var: str
     ) -> str:
-        """Generate secure replacement for the vulnerable code"""
+        """Generate secure replacement for the vulnerable code.
 
-        if extracted_info["file_path"] and extracted_info["variable_name"]:
-            # For echo statements writing to files
-            safe_var_name = extracted_info["variable_name"].lower()
-            vault_var = f"vault_{safe_var_name}"
+        Branches on the extracted credential's ``kind``, not on substring
+        presence in the whole snippet, so an unrelated ``export``/``=`` on
+        another line of a multi-line task cannot select the wrong fix shape.
+        """
+        kind = extracted_info.get("kind")
+        cred_value = extracted_info["credential_value"] or "your_actual_credential"
 
+        if kind == "echo" and extracted_info["file_path"] and extracted_info["variable_name"]:
+            vault_var = f"vault_{extracted_info['variable_name'].lower()}"
             return f'''- name: create configuration file securely
   ansible.builtin.template:
     src: config.j2
@@ -841,17 +865,11 @@ shell: >-
 {extracted_info["variable_name"]}={{{{ {vault_var} }}}}
 
 # In group_vars/all/vault.yml (encrypted with ansible-vault):
-{vault_var}: "{extracted_info["credential_value"]}"'''
+{vault_var}: "{cred_value}"'''
 
-        if "export" in code_snippet.lower():
-            # For export statements
-            safe_var_name = (
-                extracted_info["variable_name"].lower()
-                if extracted_info["variable_name"]
-                else var_name
-            )
+        if kind == "export":
+            safe_var_name = (extracted_info["variable_name"] or var_name).lower()
             vault_var = f"vault_{safe_var_name}"
-
             return f'''- name: set environment variable securely
   ansible.builtin.lineinfile:
     path: /etc/environment
@@ -859,52 +877,46 @@ shell: >-
     backup: yes
 
 # In group_vars/all/vault.yml (encrypted with ansible-vault):
-{vault_var}: "{extracted_info["credential_value"] or "your_actual_credential"}"'''
+{vault_var}: "{cred_value}"'''
 
-        if ":" in code_snippet and "=" not in code_snippet:
-            # For YAML assignments
-            safe_var_name = (
-                extracted_info["variable_name"].lower()
-                if extracted_info["variable_name"]
-                else var_name
-            )
+        if kind == "yaml":
+            safe_var_name = (extracted_info["variable_name"] or var_name).lower()
             vault_var = f"vault_{safe_var_name}"
-
             return f'''{extracted_info["variable_name"] or var_name}: "{{{{ {vault_var} }}}}"
 
 # In group_vars/all/vault.yml (encrypted with ansible-vault):
-{vault_var}: "{extracted_info["credential_value"] or "your_actual_credential"}"'''
+{vault_var}: "{cred_value}"'''
 
-        # Generic replacement. If `var_name` is still the sentinel
-        # "variable_name" (i.e. the extractor could not identify a
-        # better name from the surrounding context), pick the first
-        # secret-looking token from the snippet itself so the produced
-        # example reads `password: "{{ vault_password }}"` rather than
-        # the meaningless `variable_name: "{{ vault_variable_name }}"`.
-        effective_name = var_name
+        # No recognised assignment shape. Prefer the extractor's key, then a
+        # secret-looking token from the snippet, then the passed-in var_name,
+        # so we never emit the meaningless ``variable_name`` sentinel.
+        effective_name = extracted_info["variable_name"] or var_name
         if effective_name in ("variable_name", "vault_variable_name"):
             secret_match = re.search(
-                r"\b([A-Za-z_][A-Za-z0-9_]*(?:token|key|secret|auth|credential|pass|pwd|password)[A-Za-z0-9_]*)\s*=",
+                r"\b([A-Za-z_][A-Za-z0-9_]*(?:token|key|secret|auth|credential|pass|pwd|password)[A-Za-z0-9_]*)\s*[:=]",
                 code_snippet,
                 re.IGNORECASE,
             )
             if secret_match:
-                effective_name = secret_match.group(1).lower()
+                effective_name = secret_match.group(1)
+        effective_name = effective_name.lower() if effective_name else "credential"
         vault_var = f"vault_{effective_name}"
         return f'''{effective_name}: "{{{{ {vault_var} }}}}"
 
 # In group_vars/all/vault.yml (encrypted with ansible-vault):
-{vault_var}: "your_actual_credential"'''
+{vault_var}: "{cred_value}"'''
 
     def _generate_env_var_replacement(
         self, code_snippet: str, extracted_info: dict, env_var: str
     ) -> str:
-        """Generate environment variable replacement for the vulnerable code"""
+        """Generate environment variable replacement, branching on the
+        extracted credential's ``kind`` rather than snippet substrings.
+        """
+        kind = extracted_info.get("kind")
+        cred_value = extracted_info["credential_value"] or "your_actual_credential"
 
-        if extracted_info["file_path"] and extracted_info["variable_name"]:
-            # For echo statements writing to files
-            env_var_name = extracted_info["variable_name"] or env_var
-
+        if kind == "echo" and extracted_info["file_path"] and extracted_info["variable_name"]:
+            env_var_name = extracted_info["variable_name"]
             return f'''- name: create configuration file from environment
   ansible.builtin.template:
     src: config.j2
@@ -912,28 +924,29 @@ shell: >-
     mode: '0600'
 
 # Template file (config.j2):
-{extracted_info["variable_name"]}={{{{ lookup('env', '{env_var_name}') }}}}
+{env_var_name}={{{{ lookup('env', '{env_var_name}') }}}}
 
 # Set environment variable before running:
-# export {env_var_name}="{extracted_info["credential_value"]}"'''
+# export {env_var_name}="{cred_value}"'''
 
-        if "export" in code_snippet.lower():
-            # For export statements
+        if kind == "export":
             env_var_name = extracted_info["variable_name"] or env_var
-
             return f'''- name: set environment variable from lookup
   ansible.builtin.lineinfile:
     path: /etc/environment
     line: "{env_var_name}={{{{ lookup('env', '{env_var_name}') }}}}"
 
 # Set source environment variable before running:
-# export {env_var_name}="{extracted_info["credential_value"] or "your_actual_credential"}"'''
+# export {env_var_name}="{cred_value}"'''
 
-        # Generic replacement
-        return f'''{extracted_info["variable_name"] or "credential"}: "{{{{ lookup('env', '{env_var}') }}}}"
+        # Derive the env var from the flagged key when the extractor found one,
+        # so a real key (``token``) yields ``TOKEN`` rather than a placeholder.
+        var_name = extracted_info["variable_name"]
+        env_name = var_name.upper().replace("-", "_") if var_name else env_var
+        return f'''{var_name or "credential"}: "{{{{ lookup('env', '{env_name}') }}}}"
 
 # Set environment variable before running:
-# export {env_var}="{extracted_info["credential_value"] or "your_actual_credential"}"'''
+# export {env_name}="{cred_value}"'''
 
     def _generate_gitlab_ci_job_token_leak_fix(self, code_snippet: str) -> str:
         return f"""

--- a/src/ansible_security_scanner/remediations/remediation_generator.py
+++ b/src/ansible_security_scanner/remediations/remediation_generator.py
@@ -192,6 +192,7 @@ class RemediationGenerator(BaseRemediationGenerator):
         line_number: int = 0,
         display_snippet: str | None = None,
         *,
+        ground_snippet: str | None = None,
         title_fallback: str = "",
         description_fallback: str = "",
         recommendation_fallback: str = "",
@@ -211,11 +212,13 @@ class RemediationGenerator(BaseRemediationGenerator):
         than the ``this <rule_id> issue`` stub.
         """
         rendered_snippet = display_snippet if display_snippet is not None else code_snippet
+        grounding = ground_snippet if ground_snippet is not None else code_snippet
 
         def render_meta() -> str:
             return _render_from_metadata(
                 rule_id,
                 rendered_snippet,
+                ground_snippet=grounding,
                 title_fallback=title_fallback,
                 description_fallback=description_fallback,
                 recommendation_fallback=recommendation_fallback,

--- a/src/ansible_security_scanner/variable_extractor.py
+++ b/src/ansible_security_scanner/variable_extractor.py
@@ -19,6 +19,32 @@ _USER_RE = re.compile(r'^user:\s*["\']([^"\']+)["\']')
 _TASK_NAME_RE = re.compile(r'^\s*-\s*name:\s*["\']([^"\']+)["\']')
 _NON_IDENT_RE = re.compile(r"[^a-zA-Z0-9_]")
 _CREDENTIAL_KEYWORDS = ("password", "secret", "key", "token", "credential", "auth")
+# Canonical credential-key classification, shared with the remediation layer.
+# Structural keys that never name a credential, and the keyword fragments that
+# mark a key as credential-bearing when scanning a multi-line task snippet.
+_NON_CREDENTIAL_KEYS = frozenset(
+    {"name", "line", "url", "src", "dest", "path", "method", "uri", "body", "host"}
+)
+_CREDENTIAL_KEY_KEYWORDS = (
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "key",
+    "auth",
+    "credential",
+    "cred",
+    "pass",
+    "apikey",
+)
+
+
+def looks_like_credential_key(key: str) -> bool:
+    """True when a YAML/env key name reads like a credential, not a ``url:``/``name:``."""
+    k = key.strip().lower()
+    if k in _NON_CREDENTIAL_KEYS:
+        return False
+    return any(kw in k for kw in _CREDENTIAL_KEY_KEYWORDS)
 
 
 class VariableExtractor:
@@ -69,10 +95,18 @@ class VariableExtractor:
                     return f"{username}_password"
                 return "soar_admin_password"
 
-            match = re.search(r'^\s*([^:]+):\s*["\']', code_snippet.strip())
-            if match:
-                var_name = match.group(1).strip()
-                return self._clean_variable_name(var_name)
+            # Prefer the credential-bearing ``key: "value"`` line. On a
+            # multi-line task snippet a plain first-match would return an
+            # earlier ``url:``/``name:`` line instead of the flagged secret.
+            yaml_matches = re.findall(
+                r'^\s*(?:-\s*)?([A-Za-z_][\w.-]*)\s*:\s*["\']', code_snippet, re.MULTILINE
+            )
+            if yaml_matches:
+                chosen = next(
+                    (k for k in yaml_matches if looks_like_credential_key(k)),
+                    yaml_matches[0],
+                )
+                return self._clean_variable_name(chosen.strip())
 
             if "mysql" in code_snippet.lower() and "-p" in code_snippet:
                 return "mysql_password"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -556,6 +556,41 @@ def test_proximity_superseding_drops_generic_ssl_rule_on_uri_tasks(tmp_path):
     )
 
 
+def test_credential_remediation_uses_surrounding_task_context(tmp_path):
+    """A hardcoded token in a Splunk HEC task must be named and advised as an
+    HEC token, driven by the ``services/collector`` line two rows above it.
+    The scanner feeds generation the whole task, so context that lives in
+    surrounding lines reaches the remediation. Value is redacted in the
+    Vulnerable Code block; the fix grounds on the flagged ``token`` key.
+    """
+    from ansible_security_scanner.file_scanner import FileScanner
+
+    token = "e017639c" + "-db22-4933-936c-2950972a1e5c"
+    playbook = tmp_path / "hec.yml"
+    playbook.write_text(
+        "- hosts: localhost\n"
+        "  tasks:\n"
+        "    - name: Register HEC destination\n"
+        "      uri:\n"
+        '        url: "http://localhost:8081/api/hec/destinations"\n'
+        "        method: POST\n"
+        "        body:\n"
+        '          url: "{{ SPLUNK_CLOUD_url }}:8088/services/collector"\n'
+        f'          token: "{token}"\n'
+    )
+    scanner = FileScanner(tmp_path)
+    findings, _ = scanner.scan_file(playbook)
+    token_findings = [f for f in findings if "token" in (f.code_snippet or "").lower()]
+    assert token_findings, "expected a token finding on the HEC task"
+
+    rem = token_findings[0].remediation_example or ""
+    assert "Splunk HEC Token Detected" in rem, rem
+    assert "HTTP Event Collector" in rem, rem
+    assert "VARIABLE_NAME" not in rem, rem
+    fence = rem.split("Secure Fix")[0]
+    assert token not in fence, "the flagged token value must be redacted in the shown snippet"
+
+
 def test_proximity_superseding_keeps_generic_ssl_rule_without_specific_match(tmp_path):
     """
     If the module-specific rule does NOT fire (e.g. `validate_certs: no`

--- a/tests/test_remediations.py
+++ b/tests/test_remediations.py
@@ -22,6 +22,7 @@ if str(SRC) not in sys.path:
 
 from ansible_security_scanner.patterns_manager import known_rule_ids  # noqa: E402
 from ansible_security_scanner.remediations import _pattern_index as _PI  # noqa: E402
+from ansible_security_scanner.remediations._category_map import resolve_category  # noqa: E402
 from ansible_security_scanner.remediations.base import (  # noqa: E402
     BaseRemediationGenerator,
     _finding_artifact,
@@ -50,6 +51,13 @@ from ansible_security_scanner.remediations.template_injection import (  # noqa: 
 )
 
 PATTERNS_DIR = SRC / "ansible_security_scanner" / "patterns"
+
+# Synthetic credential fixtures shared by the credential-identity tests. The
+# UUID is split so secret scanning does not flag a contiguous literal; it is a
+# random value, not a real Splunk HEC token. The JWT decodes to a throwaway
+# ``{"alg":"HS256"}`` / ``{"sub":"x"}`` with the signature literally ``sig``.
+_SYNTHETIC_UUID = "e017639c" + "-db22-4933-936c-2950972a1e5c"
+_SYNTHETIC_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.c2ln"
 
 
 def _collect_rule_ids() -> list[tuple[str, str]]:
@@ -899,6 +907,83 @@ def test_every_known_rule_renders_a_sound_fix(
             )
 
 
+_ADVERSARIAL_DECOY_URL = "http://decoy.invalid/v1/register"
+
+
+@pytest.mark.parametrize("rule_id", KNOWN_RULE_IDS, ids=KNOWN_RULE_IDS)
+def test_every_rule_grounds_on_flagged_line_not_task_window(
+    remediation_generator: RemediationGenerator,
+    rule_id: str,
+) -> None:
+    """Universal multi-line safety: the scanner feeds a whole task window as
+    display context while the flagged line drives the fix. A URL, path, or key
+    on a *sibling* line of that window must never be mistaken for this finding's
+    artifact, and no decoy line may leak into the generated fix.
+
+    This is the assertion that catches the systemic 'written for a single line,
+    fed a multi-line task' bug class across every category at once, rather than
+    one rule at a time. It mirrors the real scanner call shape: the flagged line
+    is ``code_snippet``; the window (with adversarial decoys) is
+    ``display_snippet``.
+    """
+    if rule_id in _SCAN_META_RULES:
+        pytest.skip("scan-meta rule: reports on the scan, carries no Ansible Secure Fix")
+
+    snippet = _STRUCTURAL_SNIPPETS.get(rule_id)
+    if snippet is None:
+        examples = [ex for (rid, _cat, ex) in ALL_POSITIVE_EXAMPLES if rid == rule_id]
+        snippet = examples[0] if examples else "shell: echo placeholder"
+
+    flagged_line = snippet.splitlines()[-1].strip() if snippet.splitlines() else snippet
+    indented = "\n".join("      " + ln if ln.strip() else ln for ln in snippet.splitlines())
+    window = (
+        "- name: Provision and register external destination\n"
+        "  shell: export TMP=/x && ./run.sh mode=0600\n"
+        "  vars:\n"
+        f'    endpoint_url: "{_ADVERSARIAL_DECOY_URL}"\n'
+        f"{indented}"
+    )
+
+    out = remediation_generator.generate_remediation_example(
+        rule_id,
+        flagged_line,
+        file_path="inventory/group_vars/all.yml",
+        line_number=5,
+        display_snippet=window,
+        description_fallback="structural rule description",
+        recommendation_fallback="structural rule recommendation",
+    )
+
+    match = _SECURE_FIX_BLOCK_RE.search(out)
+    assert match, (
+        f"{rule_id}: no Secure Fix block when fed a multi-line task window.\n"
+        f"  flagged line: {flagged_line[:120]!r}\n  excerpt: {out[:320]!r}"
+    )
+    body = match.group("body")
+    assert not _TRUNCATED_JINJA_RE.search(body), f"{rule_id}: truncated Jinja.\n{body[:320]!r}"
+    assert not _NESTED_JINJA_RE.search(body), f"{rule_id}: nested Jinja.\n{body[:320]!r}"
+
+    # The decoy URL/key legitimately appears in the Vulnerable Code display
+    # block (the window is shown as context). The bug is when it bleeds into the
+    # Secure Fix - the grounding comment or the fix body - which means the
+    # generator treated a sibling line as this finding's artifact.
+    grounding_line = next(
+        (ln for ln in out.splitlines() if "Applies to the flagged finding" in ln), ""
+    )
+    assert _ADVERSARIAL_DECOY_URL not in grounding_line, (
+        f"{rule_id}: the fix grounds on the decoy sibling URL instead of the "
+        f"flagged line's own artifact.\n  grounding: {grounding_line!r}"
+    )
+    assert _ADVERSARIAL_DECOY_URL not in body, (
+        f"{rule_id}: the decoy sibling URL leaked into the Secure Fix body, so "
+        f"extraction picked the wrong line of the task window.\n  body: {body[:320]!r}"
+    )
+    assert "endpoint_url" not in body, (
+        f"{rule_id}: the decoy sibling key 'endpoint_url' leaked into the fix body, "
+        f"so extraction picked the wrong line of the task window.\n  body: {body[:320]!r}"
+    )
+
+
 # Structural (AST / Python-defined) rules have no ``patterns/*.yml`` entry and
 # therefore no ``positive_examples``, so the catalog-driven test above never
 # exercises them. They are nonetheless emitted as real findings and must ship a
@@ -1658,8 +1743,8 @@ class TestCredentialTypeLabelling:
     borrows the key (``okta_api_token:`` -> "Okta API Token").
     """
 
-    _HEC_UUID = "e017639c" + "-db22-4933-936c-2950972a1e5c"
-    _REAL_JWT = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.c2ln"
+    _HEC_UUID = _SYNTHETIC_UUID
+    _REAL_JWT = _SYNTHETIC_JWT
 
     @pytest.fixture(scope="class")
     def base(self) -> BaseRemediationGenerator:
@@ -1702,7 +1787,6 @@ class TestCredentialTypeLabelling:
         This is the assertion that catches the whole class of mislabels,
         not just the one rule that surfaced it.
         """
-        from ansible_security_scanner.remediations._category_map import resolve_category
 
         cred_ids = [
             rid
@@ -1740,7 +1824,6 @@ class TestCredentialTypeLabelling:
         a ``vault_variable_name`` var means the extractor fell through to its
         sentinel instead of reading the flagged line.
         """
-        from ansible_security_scanner.remediations._category_map import resolve_category
 
         cred_ids = [
             rid
@@ -1766,4 +1849,231 @@ class TestCredentialTypeLabelling:
         assert not ungrounded, (
             "these credential rules emit a placeholder or drop the finding's real "
             f"key/value from the generated fix: {ungrounded}"
+        )
+
+    def test_every_credential_rule_stays_grounded_in_a_task_window(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """The live scan feeds the enclosing task, not the bare line. Every
+        credential rule must still ground on the flagged ``token:`` line and
+        ignore the surrounding ``url:``/``name:`` lines, with no placeholder.
+        """
+
+        cred_ids = [
+            rid
+            for rid in sorted(known_rule_ids())
+            if resolve_category(rid) == "hardcoded_credentials"
+        ]
+        assert cred_ids, "no credential rules resolved; category map regressed"
+
+        ungrounded: list[str] = []
+        for rid in cred_ids:
+            task = (
+                "- name: Register external destination\n"
+                "  uri:\n"
+                '    url: "https://api.example.com/v1/register"\n'
+                "    body:\n"
+                f'      okta_api_token: "{self._HEC_UUID}"'
+            )
+            out = remediation_generator.generate_remediation_example(
+                rid, task, display_snippet=task
+            )
+            if "VARIABLE_NAME" in out or self._HEC_UUID not in out:
+                ungrounded.append(rid)
+
+        assert not ungrounded, (
+            "these credential rules emit a placeholder or drop the flagged value "
+            f"when handed a multi-line task window: {ungrounded}"
+        )
+
+
+class TestCredentialContextIdentity:
+    """A credential finding in a real task is a multi-line snippet: the flagged
+    ``token:`` line sits under a ``url:`` and a ``name:``. Identity, value
+    extraction, and the env var must all target the credential line, and
+    context that only appears in surrounding lines (a Splunk HEC endpoint, a
+    real JWT) must still drive the family. This is the path a live scan takes,
+    so these are the assertions that catch the mislabels users actually see.
+    """
+
+    _UUID = _SYNTHETIC_UUID
+    _REAL_JWT = _SYNTHETIC_JWT
+
+    @pytest.fixture(scope="class")
+    def base(self) -> BaseRemediationGenerator:
+        return BaseRemediationGenerator()
+
+    def _hec_task(self, token: str) -> str:
+        return (
+            "- name: Configure Splunk HEC destination\n"
+            "  uri:\n"
+            '    url: "http://localhost:8081/api/hec/destinations"\n'
+            "    method: POST\n"
+            "    body:\n"
+            '      url: "{{ SPLUNK_CLOUD_url }}:8088/services/collector"\n'
+            f'      token: "{token}"'
+        )
+
+    def test_identity_from_key_targets_the_credential_line(self, base):
+        """A multi-line task names the flagged secret, not the first url:/name:."""
+        from ansible_security_scanner.remediations.base import _identity_from_key
+
+        assert _identity_from_key(self._hec_task(self._UUID)) == "Token"
+
+    def test_hec_context_upgrades_a_generic_token_rule(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """A generic ``hardcoded_token`` in an HEC task reads as an HEC token,
+        with HEC advice, because the context is now fed to generation.
+        """
+        task = self._hec_task(self._UUID)
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_token", task, display_snippet=task
+        )
+        assert "Splunk HEC Token Detected" in out, out
+        assert "HTTP Event Collector" in out, out
+
+    def test_multiline_fix_grounds_on_the_credential_line(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """Value, vault var, and env var are all built from ``token:``, never
+        the earlier ``url:`` line, and no placeholder leaks through.
+        """
+        task = self._hec_task(self._UUID)
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_token", task, display_snippet=task
+        )
+        assert self._UUID in out, out
+        assert "VARIABLE_NAME" not in out, out
+        assert "lookup('env', 'TOKEN')" in out, out
+        assert "services/collector" not in out.split("Secure Fix")[-1], (
+            "the fix must reference the token, not the surrounding url: line"
+        )
+
+    def test_real_jwt_in_context_still_reads_as_jwt(
+        self, remediation_generator: RemediationGenerator
+    ):
+        task = (
+            "- name: Call API\n"
+            "  uri:\n"
+            '    url: "https://api.example.com"\n'
+            f'    headers:\n      Authorization: "Bearer {self._REAL_JWT}"'
+        )
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_token", task, display_snippet=task
+        )
+        assert "JWT Token Detected" in out, out
+
+    def test_inline_shell_assignment_does_not_clobber_the_credential(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """A bare ``VAR=value`` elsewhere in the task (an inline shell command)
+        must not overwrite the flagged YAML credential during extraction.
+        """
+        task = (
+            f'- name: Deploy\n  shell: FOO=bar ./deploy.sh\n  vars:\n    api_token: "{self._UUID}"'
+        )
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_token", task, display_snippet=task
+        )
+        assert "FOO" not in out.split("Secure Fix")[-1], out
+        assert "api_token" in out, out
+        assert self._UUID in out, out
+
+    def test_variable_name_extractor_targets_credential_line_in_multiline(self):
+        """The name fallback used when file context is unavailable must pick the
+        credential key on a multi-line snippet, not the leading ``url:`` line.
+        """
+        from ansible_security_scanner.variable_extractor import VariableExtractor
+
+        ve = VariableExtractor()
+        snippet = (
+            f'    url: "http://api.example.com/hec"\n    method: POST\n    token: "{self._UUID}"'
+        )
+        assert ve.extract_variable_name(snippet, "hardcoded_credentials") == "token"
+
+    def test_unrelated_export_word_does_not_pick_env_fix_shape(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """A YAML credential in a task that also contains the word ``export``
+        on an unrelated shell line must still get the YAML vault fix, not the
+        ``/etc/environment`` shape. The fix branches on the extracted
+        credential kind, not on substrings anywhere in the task.
+        """
+        task = (
+            "- name: Configure and register token\n"
+            "  shell: export PATH=/opt/bin:$PATH && ./run.sh\n"
+            "  vars:\n"
+            f'    api_token: "{self._UUID}"'
+        )
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_token", task, display_snippet=task
+        )
+        secure = out.split("Secure Fix")[1].split("Alternative")[0]
+        assert "/etc/environment" not in secure, secure
+        assert "api_token" in secure, secure
+
+    def test_equals_in_task_does_not_drop_the_credential(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """A stray ``=`` elsewhere in the task (``mode=0600``) must not send the
+        fix down the generic path that emits the ``variable_name`` sentinel.
+        """
+        task = (
+            "- name: write secret file mode=0600\n"
+            "  copy:\n"
+            '    content: "x"\n'
+            "  vars:\n"
+            f'    db_secret: "{self._UUID}"'
+        )
+        out = remediation_generator.generate_remediation_example(
+            "hardcoded_secret", task, display_snippet=task
+        )
+        assert "variable_name" not in out, out
+        assert "db_secret" in out, out
+        assert self._UUID in out, out
+
+    def test_every_credential_rule_survives_an_adversarial_task(
+        self, remediation_generator: RemediationGenerator
+    ):
+        """Class-wide fuzz: a task that leads with ``url:``, carries an
+        unrelated ``export``/``=`` shell line, and puts the credential last must
+        never produce a placeholder, drop the value, or ground the fix on the
+        URL instead of the credential. This is the assertion that catches the
+        whole 'written for single-line, fed multi-line' bug class, not one rule.
+        """
+
+        cred_ids = [
+            rid
+            for rid in sorted(known_rule_ids())
+            if resolve_category(rid) == "hardcoded_credentials"
+        ]
+        assert cred_ids, "no credential rules resolved; category map regressed"
+
+        task = (
+            "- name: Register external destination\n"
+            "  shell: export TMP=/x && ./run.sh mode=0600\n"
+            "  uri:\n"
+            '    url: "http://api.example.com/v1/register"\n'
+            "    body:\n"
+            f'      api_token: "{self._UUID}"'
+        )
+        placeholder: list[str] = []
+        dropped: list[str] = []
+        url_grounded: list[str] = []
+        for rid in cred_ids:
+            out = remediation_generator.generate_remediation_example(
+                rid, task, display_snippet=task
+            )
+            if "VARIABLE_NAME" in out or "variable_name:" in out:
+                placeholder.append(rid)
+            if self._UUID not in out:
+                dropped.append(rid)
+            if "Applies to the flagged finding: http" in out:
+                url_grounded.append(rid)
+
+        assert not placeholder, f"placeholder leaked under adversarial task: {placeholder}"
+        assert not dropped, f"flagged value dropped under adversarial task: {dropped}"
+        assert not url_grounded, (
+            f"fix grounded on the incidental url: instead of the credential: {url_grounded}"
         )


### PR DESCRIPTION
The scanner feeds remediation the whole enclosing task rather than a single line, and the credential fixes were written assuming single-line input. A url: or name: sibling line could drive the credential name, the value extraction, and the generated fix, so a hardcoded token inside a Splunk HEC task was named from the wrong line and the fix referenced the wrong artifact.

Extraction now records which assignment shape matched (echo, export, yaml, env) and the replacement generators branch on that kind instead of checking whether a word like export appears anywhere in the task. This removes the "wrong fix shape" cases where an unrelated shell line changed the output.

Grounding takes an explicit flagged-line snippet, so the fix attaches to the finding's own credential key instead of an incidental URL elsewhere in the task window. Identity resolution prefers the credential-bearing key when scanning a multi-line snippet, and it defers to the rule id or a context-detected family (Splunk HEC, JWT) before falling back.

The credential-key predicate had two slightly different copies in base and variable_extractor. It now lives in variable_extractor as the single source of truth and the remediation layer imports it.